### PR TITLE
Update 03-postgresql.mdx – Add a application_name parameter

### DIFF
--- a/content/200-concepts/200-database-connectors/03-postgresql.mdx
+++ b/content/200-concepts/200-database-connectors/03-postgresql.mdx
@@ -84,7 +84,7 @@ The following arguments can be used:
 | `pgbouncer`        | No       | `false`                | Configure the Engine to [enable PgBouncer compatibility mode](/guides/performance-and-optimization/connection-management/configure-pg-bouncer/)                                   |
 | `application_name` | No       |                        | Since 3.3.0: Specifies a value for the application_name configuration parameter 
 
-As an example, if you want to connect to a schema called `myschema`, set the connection pool size to `5` and configure a timeout for queries of `3` seconds, you can use the following arguments:
+As an example, if you want to connect to a schema called `myschema`, set the connection pool size to `5` and configure a timeout for queries of `3` seconds. You can use the following arguments:
 
 ```
 postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=myschema&connection_limit=5&socket_timeout=3

--- a/content/200-concepts/200-database-connectors/03-postgresql.mdx
+++ b/content/200-concepts/200-database-connectors/03-postgresql.mdx
@@ -82,6 +82,7 @@ The following arguments can be used:
 | `host`             | No       |                        | Points to a directory that contains a socket to be used for the connection                                                                                                        |
 | `socket_timeout`   | No       |                        | Maximum number of seconds to wait until a single query terminates                                                                                                                 |
 | `pgbouncer`        | No       | `false`                | Configure the Engine to [enable PgBouncer compatibility mode](/guides/performance-and-optimization/connection-management/configure-pg-bouncer/)                                   |
+| `application_name` | No       |                        | Specifies a value for the application_name configuration parameter 
 
 As an example, if you want to connect to a schema called `myschema`, set the connection pool size to `5` and configure a timeout for queries of `3` seconds, you can use the following arguments:
 

--- a/content/200-concepts/200-database-connectors/03-postgresql.mdx
+++ b/content/200-concepts/200-database-connectors/03-postgresql.mdx
@@ -82,7 +82,7 @@ The following arguments can be used:
 | `host`             | No       |                        | Points to a directory that contains a socket to be used for the connection                                                                                                        |
 | `socket_timeout`   | No       |                        | Maximum number of seconds to wait until a single query terminates                                                                                                                 |
 | `pgbouncer`        | No       | `false`                | Configure the Engine to [enable PgBouncer compatibility mode](/guides/performance-and-optimization/connection-management/configure-pg-bouncer/)                                   |
-| `application_name` | No       |                        | Specifies a value for the application_name configuration parameter 
+| `application_name` | No       |                        | Since 3.3.0: Specifies a value for the application_name configuration parameter 
 
 As an example, if you want to connect to a schema called `myschema`, set the connection pool size to `5` and configure a timeout for queries of `3` seconds, you can use the following arguments:
 


### PR DESCRIPTION
## Describe this PR

Adding `application_name` as a followup to https://github.com/prisma/prisma/issues/7804

## Changes

- Added `application_name` parameter to docs

## What issue does this fix?

Follow up to https://github.com/prisma/prisma/issues/7804

## Any other relevant information

@pimeys 
