### PR TITLE
Replace <inlinecode> with backticks when not in H2, H3, etc.

### DIFF
--- a/content/200-concepts/100-components/01-prisma-schema/06-relations/420-relation-mode.mdx
+++ b/content/200-concepts/100-components/01-prisma-schema/06-relations/420-relation-mode.mdx
@@ -86,8 +86,8 @@ datasource db {
 
 <Admonition type="warning">
 
-The <inlinecode>relationMode</inlinecode> field was renamed in Prisma version 4.5.0,
-and was previously named <inlinecode>referentialIntegrity</inlinecode>.
+The `relationMode` field was renamed in Prisma version 4.5.0,
+and was previously named `referentialIntegrity`.
 
 </Admonition>
 

--- a/content/300-guides/050-database/850-using-prisma-with-planetscale.mdx
+++ b/content/300-guides/050-database/850-using-prisma-with-planetscale.mdx
@@ -86,8 +86,8 @@ generator js {
 
 <Admonition type="warning">
 
-The <inlinecode>relationMode</inlinecode> field was renamed in Prisma version 4.5.0,
-and was previously named <inlinecode>referentialIntegrity</inlinecode>.
+The `relationMode` field was renamed in Prisma version 4.5.0,
+and was previously named `referentialIntegrity`.
 
 </Admonition>
 


### PR DESCRIPTION
## Describe this PR

* Change all instances of where `<inlinecode>` can be replaced with backticks <code>``</code>
* Review the use of <inlinecode> in Prisma Docs and why it is necessary
	* We currently have ~430 instances of `<inlinecode>` in H[1-5]
* Current use
	* As mentioned in the [Style guide](https://www.prisma.io/docs/about/prisma-docs/style-guide/spelling-punctuation-formatting#titles-and-headings), Prisma uses <inlinecode> to show monospace-styled text (commands, method names, code snippets, etc.) in H[1-5]
	* As a workaround to adding pipe symbols in Markdown tables
		* Example: https://www.prisma.io/docs/concepts/components/prisma-client/full-text-search#postgresql
		* Problem: If you use the pipe symbol `|` in a Markdown table row, Markdown interprets that as the end of the current cell
		* Workaround: Use the HTML pipe symbol code `&#124;` which requires the use of an HTML element, such as `<code>` or in the case of Prisma Docs `<inlinecode>`

## Changes

<!-- What changes have you made? Keep it brief!

- Refactored example to include new database field
- ... -->

## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
