### PR TITLE
fix: remove duplicate line of text

### DIFF
--- a/content/200-orm/200-prisma-client/000-setup-and-configuration/300-no-rust-engine.mdx
+++ b/content/200-orm/200-prisma-client/000-setup-and-configuration/300-no-rust-engine.mdx
@@ -12,8 +12,6 @@ This page gives an overview of how to use this version of Prisma ORM.
 
 The main technical differences if you're using Prisma ORM without a Rust engine are:
 
-The main technical differences if you're using Prisma ORM without a Rust engine are:
-
 - no `binaryTargets` field on the `generator` block
 - no query engine binary that's downloaded into the directory with your generated Prisma Client
 - `engineType` needs to be set to `"client"` on the `generator` block


### PR DESCRIPTION
I noticed there was a duplicate line of text in the article so I removed it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Cleaned up a duplicated header and extra spacing in the “Prisma ORM without a Rust engine” documentation.
  - Improved readability while preserving existing bullet points: no binaryTargets, no query engine binary in the generated client, engineType must be “client,” and use of driver adapters.
  - No content or functional changes; purely formatting and clarity improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->