### PR TITLE
omitted `assignedBy`

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/300-many-to-many-relations.mdx
@@ -396,6 +396,7 @@ model CategoriesOnPosts {
   category   Category @relation(fields: [categoryId], references: [id])
   categoryId Int
   assignedAt DateTime @default(now())
+  assignedBy String
 
   @@id([postId, categoryId])
 }


### PR DESCRIPTION
## Describe this PR
Add column assignedBy to CategoriesOnPosts model in Relation tables Section

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

Add column assignedBy to CategoriesOnPosts model in Relation tables Section

## What issue does this fix?
Document
<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
