### PR TITLE
Add commata to MySQL and PostgreSQL table creation

### DIFF
--- a/content/04-guides/01-database-workflows/08-sql-views.mdx
+++ b/content/04-guides/01-database-workflows/08-sql-views.mdx
@@ -118,7 +118,7 @@ In this section, you'll **create two tables where one references the other via a
   ```sql
   CREATE TABLE `SqlViews`.`User` (
     `id` INT AUTO_INCREMENT PRIMARY KEY,
-    `name` VARCHAR(256)
+    `name` VARCHAR(256),
     `email` VARCHAR(256) UNIQUE
   );
 
@@ -126,7 +126,7 @@ In this section, you'll **create two tables where one references the other via a
     `id` INT AUTO_INCREMENT PRIMARY KEY,
     `title` VARCHAR(256),
     `content` VARCHAR(256),
-    `published` BOOLEAN
+    `published` BOOLEAN,
     `authorId` INT,
     CONSTRAINT `author` FOREIGN KEY (`authorId`) REFERENCES `User`(`id`)
   );
@@ -139,7 +139,7 @@ In this section, you'll **create two tables where one references the other via a
    ```sql
    CREATE TABLE "public"."User" (
      id SERIAL PRIMARY KEY,
-     email TEXT UNIQUE
+     email TEXT UNIQUE,
      name TEXT
    );
 


### PR DESCRIPTION
I added "," to the CREATE statements when missing. It may be left, but helps the tutorial reader focus on the statement but not why a comma is missing in a line.