### PR TITLE
DC 5685 - update Prisma.validator api availability information in client versions

### DIFF
--- a/content/200-orm/200-prisma-client/400-type-safety/050-prisma-validator.mdx
+++ b/content/200-orm/200-prisma-client/400-type-safety/050-prisma-validator.mdx
@@ -12,7 +12,8 @@ This page introduces the `Prisma.validator` and offers some motivations behind w
 
 </TopBlock>
 
-> **Note**: If you have a use case for `Prisma.validator`, be sure to check out this [blog post](https://www.prisma.io/blog/satisfies-operator-ur8ys8ccq7zb) about improving your Prisma Client workflows with the new TypeScript `satisfies` keyword. It's likely that you can solve your use case natively using `satisfies` instead of using `Prisma.validator`.
+> **Note**: If you have a use case for `Prisma.validator`, be sure to check out this [blog post](https://www.prisma.io/blog/satisfies-operator-ur8ys8ccq7zb) about improving your Prisma Client workflows with the new TypeScript `satisfies` keyword.  
+> This API only exists when using the old `prisma-client-js` generator, and is not available in `prisma-client`. It's likely that you can solve your use case natively using `satisfies` instead of using `Prisma.validator`.
 
 ## Creating a typed query statement
 


### PR DESCRIPTION
### Summary

This PR clarifies that the `prisma.validator` API is only available when using the legacy `prisma-client-js` generator, and **not** in the new `prisma-client`.

### Visual Changes

|                                                                              Before                                                                             |                                                                              After                                                                              |
| :-------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------: |
| <img width="1512" height="741" alt="Screenshot 2025-10-17 at 14 18 42" src="https://github.com/user-attachments/assets/ad9a399b-8dc3-4c90-bfba-c091afb5ef41" /> | <img width="1511" height="738" alt="Screenshot 2025-10-17 at 16 45 27" src="https://github.com/user-attachments/assets/4416766f-c149-400f-b57b-2f048ea5e53d" /> 

### Preview link 
https://feat-dc-5685-prisma-validato.docs-51g.pages.dev/orm/prisma-client/type-safety/prisma-validator

### Related Issue

[Linear issue → DC-5685](https://linear.app/prisma-company/issue/DC-5685/clarify-prismavalidator-api-availability-in-client-versions)
