### PR TITLE
docs: document QE timestamp backward compatibility

### DIFF
--- a/content/200-orm/050-overview/500-databases/500-sqlite.mdx
+++ b/content/200-orm/050-overview/500-databases/500-sqlite.mdx
@@ -83,7 +83,7 @@ The `timestampFormat` option is available for both `@prisma/adapter-better-sqlit
 
 **When to use each format:**
 
-- **ISO 8601 (default)**: Best for new projects. Works seamlessly with SQLite's built-in date/time functions.
+- **ISO 8601 (default)**: Best for new projects and integrates well with SQLite's built-in date/time functions.
 - **`unixepoch-ms`**: Required when migrating from Prisma ORM's native SQLite driver to maintain compatibility with existing timestamp data.
 
 ## Type mapping between SQLite to Prisma schema

--- a/content/200-orm/050-overview/500-databases/500-sqlite.mdx
+++ b/content/200-orm/050-overview/500-databases/500-sqlite.mdx
@@ -55,6 +55,37 @@ const adapter = new PrismaBetterSQLite3({
 const prisma = new PrismaClient({ adapter });
 ```
 
+### 3. Configure timestamp format for backward compatibility
+
+When using driver adapters with SQLite, you can configure how `DateTime` values are stored in the database using the `timestampFormat` option.
+
+By default, driver adapters store `DateTime` values as **ISO 8601 strings**, which is the most convenient format for SQLite since SQLite date/time functions expect ISO 8601 by default.
+
+However, if you need **100% backward compatibility** with Prisma ORM's native SQLite driver (for example, when migrating an existing database), you should use the `unixepoch-ms` format, which stores timestamps as the number of milliseconds since the Unix epoch:
+
+```ts
+import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3';
+import { PrismaClient } from './generated/prisma';
+
+const adapter = new PrismaBetterSQLite3({
+  url: "file:./prisma/dev.db"
+}, {
+  timestampFormat: 'unixepoch-ms'
+});
+const prisma = new PrismaClient({ adapter });
+```
+
+:::info
+
+The `timestampFormat` option is available for both `@prisma/adapter-better-sqlite3` and `@prisma/adapter-libsql` driver adapters.
+
+:::
+
+**When to use each format:**
+
+- **ISO 8601 (default)**: Best for new projects. Works seamlessly with SQLite's built-in date/time functions.
+- **`unixepoch-ms`**: Required when migrating from Prisma ORM's native SQLite driver to maintain compatibility with existing timestamp data.
+
 ## Type mapping between SQLite to Prisma schema
 
 The SQLite connector maps the [scalar types](/orm/prisma-schema/data-model/models#scalar-fields) from the [data model](/orm/prisma-schema/data-model/models) to native column types as follows:


### PR DESCRIPTION
Add docs for SQLite QE timestamp formats.
- Clarify Prisma 7 default (ISO 8601) vs compatibility mode (unixepoch-ms)
- Show how to enable unixepoch-ms with @prisma/adapter-better-sqlite3 and @prisma/adapter-libsql

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a subsection on configuring timestamp formats for SQLite drivers.
  * Describes default ISO 8601 storage and a unixepoch‑ms option for backward compatibility with Prisma's native SQLite driver.
  * Includes a TypeScript example, guidance on when to choose each format, and notes applicability to Better SQLite3 and LibSQL adapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->