### PR TITLE
feat: add upgrade instructions for Prisma Postgres via Vercel

### DIFF
--- a/content/250-postgres/1200-more/1000-faq.mdx
+++ b/content/250-postgres/1200-more/1000-faq.mdx
@@ -239,6 +239,17 @@ A production-grade, consumer-facing application handling ~`50000` MAUs. Heavy us
 
 Every request, whether it hits the database or is served from cache, counts as an operation. Prisma Postgres use a flat per-operation price and never charge for egress traffic, so a cached response doesn't incur any extra or reduced fee. This unified rate keeps the billing model predictable and avoids per-request complexity.
 
+### How do I upgrade my plan if I am using Prisma Postgres via Vercel?
+
+To upgrade your plan via Vercel, follow these steps:
+
+- Open your [Vercel](https://vercel.com/) Dashboard.
+- Go to the **Integrations** tab in your Vercel Team.
+- Click **Manage** on the Prisma Integration.
+- Navigate to the **Settings** tab.
+- Under Current Installation Plan Level, click **Change Plan**.
+- Select the plan you want to upgrade to.
+
 ## Caching 
 
 Prisma Postgres includes built-in connection pooling and global caching. These features improve performance by optimizing how your queries are routed and cached.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new FAQ subsection explaining how to upgrade a plan when using Prisma Postgres via Vercel.
  * Includes a clear, step-by-step navigation: Dashboard > Integrations > Prisma Integration > Settings > Current Installation Plan Level > Change Plan > select plan.
  * Placed immediately after the per-operation pricing explanation.
  * Improves clarity for plan management; no product behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->