### PR TITLE
chore(): add summary sections to top pages

### DIFF
--- a/content/200-orm/050-overview/500-databases/800-sql-server/020-sql-server-local.mdx
+++ b/content/200-orm/050-overview/500-databases/800-sql-server/020-sql-server-local.mdx
@@ -4,6 +4,11 @@ metaTitle: 'SQL Server on Windows'
 metaDescription: 'Set up and configure SQL Server on Windows.'
 ---
 
+:::info Quick summary
+Learn how to set up and configure Microsoft SQL Server locally on Windows for use with Prisma ORM.
+:::
+
+
 <TopBlock>
 
 To run a Microsoft SQL Server locally on a Windows machine:

--- a/content/200-orm/050-overview/500-databases/800-sql-server/030-sql-server-docker.mdx
+++ b/content/200-orm/050-overview/500-databases/800-sql-server/030-sql-server-docker.mdx
@@ -4,6 +4,11 @@ metaTitle: 'SQL Server  on Docker'
 metaDescription: 'Download and use the Microsoft SQL Server Docker image.'
 ---
 
+:::info Quick summary
+This guide provides a quick overview on setting up and running Microsoft SQL Server in a Docker container, including pulling the image, starting the server, connecting, and creating a test database.
+:::
+
+
 <TopBlock>
 
 To run a Microsoft SQL Server container image with Docker:

--- a/content/200-orm/100-prisma-schema/20-data-model/20-relations/100-one-to-one-relations.mdx
+++ b/content/200-orm/100-prisma-schema/20-data-model/20-relations/100-one-to-one-relations.mdx
@@ -4,6 +4,11 @@ metaDescription: How to define and work with one-to-one relations in Prisma.
 tocDepth: 3
 ---
 
+:::info Quick summary
+Learn how to define and use one-to-one (1-1) relations in your Prisma schema, including modeling choices and key concepts.
+:::
+
+
 <TopBlock>
 
 This page introduces one-to-one relations and explains how to use them in your Prisma schema.

--- a/content/200-orm/100-prisma-schema/20-data-model/20-relations/300-many-to-many-relations.mdx
+++ b/content/200-orm/100-prisma-schema/20-data-model/20-relations/300-many-to-many-relations.mdx
@@ -4,6 +4,10 @@ metaDescription: How to define and work with many-to-many relations in Prisma.
 tocDepth: 3
 ---
 
+:::info Quick summary
+This guide explains how to define and use many-to-many (m-n) relationships in Prisma, with examples for both relational databases and MongoDB.
+:::
+
 <TopBlock>
 
 Many-to-many (m-n) relations refer to relations where zero or more records on one side of the relation can be connected to zero or more records on the other side.

--- a/content/200-orm/100-prisma-schema/20-data-model/20-relations/410-referential-actions/100-special-rules-for-referential-actions.mdx
+++ b/content/200-orm/100-prisma-schema/20-data-model/20-relations/410-referential-actions/100-special-rules-for-referential-actions.mdx
@@ -5,6 +5,11 @@ metaDescription: 'Circular references or multiple cascade paths can cause valida
 tocDepth: 3
 ---
 
+:::info Quick summary
+This page explains special rules and common issues when using referential actions with SQL Server and MongoDB, including how to avoid cycles and multiple cascade paths.
+:::
+
+
 <TopBlock>
 
 Some databases have specific requirements that you should consider if you are using referential actions.

--- a/content/200-orm/200-prisma-client/000-setup-and-configuration/050-databases-connections/100-connection-management.mdx
+++ b/content/200-orm/200-prisma-client/000-setup-and-configuration/050-databases-connections/100-connection-management.mdx
@@ -5,6 +5,11 @@ metaDescription: 'This page explains how database connections are handled with P
 tocDepth: 3
 ---
 
+:::info Quick summary
+This page explains how Prisma Client manages database connections, including how and when to use the `$connect()` and `$disconnect()` methods, connection pooling behavior, and best practices for both long-running and serverless environments.
+:::
+
+
 <TopBlock>
 
 `PrismaClient` connects and disconnects from your data source using the following two methods:

--- a/content/200-orm/200-prisma-client/000-setup-and-configuration/050-databases-connections/115-connection-pool.mdx
+++ b/content/200-orm/200-prisma-client/000-setup-and-configuration/050-databases-connections/115-connection-pool.mdx
@@ -5,6 +5,11 @@ tocDepth: 4
 toc_max_heading_level: 4
 ---
 
