### PR TITLE
fix: unique-constraints-and-indexes/01-postgresql

### DIFF
--- a/content/200-concepts/100-components/03-prisma-migrate/100-supported-types-and-db-features.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/100-supported-types-and-db-features.mdx
@@ -70,13 +70,13 @@ Prisma Migrate uses the specified types when it creates a migration:
 ```sql highlight=4,11;normal
   -- CreateTable
 CREATE TABLE "User" (
-"id" SERIAL,
+    "id" SERIAL,
     "name" VARCHAR(200) NOT NULL,
     PRIMARY KEY ("id")
 );
   -- CreateTable
 CREATE TABLE "Post" (
-"id" SERIAL,
+    "id" SERIAL,
     "title" VARCHAR(150) NOT NULL,
     "published" BOOLEAN NOT NULL DEFAULT true,
     "authorId" INTEGER NOT NULL,

--- a/content/200-concepts/100-components/03-prisma-migrate/index.mdx
+++ b/content/200-concepts/100-components/03-prisma-migrate/index.mdx
@@ -81,14 +81,14 @@ You can use [native type mapping attributes](supported-types-and-db-features#map
    ```sql
      -- CreateTable
    CREATE TABLE "User" (
-   "id" SERIAL,
+       "id" SERIAL,
        "name" TEXT NOT NULL,
 
        PRIMARY KEY ("id")
    );
      -- CreateTable
    CREATE TABLE "Post" (
-   "id" SERIAL,
+       "id" SERIAL,
        "title" TEXT NOT NULL,
        "published" BOOLEAN NOT NULL DEFAULT true,
        "authorId" INTEGER NOT NULL,

--- a/content/300-guides/600-general-guides/100-database-workflows/04-unique-constraints-and-indexes/01-postgresql.mdx
+++ b/content/300-guides/600-general-guides/100-database-workflows/04-unique-constraints-and-indexes/01-postgresql.mdx
@@ -52,6 +52,7 @@ Create a new file named `single-column-unique.sql` and add the following code to
 
 ```sql file=single-column-unique.sql copy
 CREATE TABLE "public"."User" (
+  "id" SERIAL PRIMARY KEY,
   email TEXT UNIQUE
 );
 ```
@@ -65,7 +66,7 @@ psql UniqueDemo < single-column-unique.sql
 Congratulations, you just created a table called `User` in the database. The table has one column called `email` on which you defined a unique index. PostgreSQL also automatically added a corresponding unique index (do **not** run this code):
 
 ```sql
-CREATE UNIQUE INDEX "User_email_key" ON "User"(email text_ops);
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email" text_ops);
 ```
 
 <details><summary>Alternative: Define the constraint as a <strong>table constraint</strong></summary>
@@ -77,6 +78,7 @@ To add the unique constraint as a table constraint, you need to adjust your SQL 
 
 ```sql
 CREATE TABLE "public"."User" (
+  "id" SERIAL PRIMARY KEY,
   email TEXT,
   UNIQUE ("email")
 );
@@ -92,6 +94,7 @@ Create a new file named `multi-column-unique.sql` and add the following code to 
 
 ```sql file=multi-column-unique.sql copy
 CREATE TABLE "public"."AnotherUser" (
+  "id" SERIAL PRIMARY KEY,
   "firstName" TEXT,
   "lastName" TEXT,
   UNIQUE ("firstName", "lastName")
@@ -118,6 +121,7 @@ Create a new file named `add-single-unique-constraint-later.sql` and add the fol
 
 ```sql file=add-single-unique-constraint-later.sql copy
 CREATE TABLE "public"."OneMoreUser" (
+  "id" SERIAL PRIMARY KEY,
   email TEXT
 );
 
@@ -138,7 +142,7 @@ psql UniqueDemo < add-single-unique-constraint-later.sql
 Congratulations, you just created a table called `OneMoreUser` in the database. The table has one column called `email` on which you later added a unique constraint in the second SQL statement. PostgreSQL also automatically added a corresponding unique index (do **not** run this code):
 
 ```sql copy
-CREATE UNIQUE INDEX "OneMoreUser_email_unique_constraint" ON "OneMoreUser"(email text_ops);
+CREATE UNIQUE INDEX "OneMoreUser_email_unique_constraint" ON "OneMoreUser"("email" text_ops);
 ```
 
 ## 5. Adding a multi-column unique constraint to an existing table
@@ -149,6 +153,7 @@ Create a new file named `add-multi-unique-constraint-later.sql` and add the foll
 
 ```sql file=add-multi-unique-constraint-later.sql copy
 CREATE TABLE "public"."TheLastUser" (
+  "id" SERIAL PRIMARY KEY,
   "firstName" TEXT,
   "lastName" TEXT
 );
@@ -161,13 +166,13 @@ This code contains two SQL statements:
 1. Create a new table called `TheLastUser`
 1. Alter the table to add an unique constraint
 
-Now run the SQL statements against your database to create a new table called `OneMoreUser`:
+Now run the SQL statements against your database to create a new table called `TheLastUser`:
 
 ```terminal copy
 psql UniqueDemo < add-multi-unique-constraint-later.sql
 ```
 
-Congratulations, you just created a table called `OneMoreUser` in the database. The table has two columns called `firstName` and `lastName` on which you later added a unique constraint in the second SQL statement. PostgreSQL also automatically added a corresponding unique index (do **not** run this code):
+Congratulations, you just created a table called `TheLastUser` in the database. The table has two columns called `firstName` and `lastName` on which you later added a unique constraint in the second SQL statement. PostgreSQL also automatically added a corresponding unique index (do **not** run this code):
 
 ```sql
 CREATE UNIQUE INDEX "TheLastUser_firstName_lastName_unique_constraint" ON "TheLastUser"(firstname text_ops,lastname text_ops);
@@ -245,37 +250,30 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
 model AnotherUser {
+  id        Int     @id @default(autoincrement())
   firstName String?
   lastName  String?
 
   @@unique([firstName, lastName])
-  @@unique([firstName, lastName], map: "AnotherUser_firstname_lastname_key")
-  @@ignore
 }
 
-/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
 model OneMoreUser {
+  id    Int     @id @default(autoincrement())
   email String? @unique(map: "OneMoreUser_email_unique_constraint")
-
-  @@ignore
 }
 
-/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
 model TheLastUser {
+  id        Int     @id @default(autoincrement())
   firstName String?
   lastName  String?
 
   @@unique([firstName, lastName], map: "TheLastUser_firstName_lastName_unique_constraint")
-  @@ignore
 }
 
-/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
 model User {
+  id    Int     @id @default(autoincrement())
   email String? @unique
-
-  @@ignore
 }
 ```
 

--- a/content/300-guides/600-general-guides/100-database-workflows/04-unique-constraints-and-indexes/01-postgresql.mdx
+++ b/content/300-guides/600-general-guides/100-database-workflows/04-unique-constraints-and-indexes/01-postgresql.mdx
@@ -94,7 +94,7 @@ Create a new file named `multi-column-unique.sql` and add the following code to 
 CREATE TABLE "public"."AnotherUser" (
   "firstName" TEXT,
   "lastName" TEXT,
-  UNIQUE (firstName, lastName)
+  UNIQUE ("firstName", "lastName")
 )
 ```
 
@@ -106,8 +106,8 @@ psql UniqueDemo < multi-column-unique.sql
 
 Congratulations, you just created a table called `AnotherUser` in the database. The table has two column called `firstName` and `lastName` on which you defined a unique index. PostgreSQL also automatically added a corresponding unique index (do **not** run this code):
 
-```sql
-CREATE UNIQUE INDEX "AnotherUser_firstname_lastname_key" ON "AnotherUser"(firstname text_ops,lastname text_ops);
+```sql copy
+CREATE UNIQUE INDEX "AnotherUser_firstname_lastname_key" ON "AnotherUser"("firstName" text_ops,"lastName" text_ops);
 ```
 
 ## 4. Adding a single-column unique constraint to an existing table
@@ -137,7 +137,7 @@ psql UniqueDemo < add-single-unique-constraint-later.sql
 
 Congratulations, you just created a table called `OneMoreUser` in the database. The table has one column called `email` on which you later added a unique constraint in the second SQL statement. PostgreSQL also automatically added a corresponding unique index (do **not** run this code):
 
-```sql
+```sql copy
 CREATE UNIQUE INDEX "OneMoreUser_email_unique_constraint" ON "OneMoreUser"(email text_ops);
 ```
 
@@ -153,7 +153,7 @@ CREATE TABLE "public"."TheLastUser" (
   "lastName" TEXT
 );
 
-ALTER TABLE "public"."TheLastUser" ADD CONSTRAINT "TheLastUser_firstName_lastName_unique_constraint" UNIQUE (firstName, lastName);
+ALTER TABLE "public"."TheLastUser" ADD CONSTRAINT "TheLastUser_firstName_lastName_unique_constraint" UNIQUE ("firstName", "lastName");
 ```
 
 This code contains two SQL statements:
@@ -163,7 +163,7 @@ This code contains two SQL statements:
 
 Now run the SQL statements against your database to create a new table called `OneMoreUser`:
 
-```
+```terminal copy
 psql UniqueDemo < add-multi-unique-constraint-later.sql
 ```
 
@@ -245,26 +245,37 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
 model AnotherUser {
   firstName String?
   lastName  String?
 
-  @@unique([firstName, lastName], name: "AnotherUser_firstname_lastname_key")
+  @@unique([firstName, lastName])
+  @@unique([firstName, lastName], map: "AnotherUser_firstname_lastname_key")
+  @@ignore
 }
 
+/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
 model OneMoreUser {
-  email String? @unique
+  email String? @unique(map: "OneMoreUser_email_unique_constraint")
+
+  @@ignore
 }
 
+/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
 model TheLastUser {
   firstName String?
   lastName  String?
 
-  @@unique([firstName, lastName], name: "TheLastUser_firstName_lastName_unique_constraint")
+  @@unique([firstName, lastName], map: "TheLastUser_firstName_lastName_unique_constraint")
+  @@ignore
 }
 
+/// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
 model User {
   email String? @unique
+
+  @@ignore
 }
 ```
 


### PR DESCRIPTION
Live page https://www.prisma.io/docs/guides/general-guides/database-workflows/unique-constraints-and-indexes/postgresql

The "" in the SQL makes the sql valid on TablePlus