### PR TITLE
DC-5044 `prisma-client-js` deprecated

### DIFF
--- a/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/03-generators.mdx
@@ -15,78 +15,9 @@ generator client {
 
 A generator determines which assets are created when you run the `prisma generate` command.
 
-There are two generators for Prisma Client:
-
-- `prisma-client` (recommended): Newer and more flexible version of `prisma-client-js` with ESM support; it outputs plain TypeScript code and _requires_ a custom `output` path (read more about it [here](https://www.prisma.io/blog/why-prisma-orm-generates-code-into-node-modules-and-why-it-ll-change))
-- `prisma-client-js`: Generates Prisma Client into `node_modules`
+The default generator for Prisma Client is `prisma-client`, which outputs plain TypeScript code and _requires_ a custom `output` path (read more about it [here](https://www.prisma.io/blog/why-prisma-orm-generates-code-into-node-modules-and-why-it-ll-change)).
 
 Alternatively, you can configure any npm package that complies with our generator specification.
-
-## `prisma-client-js`
-
-The `prisma-client-js` is the default generator for Prisma ORM 6.X versions and before. It requires the `@prisma/client` npm package and generates Prisma Client into `node_modules`.
-
-### Field reference
-
-The generator for Prisma's JavaScript Client accepts multiple additional properties:
-
-- `previewFeatures`: [Preview features](/orm/reference/preview-features) to include
-- `binaryTargets`: Engine binary targets for `prisma-client-js` (for example, `debian-openssl-1.1.x` if you are deploying to Ubuntu 18+, or `native` if you are working locally)
-
-```prisma
-generator client {
-  provider        = "prisma-client-js"
-  previewFeatures = ["sample-preview-feature"]
-  binaryTargets   = ["debian-openssl-1.1.x"] // defaults to `"native"`
-}
-```
-
-### Binary targets
-
-:::note
-
-As of [v6.16.0](https://pris.ly/release/6.16.0), Prisma ORM can be used without Rust engines in production applications. Learn more [here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
-
-**When enabled, your Prisma Client will be generated without a Rust-based query engine binary**:
-
-```prisma
-generator client {
-  provider   = "prisma-client-js" // or "prisma-client"
-  output     = "../src/generated/prisma"
-  engineType = "client"           // no Rust engine
-}
-```
-
-Note that [driver adapters](/orm/overview/databases/database-drivers#driver-adapters) are required if you want to use Prisma ORM without Rust engines.
-
-When using Prisma ORM without Rust, the `binaryTargets` field is obsolete and not needed.
-
-You can [read about the performance and DX improvements](https://www.prisma.io/blog/prisma-orm-without-rust-latest-performance-benchmarks) of this change on our blog.
-
-:::
-
-The `prisma-client-js` generator uses several [engines](https://github.com/prisma/prisma-engines). Engines are implemented in Rust and are used by Prisma Client in the form of executable, platform-dependent engine files. Depending on which platform you are executing your code on, you need the correct file. "Binary targets" are used to define which files should be present for the target platform(s).
-
-The correct file is particularly important when [deploying](/orm/prisma-client/deployment/deploy-prisma) your application to production, which often differs from your local development environment.
-
-#### The `native` binary target
-
-The `native` binary target is special. It doesn't map to a concrete operating system. Instead, when `native` is specified in `binaryTargets`, Prisma Client detects the _current_ operating system and automatically specifies the correct binary target for it.
-
-As an example, assume you're running **macOS** and you specify the following generator:
-
-```prisma file=prisma/schema.prisma
-generator client {
-  provider      = "prisma-client-js"
-  binaryTargets = ["native"]
-}
-```
-
-In that case, Prisma Client detects your operating system and finds the right binary file for it based on the [list of supported operating systems](/orm/reference/prisma-schema-reference#binarytargets-options) .
-If you use macOS Intel x86 (`darwin`), then the binary file that was compiled for `darwin` will be selected.
-If you use macOS ARM64 (`darwin-arm64`), then the binary file that was compiled for `darwin-arm64` will be selected.
-
-> **Note**: The `native` binary target is the default. You can set it explicitly if you wish to include additional [binary targets](/orm/reference/prisma-schema-reference#binarytargets-options) for deployment to different environments.
 
 ## `prisma-client`
 
@@ -104,7 +35,7 @@ Here are the main differences compared to `prisma-client-js`:
 - More flexible thanks to additional [fields](#field-reference)
 - Outputs plain TypeScript that's bundled just like the rest of your application code
 
-The `prisma-client` generator has been Generally Available since [v6.16.0](https://pris.ly/releases/6.16.0) will become the new default with Prisma ORM v7.
+The `prisma-client` generator has been Generally Available since [v6.16.0](https://pris.ly/releases/6.16.0) and is the default generator as of Prisma ORM v7.
 
 ### Getting started
 
@@ -395,6 +326,78 @@ To see what the new `prisma-client` generator looks like in practice, check out 
 | [`nuxt4-starter-nodejs`](https://github.com/prisma/prisma-examples/tree/latest/generator-prisma-client/nuxt4-starter-nodejs)                                       | Nuxt 4         | Vite 7            | Node.js                                          | n/a       |
 | [`bun`](https://github.com/prisma/prisma-examples/tree/latest/generator-prisma-client/deno-deploy)                                                                 | None           | None              | Deno 2                                           | n/a       |
 | [`deno`](https://github.com/prisma/prisma-examples/tree/latest/generator-prisma-client/deno-deploy)                                                                | None           | None              | Deno 2                                           | n/a       |
+
+## `prisma-client-js` (Deprecated)
+
+:::warning Deprecated
+
+The `prisma-client-js` generator is **deprecated as of Prisma 7**. It was the default generator for Prisma ORM 6.X and earlier versions. We recommend migrating to [`prisma-client`](#prisma-client) for new projects and updating existing projects when possible.
+
+:::
+
+The `prisma-client-js` generator requires the `@prisma/client` npm package and generates Prisma Client into `node_modules`.
+
+### Field reference
+
+The generator for Prisma's JavaScript Client accepts multiple additional properties:
+
+- `previewFeatures`: [Preview features](/orm/reference/preview-features) to include
+- `binaryTargets`: Engine binary targets for `prisma-client-js` (for example, `debian-openssl-1.1.x` if you are deploying to Ubuntu 18+, or `native` if you are working locally)
+
+```prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["sample-preview-feature"]
+  binaryTargets   = ["debian-openssl-1.1.x"] // defaults to `"native"`
+}
+```
+
+### Binary targets
+
+:::note
+
+As of [v6.16.0](https://pris.ly/release/6.16.0), Prisma ORM can be used without Rust engines in production applications. Learn more [here](/orm/prisma-client/setup-and-configuration/no-rust-engine).
+
+**When enabled, your Prisma Client will be generated without a Rust-based query engine binary**:
+
+```prisma
+generator client {
+  provider   = "prisma-client-js" // or "prisma-client"
+  output     = "../src/generated/prisma"
+  engineType = "client"           // no Rust engine
+}
+```
+
+Note that [driver adapters](/orm/overview/databases/database-drivers#driver-adapters) are required if you want to use Prisma ORM without Rust engines.
+
+When using Prisma ORM without Rust, the `binaryTargets` field is obsolete and not needed.
+
+You can [read about the performance and DX improvements](https://www.prisma.io/blog/prisma-orm-without-rust-latest-performance-benchmarks) of this change on our blog.
+
+:::
+
+The `prisma-client-js` generator uses several [engines](https://github.com/prisma/prisma-engines). Engines are implemented in Rust and are used by Prisma Client in the form of executable, platform-dependent engine files. Depending on which platform you are executing your code on, you need the correct file. "Binary targets" are used to define which files should be present for the target platform(s).
+
+The correct file is particularly important when [deploying](/orm/prisma-client/deployment/deploy-prisma) your application to production, which often differs from your local development environment.
+
+#### The `native` binary target
+
+The `native` binary target is special. It doesn't map to a concrete operating system. Instead, when `native` is specified in `binaryTargets`, Prisma Client detects the _current_ operating system and automatically specifies the correct binary target for it.
+
+As an example, assume you're running **macOS** and you specify the following generator:
+
+```prisma file=prisma/schema.prisma
+generator client {
+  provider      = "prisma-client-js"
+  binaryTargets = ["native"]
+}
+```
+
+In that case, Prisma Client detects your operating system and finds the right binary file for it based on the [list of supported operating systems](/orm/reference/prisma-schema-reference#binarytargets-options) .
+If you use macOS Intel x86 (`darwin`), then the binary file that was compiled for `darwin` will be selected.
+If you use macOS ARM64 (`darwin-arm64`), then the binary file that was compiled for `darwin-arm64` will be selected.
+
+> **Note**: The `native` binary target is the default. You can set it explicitly if you wish to include additional [binary targets](/orm/reference/prisma-schema-reference#binarytargets-options) for deployment to different environments.
 
 ## Community generators
 

--- a/content/200-orm/500-reference/100-prisma-schema-reference.mdx
+++ b/content/200-orm/500-reference/100-prisma-schema-reference.mdx
@@ -161,7 +161,7 @@ Defines a [generator](/orm/prisma-schema/overview/generators) in the Prisma sche
 
 ### Fields for `prisma-client-js` provider
 
-This is the default generator for Prisma ORM 6.x and earlier versions. Learn more about [generators](/orm/prisma-schema/overview/generators#prisma-client-js).
+This is the default generator for Prisma ORM 6.x and earlier versions. Learn more about [generators](/orm/prisma-schema/overview/generators#prisma-client-js-deprecated).
 
 A `generator` block accepts the following fields:
 


### PR DESCRIPTION
Added deprecation warnings to the `prisma-client-js` section, moved it below the `prisma-client` section, removed the two generator list from the intro, and updated text to reflect `prisma-client` as the default in Prisma 7.