### PR TITLE
fix: DC-4818 Add default color for code blocks' span

### DIFF
--- a/src/theme/CodeBlock/Content/styles.module.scss
+++ b/src/theme/CodeBlock/Content/styles.module.scss
@@ -30,6 +30,7 @@
   min-width: 100%;
   > span {
     padding: 0 0 0 calc(var(--ifm-pre-padding) * 2);
+    color: var(--primary-font-color);
   }
 }
 


### PR DESCRIPTION
Color on code's `span`s is defined inline, in order to get token highlighting working.
From reports on the issue/slack thread, it seems that this highlighting was taking a bit more time to resolve, so I've added a default color to fall back on, which is the most contrasting for both light and dark mode.

This should minimise the visual impact.

Fixes #DC-4818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Updated code block text color to align with the theme’s primary font color, improving visual consistency across the site.
  * Enhances readability and contrast in code blocks, especially across light/dark themes.
  * Purely a presentation change with no impact on functionality, layout, or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->