### PR TITLE
Remove MongoDB from Upgarde from Prisma 1 > How to upgrade

### DIFF
--- a/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/01-how-to-upgrade.mdx
+++ b/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/01-how-to-upgrade.mdx
@@ -46,7 +46,7 @@ Prisma 2._x_ and later versions:
 
 Prisma 2._x_ and later versions do not yet have full feature parity with Prisma 1. The biggest feature that is still missing from Prisma versions 2._x_ and later is real-time subscriptions.
 
-- **Realtime API (Subscriptions)**: Prisma version 2._x_ and later currently [doesn't have a way to subscribe to events happening in the database](https://github.com/prisma/prisma/issues/298) and get notified in realtime. It is currently unclear if, when, and in what form a realtime API will be added to Prisma versions 2._x_ and later. For the time being, you can implement realtime functionality using native database triggers, or if you're using GraphQL subscriptions you can consider triggering subscriptions manually inside your _mutation resolvers_.
+- **Real-time API (Subscriptions)**: Prisma version 2._x_ and later currently [doesn't have a way to subscribe to events happening in the database](https://github.com/prisma/prisma/issues/298) and get notified in real time. It is currently unclear if, when, and in what form a real-time API will be added to Prisma versions 2._x_ and later. For the time being, you can implement real-time functionality using native database triggers, or if you're using GraphQL subscriptions you can consider triggering subscriptions manually inside your _mutation resolvers_.
 
 ## Schema incompatibilities
 

--- a/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/01-how-to-upgrade.mdx
+++ b/content/300-guides/300-upgrade-guides/800-upgrade-from-prisma-1/01-how-to-upgrade.mdx
@@ -44,10 +44,9 @@ Prisma 2._x_ and later versions:
 
 ## Feature parity
 
-Prisma 2._x_ and later versions don't have full feature parity with Prisma 1 yet. These are the biggest features that are still missing from Prisma versions 2._x_ and later:
+Prisma 2._x_ and later versions do not yet have full feature parity with Prisma 1. The biggest feature that is still missing from Prisma versions 2._x_ and later is real-time subscriptions.
 
 - **Realtime API (Subscriptions)**: Prisma version 2._x_ and later currently [doesn't have a way to subscribe to events happening in the database](https://github.com/prisma/prisma/issues/298) and get notified in realtime. It is currently unclear if, when, and in what form a realtime API will be added to Prisma versions 2._x_ and later. For the time being, you can implement realtime functionality using native database triggers, or if you're using GraphQL subscriptions you can consider triggering subscriptions manually inside your _mutation resolvers_.
-- **MongoDB support**: Prisma versions 2._x_ and later [doesn't yet support MongoDB](https://github.com/prisma/prisma/issues/1277). If you're using Prisma 1 with MongoDB and want to upgrade to Prisma versions 2._x_ and later, you either need to migrate your data into a relational database first or wait until MongoDB is supported.
 
 ## Schema incompatibilities
 


### PR DESCRIPTION
## Describe this PR

MongoDB is generally available from Prisma 3.12. This PR removes the incorrect statement that it's not supported from 2.x and later from the **Upgrade from Prisma 1** > [**How to upgrade**](https://www.prisma.io/docs/guides/upgrade-guides/upgrade-from-prisma-1/how-to-upgrade) guide

## Changes


## What issue does this fix?

<!-- Link the issue this is solving, if applicable, using the issue number. This can be found to the right of the issue title, or in the url.

Fixes #1234  -->

## Any other relevant information

<!-- Add any other information you deem to be relevant to the PR -->
