### PR TITLE
SCL 412 PDP: Add section for idle connections to Data Proxy page

### DIFF
--- a/content/800-data-platform/300-data-proxy.mdx
+++ b/content/800-data-platform/300-data-proxy.mdx
@@ -242,19 +242,19 @@ postgresql://user:password@host:5432/mydb?connection_limit=60
 
 ### Idle connections to the database
 
-The Data Proxy creates several connection pools that maintain open idle connections even when no queries run from your application. The connection pools and any remaining idle connections close after 6 minutes of inactivity (no queries are sent to the database).
+The Data Proxy creates several connection pools that maintain open idle connections even when no queries run from your application. The connection pools and any remaining idle connections close after six minutes of inactivity (no queries are sent to the database).
 
-In each of the supported locations, the Data Proxy architecture includes multiple clusters that maintain idle connections to the database to ensure high availability in case of failures in any of the clusters.
+In each of the supported locations, the Data Proxy architecture includes multiple clusters that maintain idle connections to the database. This architecture ensures high availability in case of failures in any of the clusters.
 
 This architecture has a number of benefits.
 
-- **High availability**. By maintaining a separate connection pool from each cluster in a location, the Data Proxy guarantees that at least one connection pool will be always available to handle queries.
+- **High availability**. The Data Proxy maintains a separate connection pool from each cluster in a location. This guarantees that at least one connection pool is always available to handle queries.
 - **Load balancing**. The Data Proxy distributes the load of the database queries among the number of available connection pools.
-- **Scalability**. New connection pools start when an application experiences peak activity and existing connection pools stop (but two always remain with at least one being active in a separate cluster) when the peak activity subsides.
+- **Scalability**. The Data Proxy starts new connection pools when an application experiences peak activity and stops existing connection pools (but two always remain with at least one being active in a separate cluster) when the peak activity subsides.
 
 ## Error codes
 
-Because Data Proxy connections operate differently from a local database connection, error codes will be different from regular ones. In general, all Data Proxy-related errors will start with `P5xxx`.
+Because Data Proxy connections operate differently from local database connections, error codes will be different from regular ones. In general, all Data Proxy-related errors will start with `P5xxx`.
 
 ### P5000
 

--- a/content/800-data-platform/300-data-proxy.mdx
+++ b/content/800-data-platform/300-data-proxy.mdx
@@ -2,11 +2,12 @@
 title: 'Data Proxy'
 metaTitle: 'Data Proxy'
 metaDescription: 'Learn about using the Data Proxy with the Prisma Data Platform'
+tocDepth: 2
 ---
 
 <TopBlock>
 
-The Data Proxy provides database connection management and pooling for Prisma applications. By using the Data Proxy, your application can seamlessly scale up while maintaining predictable database performance, by limiting the number of total connections used.
+The Data Proxy provides database connection management and pooling for applications that use Prisma. By using the Data Proxy, your application can seamlessly scale up while maintaining predictable database performance, by limiting the number of total connections used.
 
 The benefits of using the Data Proxy include:
 
@@ -238,6 +239,18 @@ Each Data Proxy instance has its own connection pool. The size of each of these 
 ```
 postgresql://user:password@host:5432/mydb?connection_limit=60
 ```
+
+### Idle connections to the database
+
+The Data Proxy creates several connection pools that maintain open idle connections even when no queries run from your application. The connection pools and any remaining idle connections close after 6 minutes of inactivity (no queries are sent to the database).
+
+In each of the supported locations, the Data Proxy architecture includes multiple clusters that maintain idle connections to the database to ensure high availability in case of failures in any of the clusters.
+
+This architecture has a number of benefits.
+
+- **High availability**. By maintaining a separate connection pool from each cluster in a location, the Data Proxy guarantees that at least one connection pool will be always available to handle queries.
+- **Load balancing**. The Data Proxy distributes the load of the database queries among the number of available connection pools.
+- **Scalability**. New connection pools start when an application experiences peak activity and existing connection pools stop (but two always remain with at least one being active in a separate cluster) when the peak activity subsides.
 
 ## Error codes
 


### PR DESCRIPTION
## Describe this PR

Add a section to the Data Proxy page explaining the concept of idle connections to the database maintained by the Data Proxy connection pools.

## Changes

New section in the Data Proxy page

## What issue does this fix?

Fixes #3843