+:::info Quick summary
+This page explains how Prisma ORM manages database connections using a connection pool, and how you can configure limits and timeouts for optimal performance.
+:::
+
+
 The query engine manages a **connection pool** of database connections. The pool is created when Prisma Client opens the _first_ connection to the database, which can happen in one of two ways:
 
 - By [explicitly calling `$connect()`](/orm/prisma-client/setup-and-configuration/databases-connections/connection-management#connect) _or_

--- a/content/200-orm/200-prisma-client/000-setup-and-configuration/050-databases-connections/200-pgbouncer.mdx
+++ b/content/200-orm/200-prisma-client/000-setup-and-configuration/050-databases-connections/200-pgbouncer.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure Prisma Client with PgBouncer
 metaTitle: Configure Prisma Client with PgBouncer
+metaDescription: 'Configure Prisma Client with PgBouncer and other poolers: when to use pgbouncer=true, required transaction mode, prepared statements, and Prisma Migrate workarounds.'
 ---
 
 An external connection pooler like PgBouncer holds a connection pool to the database, and proxies incoming client connections by sitting between Prisma Client and the database. This reduces the number of processes a database has to handle at any given time.

--- a/content/200-orm/200-prisma-client/300-client-extensions/140-shared-extensions/100-permit-rbac.mdx
+++ b/content/200-orm/200-prisma-client/300-client-extensions/140-shared-extensions/100-permit-rbac.mdx
@@ -6,6 +6,11 @@ toc_max_heading_level: 4
 ---
 
 
+:::info Quick summary
+This page explains how to implement fine-grained authorization (FGA) in Prisma ORM applications using the `@permitio/permit-prisma` extension. It introduces different access control models—RBAC, ABAC, and ReBAC—supported by Permit.io, and guides you on choosing the right model to protect your database operations with precise, programmable permissions.
+
+:::
+
 
 Database operations often require careful control over who can access or modify which data. While Prisma ORM excels at data modeling and database access, it doesn't include built-in authorization capabilities. This guide shows how to implement fine-grained authorization in your Prisma applications using the `@permitio/permit-prisma` extension.
 

--- a/content/200-orm/200-prisma-client/300-client-extensions/500-middleware/100-soft-delete-middleware.mdx
+++ b/content/200-orm/200-prisma-client/300-client-extensions/500-middleware/100-soft-delete-middleware.mdx
@@ -5,6 +5,11 @@ metaDescription: 'How to use middleware to intercept deletes and set a field val
 toc_max_heading_level: 4
 ---
 
+:::info Quick summary
+Learn how to use Prisma Client middleware to implement a simple soft delete, marking records as deleted instead of removing them from your database.
+:::
+
+
 <TopBlock>
 
 The following sample uses [middleware](/orm/prisma-client/client-extensions/middleware) to perform a **soft delete**. Soft delete means that a record is **marked as deleted** by changing a field like `deleted` to `true` rather than actually being removed from the database. Reasons to use a soft delete include:

--- a/content/200-orm/200-prisma-client/300-client-extensions/500-middleware/200-logging-middleware.mdx
+++ b/content/200-orm/200-prisma-client/300-client-extensions/500-middleware/200-logging-middleware.mdx
@@ -4,6 +4,11 @@ metaTitle: 'Middleware sample: logging (Reference)'
 metaDescription: 'How to use middleware to log the time taken to perform any query.'
 ---
 
+:::info Quick summary
+Learn how to use Prisma Client middleware to log query execution time for easy performance monitoring.
+:::
+
+
 <TopBlock>
 
 The following example logs the time taken for a Prisma Client query to run:

--- a/content/200-orm/200-prisma-client/500-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/201-serverless/400-deploy-to-aws-lambda.mdx
@@ -6,7 +6,9 @@ tocDepth: 3
 ---
 
 
+:::info Quick summary
 This guide explains how to avoid common issues when deploying a project using Prisma ORM to [AWS Lambda](https://aws.amazon.com/lambda/).
+:::
 
 <details>
 <summary>Questions answered in this page</summary>

--- a/content/200-orm/200-prisma-client/500-deployment/301-edge/450-deploy-to-cloudflare.mdx
+++ b/content/200-orm/200-prisma-client/500-deployment/301-edge/450-deploy-to-cloudflare.mdx
@@ -6,7 +6,10 @@ sidebar_label: Deploy to Cloudflare
 tocDepth: 3
 ---
 
+
+:::info Quick summary
 This page covers everything you need to know to deploy an app with Prisma ORM to a [Cloudflare Worker](https://developers.cloudflare.com/workers/) or to [Cloudflare Pages](https://developers.cloudflare.com/pages).
+:::
 
 <details>
 <summary>Questions answered in this page</summary>

--- a/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/900-codemods.mdx
+++ b/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/900-codemods.mdx
@@ -4,6 +4,11 @@ metaTitle: 'Codemods (Guides)'
 metaDescription: 'Use codemods to upgrade your codebase as Prisma ORM evolves.'
 ---
 
+:::info Quick summary
+This page explains how to use Prisma's codemods to automatically update your codebase during major version upgrades. Learn about installation, usage commands, available code transformations, and options for safely refactoring your projects.
+:::
+
+
 <TopBlock>
 
 The `@prisma/codemods` package helps you to upgrade your codebase as Prisma ORM evolves.

--- a/content/200-orm/800-more/300-upgrade-guides/800-upgrade-from-prisma-1/02-schema-incompatibilities-postgresql.mdx
+++ b/content/200-orm/800-more/300-upgrade-guides/800-upgrade-from-prisma-1/02-schema-incompatibilities-postgresql.mdx
@@ -7,6 +7,11 @@ dbSwitcher: ['postgresql', 'mysql']
 pagination_next: orm/more/upgrade-guides/upgrade-from-prisma-1/upgrading-the-prisma-layer-postgresql
 slugSwitch: /orm/more/upgrade-guides/upgrade-from-prisma-1/schema-incompatibilities-
 ---
+
+:::info Quick summary
+This guide explains common schema incompatibility issues you may encounter when upgrading from Prisma 1 to Prisma ORM (v2+) with PostgreSQL, and how to address them.
+:::
+
  
 ## Overview
 


### PR DESCRIPTION
This takes the top visited pages and adds a summary block to the very top. This can help AI tools who crawl these pages find out what the pages are about and if it makes sense to use in queries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Quick summary blocks across documentation pages for improved navigation and quick reference
  * Enhanced guides for database setup, connections, and cloud deployment with clearer overviews
  * Expanded connection pool and middleware documentation with more comprehensive explanations
  * Enriched examples for data relationships and authorization implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->