### PR TITLE
docs: Update TypedSql docs to include custom sql folder location

### DIFF
--- a/content/200-orm/200-prisma-client/150-using-raw-sql/100-typedsql.mdx
+++ b/content/200-orm/200-prisma-client/150-using-raw-sql/100-typedsql.mdx
@@ -20,11 +20,11 @@ To start using TypedSQL in your Prisma project, follow these steps:
 
    ```prisma
    generator client {
-     provider = "prisma-client-js"
-     previewFeatures = ["typedSql"]
+    provider = "prisma-client" // or "prisma-client-js"
+    previewFeatures = ["typedSql"]
+    output = "../src/generated/prisma"
    }
    ```
-  
     :::tip[Using driver adapters with TypedSQL]
 
     If you are deploying Prisma in serverless or edge environments, you can use [driver adapters](/orm/overview/databases/database-drivers#driver-adapters) to connect through JavaScript database drivers. Driver adapters are compatible with TypedSQL, with the exception of `@prisma/adapter-better-sqlite3`. For SQLite support, use [`@prisma/adapter-libsql`](https://www.npmjs.com/package/@prisma/adapter-libsql) instead. All other driver adapters are supported.
@@ -36,6 +36,23 @@ To start using TypedSQL in your Prisma project, follow these steps:
    ```terminal
    mkdir -p prisma/sql
    ```
+
+   :::note[Custom SQL folder location]
+
+   Starting with Prisma 6.12.0, you can configure a custom location for your SQL files using the Prisma config file. Create a `prisma.config.ts` file in your project root and specify the `typedSql.path` option:
+
+   ```typescript title="prisma.config.ts"
+   import { defineConfig } from 'prisma/config'
+
+   export default defineConfig({
+     schema: './prisma/schema.prisma',
+     typedSql: {
+       path: './prisma/sql',
+     },
+   })
+   ```
+
+   :::
 
 1. Create a new `.sql` file in your `prisma/sql` directory. For example, `getUsersWithPosts.sql`. Note that the file name must be a valid JS identifier and cannot start with a `$`.
 
@@ -68,15 +85,21 @@ To start using TypedSQL in your Prisma project, follow these steps:
 
 1. Now you can import and use your SQL queries in your TypeScript code:
 
-   ```typescript title="/src/index.ts"
-   import { PrismaClient } from '@prisma/client'
-   import { getUsersWithPosts } from '@prisma/client/sql'
+  ```typescript title="/src/index.ts"
+  import { PrismaClient } from './generated/prisma/client'
+  import { getUsersWithPosts } from './generated/prisma/sql'
 
-   const prisma = new PrismaClient()
+  const prisma = new PrismaClient()
 
    const usersWithPostCounts = await prisma.$queryRawTyped(getUsersWithPosts())
    console.log(usersWithPostCounts)
    ```
+
+   :::note
+
+   If you do not customize the generator `output`, you can import from `@prisma/client` and `@prisma/client/sql` instead.
+
+   :::
 
 ## Passing Arguments to TypedSQL Queries
 
@@ -122,9 +145,9 @@ To pass arguments to your TypedSQL queries, you can use parameterized queries. T
 
 1. When using the generated function in your TypeScript code, pass the arguments as additional parameters to `$queryRawTyped`:
 
-   ```typescript title="/src/index.ts"
-   import { PrismaClient } from '@prisma/client'
-   import { getUsersByAge } from '@prisma/client/sql'
+  ```typescript title="/src/index.ts"
+  import { PrismaClient } from './generated/prisma/client'
+  import { getUsersByAge } from './generated/prisma/sql'
 
    const prisma = new PrismaClient()
 
@@ -147,8 +170,8 @@ WHERE id = ANY($1)
 ```
 
 ```typescript title="/src/index.ts"
-import { PrismaClient } from '@prisma/client'
-import { getUsersByIds } from '@prisma/client/sql'
+import { PrismaClient } from './generated/prisma/client'
+import { getUsersByIds } from './generated/prisma/sql'
 
 const prisma = new PrismaClient()
 
@@ -208,7 +231,7 @@ Manual argument type definitions are not supported for array arguments. For thes
 
 ## Examples
 
-For practical examples of how to use TypedSQL in various scenarios, please refer to the [Prisma Examples repo](https://github.com/prisma/prisma-examples). This repo contains a collection of ready-to-run Prisma example projects that demonstrate best practices and common use cases, including TypedSQL implementations.
+For practical examples of how to use TypedSQL, please refer to the [TypedSQL example in the Prisma Examples repo](https://github.com/prisma/prisma-examples/tree/latest/generator-prisma-client/basic-typedsql).
 
 ## Limitations of TypedSQL
 


### PR DESCRIPTION
- Updated generator to "prisma-client"
- Added output = "../src/generated/prisma" in schema.prisma.
- Documented custom SQL folder via prisma.config.ts (typedSql.path, since 6.12.0).
- Replaced example link with https://github.com/prisma/prisma-examples/tree/latest/generator-prisma-client/basic-typedsql

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TypedSQL docs to reflect the prisma-client generator option and configurable output path.
  * Switched code samples to generated import paths, with notes on default @prisma/client imports when not customizing output.
  * Added guidance on Custom SQL folder location and configuring typedSql.path.
  * Refreshed examples/links to the TypedSQL example repo.
  * Standardized formatting and annotations across code blocks and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->