### PR TITLE
Add missing `name` key in @relation

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/index.mdx
@@ -565,7 +565,7 @@ model User {
 model Post {
   id         String  @id @default(dbgenerated()) @map("_id") @db.ObjectId
   title      String?
-  author     User    @relation("WrittenPosts", fields: [authorId], references: [id])
+  author     User    @relation(name: "WrittenPosts", fields: [authorId], references: [id])
   authorId   String  @db.ObjectId
   pinnedBy   User?   @relation(name: "PinnedPost", fields: [pinnedById], references: [id])
   pinnedById String? @db.ObjectId


### PR DESCRIPTION
## Describe this PR

While reading the docs, I noticed that the `@relation` field was missing the `name` key just like the "PinnedPost" relation at the bottom of this page: https://www.prisma.io/docs/concepts/components/prisma-schema/relations#types-of-relations

![CleanShot 2021-10-18 at 11 00 59@2x](https://user-images.githubusercontent.com/3606121/137746368-98896856-a2fc-4e23-b015-4246a3d0f06f.png)


## Changes

- Add `name` key to `@relation` field

## What issue does this fix?

No issue, just a typo.

## Any other relevant information

None
