### PR TITLE
doc(prisma-config): update example using environment variables

### DIFF
--- a/content/200-orm/500-reference/325-prisma-config-reference.mdx
+++ b/content/200-orm/500-reference/325-prisma-config-reference.mdx
@@ -356,7 +356,28 @@ export default {} satisfies PrismaConfig;
 
 ### Using environment variables
 
-When using `prisma.config.ts`, environment variables from `.env` files are not automatically loaded. You'll need to:
+When using `prisma.config.ts`, environment variables from `.env` files are not automatically loaded. If you're using node or deno, you'll need to: 
+
+1. Pass a `--env-file` flag to the command line 
+
+<TabbedContent code>
+<TabItem value="Node">
+```terminal
+node --env-file=.env index.js
+node --env-file=.env --env-file=.local.env index.js
+```
+</TabItem>
+<TabItem value="Deno">
+```terminal
+deno run --env-file main.ts
+deno run --env-file=.env --env-file=.local.env main.ts
+```
+</TabItem>
+</TabbedContent>
+
+For Bun, `.env` files are automatically loaded.
+
+For releases of Node before v20, you'll need to: 
 
 1. Install the `dotenv` package:
 


### PR DESCRIPTION
Update prisma-config example for using environment variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for loading environment variables when using prisma.config.ts, covering Node, Deno, and Bun.
  * Added explicit command-line examples (including --env-file) and a tabbed Node/Deno example block.
  * Included Node v18/v19 guidance to install and import dotenv plus a sample usage for PrismaConfig.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->