### PR TITLE
(fix) Removing `defaultKey` prop from `FileWithIcon` component

### DIFF
--- a/content/200-concepts/100-components/08-prisma-engines/index.mdx
+++ b/content/200-concepts/100-components/08-prisma-engines/index.mdx
@@ -49,7 +49,7 @@ You can define environment variables globally on your machine or in the `.env` f
 Add the environment variable to the [`.env` file](/guides/development-environment/environment-variables#using-env-files).
 
 <TabbedContent
-  tabs={[<FileWithIcon defaultKey="unix" text="Unix, macOS" icon="code"/>, <FileWithIcon defaultKey="windows" text="Windows" icon="display"/>]}
+  tabs={[<FileWithIcon text="Unix, macOS" icon="code"/>, <FileWithIcon text="Windows" icon="display"/>]}
   defaultTabType="OS"
 >
 
@@ -76,7 +76,7 @@ PRISMA_QUERY_ENGINE_BINARY=c:\custom\path\my-query-engine-binary.exe
 Run the following command to set the environment variable globally (in this example, `PRISMA_QUERY_ENGINE_BINARY`):
 
 <TabbedContent
-  tabs={[<FileWithIcon defaultKey="unix" text="Unix, macOS" icon="code"/>, <FileWithIcon defaultKey="windows" text="Windows" icon="display"/>]}
+  tabs={[<FileWithIcon text="Unix, macOS" icon="code"/>, <FileWithIcon text="Windows" icon="display"/>]}
   defaultTabType="OS"
 >
 
@@ -109,7 +109,7 @@ npx prisma -v
 The output shows that the query engine path comes from the `PRISMA_QUERY_ENGINE_BINARY` environment variable:
 
 <TabbedContent
-  tabs={[<FileWithIcon defaultKey="unix" text="Unix, macOS" icon="code"/>, <FileWithIcon defaultKey="windows" text="Windows" icon="display"/>]}
+  tabs={[<FileWithIcon text="Unix, macOS" icon="code"/>, <FileWithIcon text="Windows" icon="display"/>]}
   defaultTabType="OS"
 >
 


### PR DESCRIPTION
## Describe this PR

Prop `defaultKey` was being set on the `<FileWithIcon />` component, which should only take two props: `text` and `icon`.

## Changes

Only instances found of this case were in the [Prisma Engines index page](https://www.prisma.io/docs/concepts/components/prisma-engines) mdx file.

## What issue does this fix?

[Fixes #3459](https://github.com/prisma/docs/issues/3459)

## Any other relevant information

N/A