### PR TITLE
Update Prisma Client page metaTitle and metaDescription

### DIFF
--- a/content/200-concepts/100-components/02-prisma-client/index.mdx
+++ b/content/200-concepts/100-components/02-prisma-client/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Prisma Client'
-metaTitle: 'Prisma Client (Reference)'
-metaDescription: 'Prisma Client is an auto-generated, type-safe query builder generated from the tables in your database.'
+metaTitle: 'Prisma Client'
+metaDescription: 'Prisma Client is an auto-generated, type-safe query builder generated based on the models and attributes of your Prisma schema.'
 ---
 
 <TopBlock>


### PR DESCRIPTION
## Describe this PR

Remove "(Reference)" from the `metaTitle` of the Prisma Client page. Also update the `metaDescription` to be a bit more precise in its description.

## Changes

Changes to `metaTitle` and `metaDescription` frontmatter attributes in `/content/200-concepts/100-components/02-prisma-client/index.mdx`

## What issue does this fix?

Fixes #4125 