### PR TITLE
Deno Deploy guide: added a note about other database types; drive-by fixes to intro wording

### DIFF
--- a/content/300-guides/200-deployment/110-deployment-guides/550-deploying-to-deno-deploy.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/550-deploying-to-deno-deploy.mdx
@@ -161,10 +161,13 @@ The next step is to sign up for Prisma's [Data Proxy](/data-platform/data-proxy)
    ![Import a Project](./450-03-import-project.png)
 
 4. Connect the Prisma Data Platform to your database and set up the Data Proxy:
+
    1. Paste your PostgreSQL connection string.
    1. Under **Location**, select a Data Proxy location that is geographically close to your database location.
    1. Click **Create Project** to test the connection and set up the Data Proxy.
+
       You are greeted with a new connection string that starts with `prisma://`.
+
 5. Copy the `prisma://` connection string to your clipboard.
 
    <!-- TODO redo -->

--- a/content/300-guides/200-deployment/110-deployment-guides/550-deploying-to-deno-deploy.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/550-deploying-to-deno-deploy.mdx
@@ -6,15 +6,15 @@ metaDescription: 'Learn how to deploy a TypeScript application to Deno Deploy.'
 
 <TopBlock>
 
+In this guide, you'll learn how to build and deploy a simple application to Deno Deploy. The application uses Prisma to save every request to a PostgreSQL database for inspection later.
+
+This guide covers Prisma CLI with Deno CLI, Prisma Client, Data Proxy, and Deno Deploy.
+
 <Admonition type="info">
 
 This guide demonstrates how to deploy an application to Deno Deploy in conjunction with a PostgreSQL database, but you can use [any database type supported by Prisma](/reference/database-reference/supported-databases).
 
 </Admonition>
-
-In this guide, you'll learn how to build and deploy a simple application to Deno Deploy. The application uses Prisma to save every request to a PostgreSQL database for inspection later.
-
-This guide covers Prisma CLI with Deno CLI, Prisma Client, Data Proxy, and Deno Deploy.
 
 </TopBlock>
 

--- a/content/300-guides/200-deployment/110-deployment-guides/550-deploying-to-deno-deploy.mdx
+++ b/content/300-guides/200-deployment/110-deployment-guides/550-deploying-to-deno-deploy.mdx
@@ -6,9 +6,15 @@ metaDescription: 'Learn how to deploy a TypeScript application to Deno Deploy.'
 
 <TopBlock>
 
-Today you'll be building and deploying a simple application to Deno Deploy that uses Prisma to save every request to a PostgreSQL database for inspection later.
+<Admonition type="info">
 
-This guide covers Prisma CLI via Deno CLI, Prisma Client, Data Proxy, and Deno Deploy. Let's get started!
+This guide demonstrates how to deploy an application to Deno Deploy in conjunction with a PostgreSQL database, but you can use [any database type supported by Prisma](/reference/database-reference/supported-databases).
+
+</Admonition>
+
+In this guide, you'll learn how to build and deploy a simple application to Deno Deploy. The application uses Prisma to save every request to a PostgreSQL database for inspection later.
+
+This guide covers Prisma CLI with Deno CLI, Prisma Client, Data Proxy, and Deno Deploy.
 
 </TopBlock>
 
@@ -88,7 +94,7 @@ deno run -A --unstable npm:prisma generate --data-proxy
 You now have a database schema and a generated local Prisma Client. You can now create a minimal local Deno application. Create an `index.ts` with the following content:
 
 ```ts
-import { serve } from "https://deno.land/std@0.140.0/http/server.ts";
+import { serve } from 'https://deno.land/std@0.140.0/http/server.ts'
 import { PrismaClient } from './generated/client/deno/edge.ts'
 
 const prisma = new PrismaClient()
@@ -103,13 +109,13 @@ async function handler(request: Request) {
       },
     },
   })
-  const body = JSON.stringify(log, null, 2);
+  const body = JSON.stringify(log, null, 2)
   return new Response(body, {
-    headers: { "content-type": "application/json; charset=utf-8" },
-  });
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+  })
 }
 
-serve(handler);
+serve(handler)
 ```
 
 You cannot execute this script yet, because you lack the credentials for Data Proxy that let you use this Client with your database. In the next section, you will resolve this.
@@ -137,10 +143,12 @@ You're ready to import your project into the Prisma Data Platform.
 The next step is to sign up for Prisma's [Data Proxy](/data-platform/data-proxy).
 
 1. Sign up for a free [Prisma Data Platform account](https://cloud.prisma.io/).
+
    <Admonition type="info">
-   
+
    **Note**<br /><br />
    You need a GitHub account to sign up for the Prisma Data Platform.
+
    </Admonition>
 
    ![Signup for Prisma Data Platform](./450-02-signup-pdp.png)
@@ -149,19 +157,19 @@ The next step is to sign up for Prisma's [Data Proxy](/data-platform/data-proxy)
 3. Fill in the repository and project details, and click **Next**.
 
    <!-- TODO redo -->
+
    ![Import a Project](./450-03-import-project.png)
 
 4. Connect the Prisma Data Platform to your database and set up the Data Proxy:
    1. Paste your PostgreSQL connection string.
    1. Under **Location**, select a Data Proxy location that is geographically close to your database location.
    1. Click **Create Project** to test the connection and set up the Data Proxy.
-      
-   You are greeted with a new connection string that starts with `prisma://`. 
+      You are greeted with a new connection string that starts with `prisma://`.
 5. Copy the `prisma://` connection string to your clipboard.
 
    <!-- TODO redo -->
-   ![Data Proxy Page](./450-05-data-proxy.png)
 
+   ![Data Proxy Page](./450-05-data-proxy.png)
 
 ## 7. Set the Data Proxy Connection string in your environment
 


### PR DESCRIPTION
I added a note at the top to clarify that users can use this feature in conjunction with any supported database type. I also brought the intro more in line with our current style guide.

