### PR TITLE
Fix section heading formatting of Indexes page

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/09-indexes.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/09-indexes.mdx
@@ -34,7 +34,7 @@ The following arguments can be specified:
 
 - The `clustered` argument is available **in SQL Server only** on the `@id`, `@@id`, `@unique`, `@@unique` and `@@index` attribute in version `3.13.0` and later. It allows Prisma to configure (non)clustered indexes.
 
-### Enabling the `extendedIndexes` preview feature
+### Enabling the <inlineCode>extendedIndexes</inlineCode> preview feature
 
 To enable the `extendedIndexes` preview feature, add the `extendedIndexes` feature flag to the `generator` block of the `schema.prisma` file:
 
@@ -45,7 +45,7 @@ generator client {
 }
 ```
 
-### Configuring the length of indexes with `length` (MySQL)
+### Configuring the length of indexes with <inlineCode>length</inlineCode> (MySQL)
 
 The `length` argument is specific to MySQL and allows you to define indexes and constraints on columns of `String` and `Byte` types. For these types, MySQL requires you to specify a maximum length for the subpart of the value to be indexed in cases where the full value would exceed MySQL's limits for index sizes. See [the MySQL documentation](https://dev.mysql.com/doc/refman/8.0/en/innodb-limits.html) for more details.
 
@@ -92,7 +92,7 @@ model CompoundId {
 
 A similar syntax can be used for the `@@unique` and `@@index` attributes.
 
-### Configuring the index sort order with `sort`
+### Configuring the index sort order with <inlineCode>sort</inlineCode>
 
 The `sort` argument is available for all databases supported by Prisma. It allows you to specify the order that the entries of the index or constraint are stored in the database. This can have an effect on whether the database is able to use an index for specific queries.
 
@@ -126,7 +126,7 @@ model CompoundUnique {
 }
 ```
 
-### Example: using `sort` and `length` together
+### Example: using <inlineCode>sort</inlineCode> and <inlineCode>length</inlineCode> together
 
 The following example demonstrates the use of the `sort` and `length` arguments to configure indexes and constraints for a `Post` model:
 
@@ -143,7 +143,7 @@ model Post {
 }
 ```
 
-### Configuring the access type of indexes with `type` (PostgreSQL)
+### Configuring the access type of indexes with <inlineCode>type</inlineCode> (PostgreSQL)
 
 The `type` argument is available for configuring the index type in PostgreSQL, with the `@@index` attribute (version `3.6.0` and later). This allows you to use `Hash` as the index access method, instead of the default `BTree` access method. In version `3.14.0` and later, the `Gist`, `Gin`, `SpGist` and `Brin` index types provide additional access methods.
 
@@ -413,7 +413,7 @@ The default operator class (marked with ✅) can be omitted from the index defin
 
 Read more about built-in operator classes in the [official PostgreSQL documentation](https://www.postgresql.org/docs/14/brin-builtin-opclasses.html).
 
-### Configuring if indexes are clustered or non-clustered with `clustered` (SQL Server)
+### Configuring if indexes are clustered or non-clustered with <inlineCode>clustered</inlineCode> (SQL Server)
 
 The `clustered` argument is available to configure (non)clustered indexes in SQL Server in version `3.13.0` and later. It can be used on `@id`, `@@id`, `@unique`, `@@unique` and `@@index` attributes.
 
@@ -475,7 +475,7 @@ For now we do not enable the full text search commands in the Prisma Client for 
 
 </Admonition>
 
-### Enabling the `fullTextIndex` preview feature
+### Enabling the <inlineCode>fullTextIndex</inlineCode> preview feature
 
 To enable the `fullTextIndex` preview feature, add the `fullTextIndex` feature flag to the `generator` block of the `schema.prisma` file:
 


### PR DESCRIPTION
Fix small annoyance where section headings were wrongly formatted in table of contents 

## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
