### PR TITLE
fix: docs: 100-prisma-schema: missing SQL field

### DIFF
--- a/content/200-orm/100-prisma-schema/20-data-model/20-relations/300-many-to-many-relations.mdx
+++ b/content/200-orm/100-prisma-schema/20-data-model/20-relations/300-many-to-many-relations.mdx
@@ -74,6 +74,7 @@ CREATE TABLE "CategoriesOnPosts" (
     "postId" INTEGER NOT NULL,
     "categoryId" INTEGER NOT NULL,
     "assignedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "assignedBy" TEXT NOT NULL,
 
     CONSTRAINT "CategoriesOnPosts_pkey" PRIMARY KEY ("postId","categoryId")
 );


### PR DESCRIPTION
The explicit example showcases custom fields on underlying join table `assignedBy` and `assignedAt`

But the RAW SQL code missed the `assignedBy` field