### PR TITLE
Add Warp to the MCP server guide

### DIFF
--- a/content/250-postgres/1100-integrations/400-mcp-server.mdx
+++ b/content/250-postgres/1100-integrations/400-mcp-server.mdx
@@ -267,7 +267,7 @@ You can add the Prisma MCP to Warp as a globally available tool. First, [visit y
 }
 ```
 
-Hit "Save" and ensure the MCP server is running from your MCP settings panel. Then, open a new terminal window and ask Warp to manage your Prisma database. It should reach for the Prisma MCP server automatically.
+Hit **Save** and ensure the MCP server is running from your MCP settings panel. Then, open a new terminal window and ask Warp to manage your Prisma database. It should reach for the Prisma MCP server automatically.
 
 To learn more about Warp's MCP integration, visit the [Warp MCP docs](https://docs.warp.dev/knowledge-and-collaboration/mcp).
 

--- a/content/250-postgres/1100-integrations/400-mcp-server.mdx
+++ b/content/250-postgres/1100-integrations/400-mcp-server.mdx
@@ -249,7 +249,7 @@ Adding it via the  **Windsurf Settings** will modify the global `~/.codeium/wind
 
 ### Warp
 
-You can add the Prisma MCP to Warp as a globally available tool. First, [visit your MCP settings](https://docs.warp.dev/knowledge-and-collaboration/mcp#how-to-access-mcp-server-settings) and click "+ Add". From here, you can configure the Prisma MCP server as JSON. Use the `command` and `args` properties to start the Prisma MCP server as a setup command. You can optionally configure Prisma to activate on startup using the `start_on_launch` flag:
+You can add the Prisma MCP to Warp as a globally available tool. First, [visit your MCP settings](https://docs.warp.dev/knowledge-and-collaboration/mcp#how-to-access-mcp-server-settings) and click **+ Add**. From here, you can configure the Prisma MCP server as JSON. Use the `command` and `args` properties to start the Prisma MCP server as a setup command. You can optionally configure Prisma to activate on startup using the `start_on_launch` flag:
 
 ```json
 {

--- a/content/250-postgres/1100-integrations/400-mcp-server.mdx
+++ b/content/250-postgres/1100-integrations/400-mcp-server.mdx
@@ -247,6 +247,29 @@ Adding it via the  **Windsurf Settings** will modify the global `~/.codeium/wind
 }
 ```
 
+### Warp
+
+You can add the Prisma MCP to Warp as a globally available tool. First, [visit your MCP settings](https://docs.warp.dev/knowledge-and-collaboration/mcp#how-to-access-mcp-server-settings) and click "+ Add". From here, you can configure the Prisma MCP server as JSON. Use the `command` and `args` properties to start the Prisma MCP server as a setup command. You can optionally configure Prisma to activate on startup using the `start_on_launch` flag:
+
+```json
+{
+  "Prisma": {
+    "command": "npx",
+    "args": [
+      "-y",
+      "prisma",
+      "mcp"
+    ],
+    "env": {},
+    "working_directory": null,
+    "start_on_launch": true
+  }
+}
+```
+
+Hit "Save" and ensure the MCP server is running from your MCP settings panel. Then, open a new terminal window and ask Warp to manage your Prisma database. It should reach for the Prisma MCP server automatically.
+
+To learn more about Warp's MCP integration, visit the [Warp MCP docs](https://docs.warp.dev/knowledge-and-collaboration/mcp).
 
 ### Claude Code
 


### PR DESCRIPTION
This adds installation instructions for the Prisma MCP server in Warp. I followed the Cursor and Windsurf guides as a template, but I'm open to feedback on the overall wording here!