### PR TITLE
fix: make tab items scrollable on mobile to avoid overflow

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -678,6 +678,9 @@ hr {
   .header-github-link {
     display: none;
   }
+  .tabs-container ul.tabs{
+    overflow-x: scroll;
+  }
 }
 
 .navbar__items--right > :last-child {


### PR DESCRIPTION
On tablet and smaller screen sizes, the tabs are going off the screen.

**Link** 
https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/no-rust-engine

**Problem**
<img width="573" height="828" alt="proof" src="https://github.com/user-attachments/assets/6b82aeee-bb18-4276-a37c-819f88a58df5" />

**Solution**
Targeted both tabs with a css class in a pre-existing media query, and added an overflow-x attribute with value of scroll

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enables horizontal scrolling for the tab navigation on smaller viewports (≤1191px), making wide tab lists accessible without wrapping.

- Style
  - Introduces responsive CSS that applies overflow-x: scroll to the tabs list under narrow widths.
  - Scrollbar is consistently shown when the rule applies.
  - No visual changes on wider viewports; existing styles remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->