### PR TITLE
Remove duplicate instruction in 01-quickstart

### DIFF
--- a/content/01-getting-started/01-quickstart.mdx
+++ b/content/01-getting-started/01-quickstart.mdx
@@ -41,17 +41,15 @@ If you're looking to set up Prisma with your own database, you have these option
 
 ## Prerequisites
 
-<SwitchTech technologies={['typescript']}>
-
-The only requirement for this guide is to have [**Node.js**](https://nodejs.org/en/) (version 10 or higher) installed on your machine.
-
-TypeScript will be added as a local dependency to the project, so no need to install it.
-
-</SwitchTech>
-
 <SwitchTech technologies={['node']}>
 
 The only requirement for this guide is to have [**Node.js**](https://nodejs.org/en/) (version 10 or higher) installed on your machine.
+
+</SwitchTech>
+
+<SwitchTech technologies={['typescript']}>
+
+TypeScript will be added as a local dependency to the project, so no need to install it.
 
 </SwitchTech>
 


### PR DESCRIPTION
**Why** is the change needed?

The exact instruction is repeated twice in a manner that seems unintentional.

**How** is the need addressed?

- Remove one of the instances of the instruction.
- Change the surrounding tag names to reflect the change.

What **side-effects** could the change have?

Can not think of any.