### PR TITLE
Fix anchor and relative broken links that cause build failures

### DIFF
--- a/content/200-concepts/300-more/400-comparisons/index.mdx
+++ b/content/200-concepts/300-more/400-comparisons/index.mdx
@@ -9,7 +9,7 @@ metaDescription: 'Learn how Prisma compares to other ORMs, ORMs and database lib
 Find out how Prisma compares to ORMs and ODMs in the Node.js and TypeScript ecosystem.
 
 For a comprehensive overview of the most popular database libraries, read this article: [Top Node.js ORMs, Query Builders & Database Libraries in 2020
-](/dataguide/database-tools/top-nodejs-orms-query-builders-and-database-libraries).
+](https://www.prisma.io/dataguide/database-tools/top-nodejs-orms-query-builders-and-database-libraries).
 
 </TopBlock>
 

--- a/content/300-guides/050-database/100-developing-with-prisma-migrate/170-customizing-migrations.mdx
+++ b/content/300-guides/050-database/100-developing-with-prisma-migrate/170-customizing-migrations.mdx
@@ -14,7 +14,7 @@ Instead of `migrate dev`, [`db push`](/concepts/components/prisma-migrate/db-pus
 
 </Admonition>
 
-In some scenarios, you need to edit a migration file before you apply it. For example, to [change the direction of a 1-1 relation](#changing-the-direction-of-a-1-1-relation) (moving the foreign key from one side to another) without data loss, you need to move data as part of the migration - this SQL is not part of the default migration, and must be written by hand.
+In some scenarios, you need to edit a migration file before you apply it. For example, to [change the direction of a 1-1 relation](#example-change-the-direction-of-a-1-1-relation) (moving the foreign key from one side to another) without data loss, you need to move data as part of the migration - this SQL is not part of the default migration, and must be written by hand.
 
 This guide explains how to edit migration files and gives some examples of use cases where you may want to do this.
 

--- a/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
+++ b/content/300-guides/100-performance-and-optimization/100-prisma-client-transactions-guide.mdx
@@ -360,8 +360,6 @@ await prisma.team.deleteMany({
 })
 ```
 
-You can use the [`$transaction` API to perform a cascading delete](#are-cascading-deletes-supported-by-the-prisma-client-nested-writes).
-
 #### Can I use bulk operations with the `$transaction` API?
 
 Yes - for example, you can include multiple `deleteMany` operations inside a `$transaction`.

--- a/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/01-how-to-upgrade.mdx
+++ b/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/01-how-to-upgrade.mdx
@@ -38,7 +38,7 @@ Prisma 2._x_ and later versions:
   - Prisma Migrate: Data modeling and migrations (formerly `prisma deploy`).
 - use the [Prisma schema](/concepts/components/prisma-schema), a merge of Prisma 1 datamodel and `prisma.yml`.
 - use its own [modeling language](https://github.com/prisma/specs/tree/master/schema) instead of being based on GraphQL SDL.
-- don't expose ["a GraphQL API for your database"](/blog/prisma-and-graphql-mfl5y2r7t49c) anymore, but only allows for _programmatic access_ via the Prisma Client API.
+- don't expose ["a GraphQL API for your database"](https://prisma.io/blog/prisma-and-graphql-mfl5y2r7t49c) anymore, but only allows for _programmatic access_ via the Prisma Client API.
   - [don't support Prisma binding](/about/prisma/faq#does-prisma-client-support-graphql-schema-delegation-and-graphql-binding) any more.
 - allows connecting Prisma 2._x_ and later version to any existing database, via more powerful introspection
 

--- a/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/03-upgrading-the-prisma-layer.mdx
+++ b/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/03-upgrading-the-prisma-layer.mdx
@@ -43,7 +43,7 @@ Once done with these steps, you can move on to the next guide that explains how 
 
 The Prisma 2 CLI is available as the [`prisma`](https://www.npmjs.com/package/prisma) package on npm and is invoked via the `prisma` command.
 
-Note that the former `prisma` command for Prisma 1 has been renamed to `prisma1`. You can learn more about this [here](/blog/prisma-2-beta-b7bcl0gd8d8e#renaming-the-prisma2-cli).
+Note that the former `prisma` command for Prisma 1 has been renamed to `prisma1`. You can learn more about this [here](https://www.prisma.io/blog/prisma-2-beta-b7bcl0gd8d8e#renaming-the-prisma2-cli).
 
 You can install the Prisma 2 CLI in your Node.js project as follows (be sure to invoke this command in the directory where your `package.json` is located):
 


### PR DESCRIPTION
## Describe this PR

Five links seem to be causing docs build failures. This resolves these by removing them or making them absolute links.