### PR TITLE
fix: updated service token instructions

### DIFF
--- a/content/800-guides/330-management-api-basic.mdx
+++ b/content/800-guides/330-management-api-basic.mdx
@@ -28,13 +28,9 @@ The API reference is also available via an [OpenAPI 3.1. spec](https://api.prism
 First, you need to create a service token to be able to access the Management API:
 
 1. Open the [Prisma Console](https://console.prisma.io/)
-2. Navigate to the **Integrations** page of your workspace
-3. Click **Generate integration token**
+2. Navigate to the **Settings** page of your workspace and select **Service Tokens**
+3. Click **New Service Token**
 4. Copy and save the generated service token securely, you'll use it in step 2.2.
-
-<!-- :::note
-The **Generate integration token** is currently listed in the **Netlify** section. Don't get confused by this, the token will still work and the UI is going to be updated soon.
-::: -->
 
 
 ## 2. Set up your project directory


### PR DESCRIPTION
This PR updates the instructions on where to create a new service token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated the Management API guide to reflect the current service token creation flow: Prisma Console → Settings → Service Tokens → New Service Token, with a reminder to copy and save the token.
  * Removed an outdated note referencing the Netlify UI and potential UI changes.
  * All other setup steps and code examples remain unchanged, improving accuracy and reducing confusion during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->