### PR TITLE
fix: integration testing about migrate

### DIFF
--- a/content/300-guides/150-testing/150-integration-testing.mdx
+++ b/content/300-guides/150-testing/150-integration-testing.mdx
@@ -462,17 +462,16 @@ You can add some scripts to your projects `package.json` file which will setup t
 
 ```json file=package.json
   "scripts": {
-    "migrate:init": "npx prisma migrate dev --name init",
     "docker:up": "docker-compose up -d",
     "docker:down": "docker-compose down",
-    "test": "yarn docker:up && yarn migrate:init && jest -i && yarn docker:down"
+    "test": "yarn docker:up && npx prisma migrate deploy && jest -i && yarn docker:down"
   },
 ```
 
 The `test` script does the following:
 
 1. Runs `docker-compose up -d` to create the container with the Postgres image and database.
-1. Runs a migration on the database using your projects schema, this creates the tables in the container's database.
+1. Applies the migrations found in `./prisma/migrations/` diretory to the database, this creates the tables in the container's database.
 1. Executes the tests.
 
 Once you are satisfied you can run `yarn docker:down` to destroy the container, its database and any test data.

--- a/content/300-guides/150-testing/150-integration-testing.mdx
+++ b/content/300-guides/150-testing/150-integration-testing.mdx
@@ -464,7 +464,7 @@ You can add some scripts to your projects `package.json` file which will setup t
   "scripts": {
     "docker:up": "docker-compose up -d",
     "docker:down": "docker-compose down",
-    "test": "yarn docker:up && npx prisma migrate deploy && jest -i && yarn docker:down"
+    "test": "yarn docker:up && yarn prisma migrate deploy && jest -i && yarn docker:down"
   },
 ```
 


### PR DESCRIPTION
`migrate dev` should not be used in integration testing, `migrate deploy` is the correct command to use

Current docs at https://www.prisma.io/docs/guides/testing/integration-testing#running-the-tests