### PR TITLE
Add command options for avoiding vscode error checking problems

### DIFF
--- a/content/100-getting-started/01-quickstart-sqlite.mdx
+++ b/content/100-getting-started/01-quickstart-sqlite.mdx
@@ -49,7 +49,7 @@ See [installation instructions](/orm/tools/prisma-cli#installation) to learn how
 Now, initialize TypeScript:
 
 ```terminal
-npx tsc --init --types=node
+npx tsc --init --types node
 ```
 
 Then, install the Prisma CLI as a development dependency in the project:

--- a/content/100-getting-started/01-quickstart-sqlite.mdx
+++ b/content/100-getting-started/01-quickstart-sqlite.mdx
@@ -34,7 +34,7 @@ cd hello-prisma
 Next, initialize a TypeScript project using npm:
 
 ```terminal
-npm init -y
+npm init --init-type=module -y
 npm install typescript tsx @types/node --save-dev
 ```
 
@@ -49,7 +49,7 @@ See [installation instructions](/orm/tools/prisma-cli#installation) to learn how
 Now, initialize TypeScript:
 
 ```terminal
-npx tsc --init
+npx tsc --init --types=node
 ```
 
 Then, install the Prisma CLI as a development dependency in the project:

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-cockroachdb.mdx
@@ -41,7 +41,7 @@ cd hello-prisma
 Next, initialize a Node.js project and add the Prisma CLI as a development dependency to it:
 
 ```terminal copy
-npm init -y
+npm init --init-type=module -y
 npm install prisma --save-dev
 ```
 

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-mysql.mdx
@@ -41,7 +41,7 @@ cd hello-prisma
 Next, initialize a Node.js project and add the Prisma CLI as a development dependency to it:
 
 ```terminal copy
-npm init -y
+npm init --init-type=module -y
 npm install prisma --save-dev
 ```
 

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-planetscale.mdx
@@ -34,7 +34,7 @@ This tutorial will also assume that you can push to the `main` branch of your da
 Next, initialize a Node.js project and add the Prisma CLI as a development dependency to it:
 
 ```terminal copy
-npm init -y
+npm init --init-type=module -y
 npm install prisma --save-dev
 ```
 

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-postgresql.mdx
@@ -41,7 +41,7 @@ cd hello-prisma
 Next, initialize a Node.js project and add the Prisma CLI as a development dependency to it:
 
 ```terminal copy
-npm init -y
+npm init --init-type=module -y
 npm install prisma --save-dev
 ```
 

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-node-sqlserver.mdx
@@ -44,7 +44,7 @@ cd hello-prisma
 Next, initialize a Node.js project and add the Prisma CLI as a development dependency to it:
 
 ```terminal copy
-npm init -y
+npm init --init-type=module -y
 npm install prisma --save-dev
 ```
 

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-cockroachdb.mdx
@@ -41,7 +41,7 @@ cd hello-prisma
 Next, initialize a TypeScript project and add the Prisma CLI as a development dependency to it:
 
 ```terminal copy
-npm init -y
+npm init --init-type=module -y
 npm install prisma typescript tsx @types/node --save-dev
 ```
 
@@ -50,7 +50,7 @@ This creates a `package.json` with an initial setup for your TypeScript app.
 Next, initialize TypeScript:
 
 ```terminal copy
-npx tsc --init
+npx tsc --init --types=node
 ```
 
 :::info

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-cockroachdb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-cockroachdb.mdx
@@ -50,7 +50,7 @@ This creates a `package.json` with an initial setup for your TypeScript app.
 Next, initialize TypeScript:
 
 ```terminal copy
-npx tsc --init --types=node
+npx tsc --init --types node
 ```
 
 :::info

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-mysql.mdx
@@ -41,7 +41,7 @@ cd hello-prisma
 Next, initialize a TypeScript project and add the Prisma CLI as a development dependency to it:
 
 ```terminal copy
-npm init -y
+npm init --init-type=module -y
 npm install prisma typescript tsx @types/node --save-dev
 ```
 
@@ -50,7 +50,7 @@ This creates a `package.json` with an initial setup for your TypeScript app.
 Next, initialize TypeScript:
 
 ```terminal copy
-npx tsc --init
+npx tsc --init --types=node
 ```
 
 :::info

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-mysql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-mysql.mdx
@@ -50,7 +50,7 @@ This creates a `package.json` with an initial setup for your TypeScript app.
 Next, initialize TypeScript:
 
 ```terminal copy
-npx tsc --init --types=node
+npx tsc --init --types node
 ```
 
 :::info

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-planetscale.mdx
@@ -47,7 +47,7 @@ cd hello-prisma
 Next, initialize a TypeScript project and add the Prisma CLI as a development dependency to it:
 
 ```terminal copy
-npm init -y
+npm init --init-type=module -y
 npm install prisma typescript tsx @types/node --save-dev
 ```
 
@@ -56,7 +56,7 @@ This creates a `package.json` with an initial setup for your TypeScript app.
 Next, initialize TypeScript:
 
 ```terminal copy
-npx tsc --init
+npx tsc --init --types=node
 ```
 
 :::info

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-planetscale.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-planetscale.mdx
@@ -56,7 +56,7 @@ This creates a `package.json` with an initial setup for your TypeScript app.
 Next, initialize TypeScript:
 
 ```terminal copy
-npx tsc --init --types=node
+npx tsc --init --types node
 ```
 
 :::info

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-postgresql.mdx
@@ -45,7 +45,7 @@ This creates a `package.json` with an initial setup for your TypeScript app.
 Next, initialize TypeScript:
 
 ```terminal copy
-npx tsc --init --types=node
+npx tsc --init --types node
 ```
 
 :::info

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-postgresql.mdx
@@ -36,7 +36,7 @@ cd hello-prisma
 Next, initialize a TypeScript project and add the Prisma CLI as a development dependency to it:
 
 ```terminal copy
-npm init -y
+npm init --init-type=module -y
 npm install prisma typescript tsx @types/node --save-dev
 ```
 
@@ -45,7 +45,7 @@ This creates a `package.json` with an initial setup for your TypeScript app.
 Next, initialize TypeScript:
 
 ```terminal copy
-npx tsc --init
+npx tsc --init --types=node
 ```
 
 :::info

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-prismaPostgres.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-prismaPostgres.mdx
@@ -46,7 +46,7 @@ This creates a `package.json` with an initial setup for your TypeScript app.
 Next, initialize TypeScript:
 
 ```terminal copy
-npx tsc --init --types=node
+npx tsc --init --types node
 ```
 
 You can now invoke the Prisma CLI by prefixing it with `npx`:

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-prismaPostgres.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-prismaPostgres.mdx
@@ -37,7 +37,7 @@ cd hello-prisma
 Next, initialize a TypeScript project and add the Prisma CLI as a development dependency to it:
 
 ```terminal copy
-npm init -y
+npm init --init-type=module -y
 npm install prisma typescript tsx @types/node --save-dev
 ```
 
@@ -46,7 +46,7 @@ This creates a `package.json` with an initial setup for your TypeScript app.
 Next, initialize TypeScript:
 
 ```terminal copy
-npx tsc --init
+npx tsc --init --types=node
 ```
 
 You can now invoke the Prisma CLI by prefixing it with `npx`:

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-sqlserver.mdx
@@ -52,7 +52,7 @@ This creates a `package.json` with an initial setup for your TypeScript app.
 Next, initialize TypeScript:
 
 ```terminal copy
-npx tsc --init --types=node
+npx tsc --init --types node
 ```
 
 :::info

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-sqlserver.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases-typescript-sqlserver.mdx
@@ -43,7 +43,7 @@ cd hello-prisma
 Next, initialize a TypeScript project and add the Prisma CLI as a development dependency to it:
 
 ```terminal copy
-npm init -y
+npm init --init-type=module -y
 npm install prisma typescript tsx @types/node --save-dev
 ```
 
@@ -52,7 +52,7 @@ This creates a `package.json` with an initial setup for your TypeScript app.
 Next, initialize TypeScript:
 
 ```terminal copy
-npx tsc --init
+npx tsc --init --types=node
 ```
 
 :::info

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb-node-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb-node-mongodb.mdx
@@ -43,7 +43,7 @@ cd hello-prisma
 Next, initialize a Node.js project and add the Prisma CLI as a development dependency to it:
 
 ```terminal copy
-npm init -y
+npm init --init-type=module -y
 npm install prisma --save-dev
 ```
 

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb-typescript-mongodb.mdx
@@ -51,7 +51,7 @@ This creates a `package.json` with an initial setup for your TypeScript app.
 Next, initialize TypeScript:
 
 ```terminal copy
-npx tsc --init --types=node
+npx tsc --init --types node
 ```
 
 import PrismaInitPartial from './_prisma-init-partial.mdx'

--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/120-mongodb-typescript-mongodb.mdx
@@ -42,7 +42,7 @@ cd hello-prisma
 Next, initialize a TypeScript project and add the Prisma CLI as a development dependency to it:
 
 ```terminal copy
-npm init -y
+npm init --init-type=module -y
 npm install prisma typescript tsx @types/node --save-dev
 ```
 
@@ -51,7 +51,7 @@ This creates a `package.json` with an initial setup for your TypeScript app.
 Next, initialize TypeScript:
 
 ```terminal copy
-npx tsc --init
+npx tsc --init --types=node
 ```
 
 import PrismaInitPartial from './_prisma-init-partial.mdx'

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/125-introspection-node-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/125-introspection-node-mongodb.mdx
@@ -38,7 +38,7 @@ Now that you have a MongoDB database, the next step is to create a new project a
 ```terminal copy
 mkdir blog
 cd blog
-npm init -y
+npm init --init-type=module -y
 npm install -D prisma
 npx prisma init --datasource-provider mongodb --output ../generated/prisma
 ```

--- a/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/125-introspection-typescript-mongodb.mdx
+++ b/content/100-getting-started/02-setup-prisma/200-add-to-existing-project/120-mongodb/125-introspection-typescript-mongodb.mdx
@@ -38,7 +38,7 @@ Now that you have a MongoDB database, the next step is to create a new project a
 ```terminal copy
 mkdir blog
 cd blog
-npm init -y
+npm init --init-type=module -y
 npm install -D prisma
 npx prisma init --datasource-provider mongodb --output ../generated/prisma
 ```

--- a/content/100-getting-started/03-prisma-postgres/100-from-the-cli.mdx
+++ b/content/100-getting-started/03-prisma-postgres/100-from-the-cli.mdx
@@ -101,7 +101,7 @@ Now that your project is in the correct location, continue with the setup.
 Initialize a TypeScript project and add the Prisma CLI as a development dependency:
 
 ```terminal
-npm init -y
+npm init --init-type=module -y
 npm install typescript tsx @types/node --save-dev
 ```
 
@@ -110,7 +110,7 @@ This creates a `package.json` file with an initial setup for your TypeScript app
 Next, initialize TypeScript with a `tsconfig.json` file in the project:
 
 ```terminal
-npx tsc --init
+npx tsc --init --types=node
 ```
 
 ### 2.2. Set up Prisma ORM

--- a/content/100-getting-started/03-prisma-postgres/100-from-the-cli.mdx
+++ b/content/100-getting-started/03-prisma-postgres/100-from-the-cli.mdx
@@ -110,7 +110,7 @@ This creates a `package.json` file with an initial setup for your TypeScript app
 Next, initialize TypeScript with a `tsconfig.json` file in the project:
 
 ```terminal
-npx tsc --init --types=node
+npx tsc --init --types node
 ```
 
 ### 2.2. Set up Prisma ORM

--- a/package-lock.json
+++ b/package-lock.json
@@ -247,6 +247,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.40.0.tgz",
       "integrity": "sha512-nlr/MMgoLNUHcfWC5Ns2ENrzKx9x51orPc6wJ8Ignv1DsrUmKm0LUih+Tj3J+kxYofzqQIQRU495d4xn3ozMbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.40.0",
         "@algolia/requester-browser-xhr": "5.40.0",
@@ -372,6 +373,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2312,6 +2314,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2334,6 +2337,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2443,6 +2447,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2864,6 +2869,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3546,6 +3552,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.1.tgz",
       "integrity": "sha512-FWDk1LIGD5UR5Zmm9rCrXRoxZUgbwuP6FBA7rc50DVfzqDOMkeMe3NyJhOsA2dF0zBE3VbHEIMmTjKwTZJwbaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/babel": "3.9.1",
         "@docusaurus/bundler": "3.9.1",
@@ -3622,6 +3629,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.9.1.tgz",
       "integrity": "sha512-zJIrIv+R/IN5TTLV9L+SvO3hwz62L6pO/L16k+b2nC3to3Gn01cnEGHL6doTGAezuPwTSmteJl+kzaoOf+znzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/types": "3.9.1",
         "@rspack/core": "^1.5.0",
@@ -3750,6 +3758,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.1.tgz",
       "integrity": "sha512-DyLk9BIA6I9gPIuia8XIL+XIEbNnExam6AHzRsfrEq4zJr7k/DsWW7oi4aJMepDnL7jMRhpVcdsCxdjb0/A9xg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.1",
         "@docusaurus/logger": "3.9.1",
@@ -5530,6 +5539,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -6712,6 +6722,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6816,6 +6827,7 @@
       "integrity": "sha512-WezcBo8a0Dg2rnR82zhwoR6aRNxeTGfK5QCD6TQ+kg3xx/zNT02s/0o+81h/3zhvFSB24NtqEr8FTw88O5W/JQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.24"
@@ -7505,6 +7517,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -7864,6 +7877,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7949,6 +7963,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7994,6 +8009,7 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.40.0.tgz",
       "integrity": "sha512-a9aIL2E3Z7uYUPMCmjMFFd5MWhn+ccTubEvnMy7rOTZCB62dXBJtz0R5BZ/TPuX3R9ocBsgWuAbGWQ+Ph4Fmlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.6.0",
         "@algolia/client-abtesting": "5.40.0",
@@ -8505,6 +8521,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -9537,6 +9554,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11105,6 +11123,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -16152,6 +16171,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -16832,6 +16852,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -17735,6 +17756,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -18571,6 +18593,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18580,6 +18603,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -18635,6 +18659,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -18663,6 +18688,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -19414,6 +19440,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.2.tgz",
       "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -20716,7 +20743,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
@@ -20779,6 +20807,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20815,6 +20844,7 @@
       "integrity": "sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "defu": "^6.1.4",
         "exsolve": "^1.0.7",
@@ -21180,6 +21210,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -21401,6 +21432,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -21828,6 +21860,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -22094,6 +22127,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
I encountered a bunch of errors from vscode because the default configurations don't match to esm. (see: prisma/prisma#28279) This changes can:

* Set `type` option in `package.json` file to `module`. Ref: https://docs.npmjs.com/cli/v11/commands/npm-init#init-type
* Set `compilerOptions.types` in `tsconfig.json` to `["node"]` for accepting `node:`-prefixed modules. Ref: https://www.typescriptlang.org/docs/handbook/compiler-options.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated multiple getting-started guides to initialize new projects with ES module support by default (uses npm init --init-type=module -y).
  * Clarified TypeScript setup to include Node.js type definitions when initializing the TS config (uses npx tsc --init --types node).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->