### PR TITLE
docs: added missing 'Profile' table mentioned

### DIFF
--- a/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-node-postgresql.mdx
+++ b/content/100-getting-started/02-setup-prisma/100-start-from-scratch/110-relational-databases/250-querying-the-database-node-postgresql.mdx
@@ -143,7 +143,7 @@ The output should look similar to this:
 ]
 ```
 
-The query added new records to the `User` and the `Post` tables:
+The query added new records to the `User`, `Post` and `Profile` tables:
 
 **User**
 


### PR DESCRIPTION
## Description
Added missing `Profile` table reference in the database querying example. The example was showing queries for `User` and `Post` tables but omitted the recently created `Profile` table that was mentioned earlier in the guide.

<img width="auto" height="400" alt="missing-table-name" src="https://github.com/user-attachments/assets/046e2863-a034-4972-be55-c1f8928c21df" />


## Changes Made
- **File**: `250-querying-the-database-node-postgresql.mdx`
- **Specific updates**:  Added `Profile` to line 146

<img width="auto" height="400" alt="image" src="https://github.com/user-attachments/assets/b269251f-660a-4a72-bc56-949fc28c1762" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup guide to reflect that User, Post, and Profile table records are created during the initial database configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->