### PR TITLE
style: apply the same font color for inline code even in Admonitions

### DIFF
--- a/src/components/shortcodes/admonition.tsx
+++ b/src/components/shortcodes/admonition.tsx
@@ -90,7 +90,7 @@ const AdmonitionWrapper = styled.span<{ type?: string }>`
   }
 
   code {
-    color: ${theme.colors.gray600} !important;
+    color: ${theme.colors.gray900} !important;
   }
 
   p {


### PR DESCRIPTION
## Describe this PR

apply the same font color for inline code even in Admonitions

## Changes

Small CSS change/fix

## What issue does this fix?

