### PR TITLE
fix TRUNCATE example types

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -959,8 +959,8 @@ for (const { tablename } of tablenames) {
 const transactions: PrismaPromise<any>[] = []
 transactions.push(prisma.$executeRaw`SET FOREIGN_KEY_CHECKS = 0;`)
 
-const tablenames: Array<{ tablename: string }> =
-    await prisma.$queryRaw`SELECT TABLE_NAME from information_schema.TABLES WHERE TABLE_SCHEMA = 'tests';`
+const tablenames =
+    await prisma.$queryRaw<Array<{ tablename: string }>>`SELECT TABLE_NAME from information_schema.TABLES WHERE TABLE_SCHEMA = 'tests';`
 
 for (const { tablename } of tablenames) {
   if (tablename !== '_prisma_migrations') {

--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -937,9 +937,10 @@ The second tab shows performing the same function but with a MySQL database. In 
 <tab>
 
 ```ts
-for (const {
-  tablename,
-} of await prisma.$queryRaw`SELECT tablename FROM pg_tables WHERE schemaname='public'`) {
+const tablenames: Array<{ tablename: string }> =
+    await prisma.$queryRaw`SELECT tablename FROM pg_tables WHERE schemaname='public'`
+
+for (const { tablename } of tablenames) {
   if (tablename !== '_prisma_migrations') {
     try {
       await prisma.$executeRawUnsafe(`TRUNCATE TABLE "public"."${tablename}" CASCADE;`)
@@ -958,12 +959,13 @@ for (const {
 const transactions: PrismaPromise<any>[] = []
 transactions.push(prisma.$executeRaw`SET FOREIGN_KEY_CHECKS = 0;`)
 
-for (const {
-  TABLE_NAME,
-} of await prisma.$queryRaw`SELECT TABLE_NAME from information_schema.TABLES WHERE TABLE_SCHEMA = 'tests';`) {
-  if (TABLE_NAME !== '_prisma_migrations') {
+const tablenames: Array<{ tablename: string }> =
+    await prisma.$queryRaw`SELECT TABLE_NAME from information_schema.TABLES WHERE TABLE_SCHEMA = 'tests';`
+
+for (const { tablename } of tablenames) {
+  if (tablename !== '_prisma_migrations') {
     try {
-      transactions.push(prisma.$executeRawUnsafe(`TRUNCATE ${TABLE_NAME};`))
+      transactions.push(prisma.$executeRawUnsafe(`TRUNCATE ${tablename};`))
     } catch (error) {
       console.log({ error })
     }

--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -937,8 +937,8 @@ The second tab shows performing the same function but with a MySQL database. In 
 <tab>
 
 ```ts
-const tablenames: Array<{ tablename: string }> =
-    await prisma.$queryRaw`SELECT tablename FROM pg_tables WHERE schemaname='public'`
+const tablenames =
+    await prisma.$queryRaw<Array<{ tablename: string }>>`SELECT tablename FROM pg_tables WHERE schemaname='public'`
 
 for (const { tablename } of tablenames) {
   if (tablename !== '_prisma_migrations') {


### PR DESCRIPTION
Reported by Mischa in https://prisma.slack.com/archives/CCWDULGUW/p1634046610177100?thread_ts=1634034845.175700&cid=CCWDULGUW

Note it's part of a breaking change from v3 https://github.com/prisma/prisma/pull/8728

Page preview at
https://deploy-preview-2395--prisma2-docs.netlify.app/docs/concepts/components/prisma-client/crud#deleting-all-data-with-raw-sql--truncate