### PR TITLE
Update content width to 800px

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -27,7 +27,7 @@ const HeaderWrapper = styled.div`
   justify-content: center;
 
   .container {
-    width: 1210px;
+    width: 1110px;
   }
 `;
 

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -35,8 +35,8 @@ const Layout: React.FunctionComponent<LayoutProps> = ({ children }) => {
   `;
 
   const Content = styled.article`
-    max-width: 980px;
-    width: 980px;
+    max-width: 880px;
+    width: 880px;
     margin: -80px 0 1rem 24px;
     // @media only screen and (max-width: 1023px) {
     //   padding-left: 0;


### PR DESCRIPTION
Suggestion: could we change the content width to 800px (currently 900px)? This is because of two reasons -

1) The readability drops for very long lines of text. The suggested width on desktop is around 70 characters, and ours is closer to 120.
2) The diagrams are currently exported at 1600px, which means at 800px width they will render at 2x and appear sharper.