### PR TITLE
Mistakenly repeated line

### DIFF
--- a/content/200-orm/200-prisma-client/000-setup-and-configuration/300-no-rust-engine.mdx
+++ b/content/200-orm/200-prisma-client/000-setup-and-configuration/300-no-rust-engine.mdx
@@ -12,8 +12,6 @@ This page gives an overview of how to use this version of Prisma ORM.
 
 The main technical differences if you're using Prisma ORM without a Rust engine are:
 
-The main technical differences if you're using Prisma ORM without a Rust engine are:
-
 - no `binaryTargets` field on the `generator` block
 - no query engine binary that's downloaded into the directory with your generated Prisma Client
 - `engineType` needs to be set to `"client"` on the `generator` block


### PR DESCRIPTION
This text was mistakenly repeated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cleaned up a duplicated heading and spacing in the Prisma ORM (no Rust engine) guide.
  * Clarified behavior: no binaryTargets in the generator, no query engine binary downloaded with Prisma Client, and engineType must be set to "client".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->