### PR TITLE
CD-6112 add youtube video link to blog post

### DIFF
--- a/content/900-ai/prompts/nextjs.mdx
+++ b/content/900-ai/prompts/nextjs.mdx
@@ -15,6 +15,22 @@ Include this prompt in your AI assistant to guide consistent code generation for
 - **Zed**: Use `/file` followed by your prompt's path.  
 - **Windsurf**: Use `@Files` and choose your prompt file from the list.  
 
+## Video Tutorial
+
+Watch this step-by-step walkthrough showing this prompt in action:
+
+<div class="videoWrapper">
+  <iframe
+    width="560"
+    height="315"
+    src="https://www.youtube.com/embed/Aqkc95jtHzM"
+    title="YouTube video player"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+  ></iframe>
+</div>
+
 ## Prompt
 
 ````md


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a video tutorial section to the Next.js documentation featuring an embedded demonstration of the prompt in action, providing visual guidance to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="1000" height="1204" alt="Screenshot 2025-10-31 at 14 35 45" src="https://github.com/user-attachments/assets/9cee4fca-8b15-4044-be55-679665a989bd" />
