### PR TITLE
docs(config): add missing datasource reference

### DIFF
--- a/content/200-orm/500-reference/325-prisma-config-reference.mdx
+++ b/content/200-orm/500-reference/325-prisma-config-reference.mdx
@@ -101,6 +101,13 @@ export declare type PrismaConfig = {
   // Depending on the choice, you must provide either a `datasource` object or driver adapter
   engine: 'classic' | 'js'
   
+  // If using the clasic engine, datasource sets the database url, shadowDatabaseUrl, or directURL
+  datasource: {
+    url: string;
+    directUrl?: string;
+    shadowDatabaseUrl?: string;
+  }
+  
 };
 ```
 
@@ -363,29 +370,37 @@ export default defineConfig({
 });
 ```
 
-Alternatively, if you are opting to use the newer Rust-free schema engine, set the engine to `js` and
-provide the adapter you wish to use
+### `datasource.url`
 
-```ts
-import path from "node:path";
-import { defineConfig, env } from "prisma/config";
-import { PrismaD1 } from "@prisma/adapter-d1";
-export default defineConfig({
-  experimental: {
-    adapter: true
-  },
-  engine: "js",
-  async adapter() {
-    return new PrismaD1({
-      CLOUDFLARE_D1_TOKEN: process.env.CLOUDFLARE_D1_TOKEN,
-      CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID,
-      CLOUDFLARE_DATABASE_ID: process.env.CLOUDFLARE_DATABASE_ID,
-    });
-  },
-  schema: path.join("prisma", "schema.prisma"),
-});
+Connection URL including authentication info. Most connectors use [the syntax provided by the database](/orm/reference/connection-urls#format).
 
-```
+| Property         | Type               | Required | Default           |
+| --------         | ------------------ | -------- | ----------------- |
+| `datasource.url` | `string`           | Yes       | `''`              |
+
+
+### `datasource.shadowDatabaseUrl`
+
+
+Connection URL to the shadow database used by Prisma Migrate. Allows you to use a cloud-hosted database as the shadow database
+
+| Property                       | Type               | Required | Default           |
+| --------                       | ------------------ | -------- | ----------------- |
+| `datasource.shadowDatabaseUrl` | `string`           | No       | `''`              |
+
+
+### `datasource.directUrL`
+
+
+Connection URL for direct connection to the database.
+
+If you use a connection pooler URL in the `url` argument (for example, if you use [Prisma Accelerate](/accelerate) or pgBouncer), Prisma CLI commands that require a direct connection to the database use the URL in the `directUrl` argument. <br/> <br/> The `directUrl` property is supported by Prisma Studio from version 5.1.0 upwards. <br/> <br/> The `directUrl` property is not needed when using [Prisma Postgres](/postgres) database.
+
+| Property               | Type               | Required | Default           |
+| --------               | ------------------ | -------- | ----------------- |
+| `datasource.directUrl` | `string`           | No       | `''`              |
+
+
 
 
 ## Common patterns

--- a/content/200-orm/500-reference/325-prisma-config-reference.mdx
+++ b/content/200-orm/500-reference/325-prisma-config-reference.mdx
@@ -101,8 +101,8 @@ export declare type PrismaConfig = {
   // Depending on the choice, you must provide either a `datasource` object or driver adapter
   engine: 'classic' | 'js'
   
-  // If using the clasic engine, datasource sets the database url, shadowDatabaseUrl, or directURL
-  datasource: {
+  // If using the classic engine, datasource sets the database url, shadowDatabaseUrl, or directURL
+  datasource?: {
     url: string;
     directUrl?: string;
     shadowDatabaseUrl?: string;
@@ -389,7 +389,7 @@ Connection URL to the shadow database used by Prisma Migrate. Allows you to use 
 | `datasource.shadowDatabaseUrl` | `string`           | No       | `''`              |
 
 
-### `datasource.directUrL`
+### `datasource.directUrl`
 
 
 Connection URL for direct connection to the database.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma configuration reference to document a new optional datasource object with required url and optional directUrl and shadowDatabaseUrl fields.
  * Revised example usage in the reference to reflect the updated datasource options and clarify configuration patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->