### PR TITLE
Add example of explicit many-to-many relation

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/400-self-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/400-self-relations.mdx
@@ -310,7 +310,54 @@ This relation expresses the following:
 - "a user can be followed by zero or more users"
 - "a user can follow zero or more users"
 
-Note that this n-n-relation is [implicit](many-to-many-relations#implicit-many-to-many-relations). This means Prisma maintains a [relation table](../relations/many-to-many-relations#relation-tables) for it in the underlying database:
+Note that this n-n-relation is [implicit](many-to-many-relations#implicit-many-to-many-relations). This means Prisma maintains a [relation table](../relations/many-to-many-relations#relation-tables) for it in the underlying database.
+
+If you need the relation to hold other fields, you can create an [explicit](many-to-many-relations#explicit-many-to-many-relations) n-n self relation as well. The explicit version of the self relation shown previously is as follows:
+
+<TabbedContent tabs={[<FileWithIcon text="Relational databases" icon="database"/>]}>
+<tab>
+
+```prisma highlight=5,6;normal
+model User {
+  id         Int       @id @default(autoincrement())
+  name       String?
+  followedBy Follows[] @relation("follower")
+  following  Follows[] @relation("following")
+}
+
+model Follows {
+  follower    User @relation("follower", fields: [followerId], references: [id])
+  followerId  Int
+  following   User @relation("following", fields: [followingId], references: [id])
+  followingId Int
+
+  @@id([followerId, followingId])
+}
+```
+
+</tab>
+<tab>
+
+```prisma highlight=5,6;normal
+model User {
+  id         Int       @id @default(autoincrement())
+  name       String?
+  followedBy Follows[] @relation("follower")
+  following  Follows[] @relation("following")
+}
+
+model Follows {
+  follower    User @relation("follower", fields: [followerId], references: [id])
+  followerId  Int
+  following   User @relation("following", fields: [followingId], references: [id])
+  followingId Int
+
+  @@id([followerId, followingId])
+}
+```
+
+</tab>
+</TabbedContent>
 
 ### Many-to-many self-relations in the database
 


### PR DESCRIPTION
Fixes #2201

Note: I haven't added the explicit many-to-many version for MongoDB.  I'm not sure if this makes sense to demonstrate, considering the way many-to-many is modeled in MongoDB. This is something I'll have to look into a bit further. I hope it's alright that this is not provided at the moment :sweat_smile:  