### PR TITLE
fix: add a closing parenthesis in CRUD > 'Filter by a single field value'

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/030-crud.mdx
@@ -470,7 +470,7 @@ The following query returns all `User` records with an email that ends in `"pris
         endsWith: "prisma.io"
       }
     },
-  }
+  })
 ```
 
 #### Filter by multiple field values


### PR DESCRIPTION
## Describe this PR

Adding a closing parenthesis in the code sample in 'Filter by a single field value' section

## Changes

Small change in 02-prisma-client/030-crud.mdx

## What issue does this fix?

Reported in Slack: https://prisma-company.slack.com/archives/C5Z9TH6N9/p1665537364273809