### PR TITLE
Added a warning that `prisma-client-js` will be deprecated in v7

### DIFF
--- a/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
@@ -24,6 +24,12 @@ Alternatively, you can configure any npm package that complies with our generato
 
 ## `prisma-client-js`
 
+:::warning
+
+In Prisma ORM 7, `prisma-client-js` will be deprecated in favor of `prisma-client`. For more information, [read more](https://www.prisma.io/blog/rust-free-prisma-orm-is-ready-for-production).
+
+:::
+
 The `prisma-client-js` is the default generator for Prisma ORM 6.X versions and before. It requires the `@prisma/client` npm package and generates Prisma Client into `node_modules`.
 
 ### Field reference


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notice for prisma-client-js generator, indicating it will be deprecated in Prisma ORM 7 in favor of prisma-client with guidance on migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->