### PR TITLE
use Prisma namespace for UserCreateInput because deprecation in 2.12.0

### DIFF
--- a/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
+++ b/content/400-reference/200-api-reference/050-prisma-client-reference.mdx
@@ -816,12 +816,12 @@ The following example results in **two** `INSERT` statements:
 <cmd>
 
 ```ts
-import { PrismaClient, UserCreateInput } from '@prisma/client'
+import { Prisma, PrismaClient } from '@prisma/client'
 
 const prisma = new PrismaClient({ log: ['query'] })
 
 async function main() {
-  let users: UserCreateInput[] = [
+  let users: Prisma.UserCreateInput[] = [
     {
       email: 'ariana@prisma.io',
       name: 'Ari',


### PR DESCRIPTION
## Describe this PR

<!-- Please describe the issue, problem or reason for the PR... A little context helps us scan the PR first, without having to dive into the code -->
In release 2.12.0, deprecated most generated types like `import { UserCreateInput } from '@prisma/client'`
https://github.com/prisma/prisma/releases/tag/2.12.0

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->
- Fix deprecated import, add `Prisma` namespace.

