### PR TITLE
Replace "middlewares" with "middleware functions"

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/053-middleware/index.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/053-middleware/index.mdx
@@ -6,7 +6,7 @@ metaDescription: 'Prisma Client middleware allows you to perform actions before 
 
 <TopBlock>
 
-Middleware items act as query-level lifecycle hooks, which allow you to perform an action before or after a query runs. Use the [`prisma.$use`](/reference/api-reference/prisma-client-reference#use) <span class="api"></span> method to add middleware, as follows:
+Middleware functions act as query-level lifecycle hooks, which allow you to perform an action before or after a query runs. Use the [`prisma.$use`](/reference/api-reference/prisma-client-reference#use) <span class="api"></span> method to add middleware, as follows:
 
 ```ts highlight=4-9,12-17;normal
 const prisma = new PrismaClient()
@@ -79,15 +79,15 @@ app.get('/feed', async (req, res) => {
 
 ## Running order and the middleware stack
 
-If you have multiple middleware items, the running order for **each separate query** is:
+If you have multiple middleware functions, the running order for **each separate query** is:
 
-1. All logic **before** `await next(params)` in each middleware, in descending order
-2. All logic **after** `await next(params)` in each middleware, in ascending order
+1. All logic **before** `await next(params)` in each middleware function, in descending order
+2. All logic **after** `await next(params)` in each middleware function, in ascending order
 
 Depending on where you are in the stack, `await next(params)` either:
 
-- Runs the next middleware (in middleware items #1 and #2 in the example) _or_
-- Runs the original Prisma Client query (in middleware item #3)
+- Runs the next middleware (in middleware functions #1 and #2 in the example) _or_
+- Runs the original Prisma Client query (in middleware function #3)
 
 ```ts
 const prisma = new PrismaClient()

--- a/content/200-concepts/100-components/02-prisma-client/053-middleware/index.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/053-middleware/index.mdx
@@ -6,7 +6,7 @@ metaDescription: 'Prisma Client middleware allows you to perform actions before 
 
 <TopBlock>
 
-Middlewares act as query-level lifecycle hooks, which allow you to perform an action **before or after** a query runs. Use the [`prisma.$use`](/reference/api-reference/prisma-client-reference#use) <span class="api"></span> method to add middlewares:
+Middleware items act as query-level lifecycle hooks, which allow you to perform an action before or after a query runs. Use the [`prisma.$use`](/reference/api-reference/prisma-client-reference#use) <span class="api"></span> method to add middleware, as follows:
 
 ```ts highlight=4-9,12-17;normal
 const prisma = new PrismaClient()
@@ -45,7 +45,7 @@ There are many more use cases for middleware - this list serves as inspiration f
 
 ## Samples
 
-Here are some sample scenarios that show how to use middlewares in practice:
+The following sample scenarios show how to use middleware in practice:
 
 <Subsections />
 
@@ -79,15 +79,15 @@ app.get('/feed', async (req, res) => {
 
 ## Running order and the middleware stack
 
-If you have multiple middlewares, the running order for **each separate query** is:
+If you have multiple middleware items, the running order for **each separate query** is:
 
 1. All logic **before** `await next(params)` in each middleware, in descending order
 2. All logic **after** `await next(params)` in each middleware, in ascending order
 
 Depending on where you are in the stack, `await next(params)` either:
 
-- Runs the next middleware (in middlewares #1 and #2 in the example) _or_
-- Runs the original Prisma Client query (in middleware #3)
+- Runs the next middleware (in middleware items #1 and #2 in the example) _or_
+- Runs the original Prisma Client query (in middleware item #3)
 
 ```ts
 const prisma = new PrismaClient()


### PR DESCRIPTION
I've replaced "middlewares" with "middleware functions" (I was going with "middleware items", but @nikolasburk  suggested the superior "functions"). "Middlewares" doesn't seem grammatical (we don't say "softwares", for example). I did consider "pieces of middleware", as in "pieces of software", but I think that might apply "partial middleware items" to some second language speakers, so I went with what I hope is a good alternative.