### PR TITLE
docs(): update for the 6.19 release

### DIFF
--- a/content/250-postgres/300-database/400-connection-pooling.mdx
+++ b/content/250-postgres/300-database/400-connection-pooling.mdx
@@ -6,40 +6,41 @@ tocDepth: 3
 toc: true
 ---
 
-Prisma Postgres provides built-in [connection pooling](https://www.prisma.io/dataguide/database-tools/connection-pooling) by default, enabled by [Prisma Accelerate](/accelerate/). By using Prisma Postgres, you get the benefits of connection pooling without having to configure anything. The efficient management of database connections allows the database to process more queries without exhausting the available database connections, making your application more scalable.
+Prisma Postgres provides built-in [connection pooling](https://www.prisma.io/dataguide/database-tools/connection-pooling) without you having to configure anything. The efficient management of database connections allows the database to process more queries without exhausting the available database connections, making your application more scalable.
 
-In some cases, however, it may be beneficial to further configure connection pooling in order to optimize the performance of your application.
-
-:::note
-
-This document focuses on the connection pooling features of Prisma Postgres. For more information about the internal connection pool of Prisma ORM specifically, see our [ORM connection pooling documentation](/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool).
-
-:::
+However, if you are using your own database with Prisma Accelerate, it may be beneficial to further configure connection pooling in order to optimize the performance of your application.
 
 
 ### Connection pooling in Prisma Postgres
 
-Currently, Prisma Postgres allows a maximum of 10 concurrent database connections per Prisma Schema. This limit is typically sufficient due to Prisma Postgres's efficient unikernel-based architecture, which minimizes the need for large connection pools.
+
+For Prisma Postgres, the connection limit starts at 10 and scales depening on your plan.
+
+|                           | Free | Starter | Pro | Business |
+|---------------------------|------|---------|-----|----------|
+| Connection Limit (Pooled) | 10   | 100     | 500 | 1000     |
+
+
+
+
+If you're using **your own database** with Prisma Accelerate, the connection limits are:
+
+|                           | Free | Starter | Pro | Business |
+|---------------------------|------|---------|-----|----------|
+| Connection Limit (Pooled) | 10   | 100     | 100 | 1000     |
 
 :::note
-
-If you're using **your own database** with Prisma Accelerate, the connection limits differ:
-
-- **Free plan**: Maximum of `10` connections.
-- **Starter plan**: Maximum of `10` connections. This is often sufficient for most workloads, but if you're expecting high traffic or intensive compute operations, you may want to [increase this limit](#configuring-the-connection-pool-size).
-- **Pro plan**: Supports up to `100` concurrent connections.
-- **Business plan**: Supports up to `1000` concurrent connections.
+For the **Starter plan**,this is often sufficient for most workloads, but if you're expecting high traffic or intensive compute operations, you may want to [increase this limit](#configuring-the-connection-pool-size).
+:::
 
 You can compare plans on the [Prisma pricing page](https://www.prisma.io/pricing).
-
-:::
 
 
 ### Configuring the connection pool size
 
-If you're **not using Prisma Postgres**, you can configure the connection pool size for Prisma ORM by specifying it [in the connection string](/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool#setting-the-connection-pool-size).
+For Prisma Postgres, the connection limit is managed automatially for you.
 
-For Prisma Postgres, the connection limit is currently **fixed at `10`** and cannot be changed.
+If you're **not using Prisma Postgres**, you can configure the connection pool size for Prisma ORM by specifying it [in the connection string](/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool#setting-the-connection-pool-size).
 
 If you're using Prisma Accelerate with your own database, you can configure the connection pool size through the `Connection limit` setting in your project on the [Accelerate setup page](/accelerate/getting-started).
 

--- a/content/250-postgres/300-database/400-connection-pooling.mdx
+++ b/content/250-postgres/300-database/400-connection-pooling.mdx
@@ -14,16 +14,9 @@ However, if you are using your own database with Prisma Accelerate, it may be be
 ### Connection pooling in Prisma Postgres
 
 
-For Prisma Postgres, the connection limit starts at 10 and scales depending on your plan.
+For Prisma Postgres, the connection limit is 1000 no matter your plan.
 
-|                           | Free | Starter | Pro | Business |
-|---------------------------|------|---------|-----|----------|
-| Connection Limit (Pooled) | 10   | 100     | 500 | 1000     |
-
-
-
-
-If you're using **your own database** with Prisma Accelerate, the connection limits are:
+If you're using **your own database** and Prisma Accelerate, the connection limits are:
 
 |                           | Free | Starter | Pro | Business |
 |---------------------------|------|---------|-----|----------|

--- a/content/250-postgres/300-database/400-connection-pooling.mdx
+++ b/content/250-postgres/300-database/400-connection-pooling.mdx
@@ -30,7 +30,7 @@ If you're using **your own database** with Prisma Accelerate, the connection lim
 | Connection Limit (Pooled) | 10   | 100     | 100 | 1000     |
 
 :::note
-For the **Starter plan**,this is often sufficient for most workloads, but if you're expecting high traffic or intensive compute operations, you may want to [increase this limit](#configuring-the-connection-pool-size).
+For the **Starter plan**, this is often sufficient for most workloads, but if you're expecting high traffic or intensive compute operations, you may want to [increase this limit](#configuring-the-connection-pool-size).
 :::
 
 You can compare plans on the [Prisma pricing page](https://www.prisma.io/pricing).

--- a/content/250-postgres/300-database/400-connection-pooling.mdx
+++ b/content/250-postgres/300-database/400-connection-pooling.mdx
@@ -38,7 +38,7 @@ You can compare plans on the [Prisma pricing page](https://www.prisma.io/pricing
 
 ### Configuring the connection pool size
 
-For Prisma Postgres, the connection limit is managed automatially for you.
+For Prisma Postgres, the connection limit is managed automatically for you.
 
 If you're **not using Prisma Postgres**, you can configure the connection pool size for Prisma ORM by specifying it [in the connection string](/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool#setting-the-connection-pool-size).
 

--- a/content/250-postgres/300-database/400-connection-pooling.mdx
+++ b/content/250-postgres/300-database/400-connection-pooling.mdx
@@ -14,7 +14,7 @@ However, if you are using your own database with Prisma Accelerate, it may be be
 ### Connection pooling in Prisma Postgres
 
 
-For Prisma Postgres, the connection limit starts at 10 and scales depening on your plan.
+For Prisma Postgres, the connection limit starts at 10 and scales depending on your plan.
 
 |                           | Free | Starter | Pro | Business |
 |---------------------------|------|---------|-----|----------|

--- a/content/250-postgres/300-database/650-direct-connections.mdx
+++ b/content/250-postgres/300-database/650-direct-connections.mdx
@@ -21,7 +21,7 @@ In order to get a direct connection string, you need to:
 1. Click the **Connect to your database** button in your dashboard.
 1. Click the **Generate new connection string** button.
 1. If enabling connection pooling, click the toggle button
-1. Copy the connection string starting that is generated below.
+1. Copy the connection string that is generated below.
 
 ## Connection string
 

--- a/content/250-postgres/300-database/650-direct-connections.mdx
+++ b/content/250-postgres/300-database/650-direct-connections.mdx
@@ -8,7 +8,7 @@ toc: true
 
 ## Overview
 
-Prisma Postgres is the perfect choice for your applications, whether you connect to it via [Prisma ORM](/orm) or any other ORM, database library / tool of your choice. If you use it with Prisma ORM, Prisma Postgres comes with built-in connection pooling and an integrated caching layer (powered by [Prisma Accelerate](/accelerate/)). 
+Prisma Postgres is the perfect choice for your applications, whether you connect to it via [Prisma ORM](/orm) or any other ORM, database library / tool of your choice. If you use it with Prisma ORM, Prisma Postgres comes with built-in connection pooling, and an integrated caching layer (powered by [Prisma Accelerate](/accelerate/)). 
 
 If you connect to it via another tool, you can do so with a [direct connection string](#connection-string) following the conventional PostgreSQL format.
 
@@ -18,10 +18,10 @@ In order to get a direct connection string, you need to:
 
 1. Open a project in your [Prisma Console](https://console.prisma.io) account (or create a new one)
 1. Navigate to your active Prisma Postgres instance.
-1. Click the **API Keys** tab in the project's sidenav.
-1. Click the **Create API key** button.
-1. In the popup, provide a **Name** for the API key and click **Create**.
-1. Copy the connection string starting with `postgres://`, this is your direct connection string.
+1. Click the **Connect to your datatbase** button in your dashboard.
+1. Click the **Generate new connection string** button.
+1. If enabling connection pooling, click the toggle button
+1. Copy the connection string starting that is generated below.
 
 ## Connection string
 
@@ -43,6 +43,14 @@ DATABASE_URL="postgres://2f9881cc7eef46f094ac913df34c1fb441502fe66cbe28cc48998d4
 
 SSL mode is required when connecting to Prisma Postgres via direct TCP, so you need to append `sslmode=require` to your TCP connection string.
 
+### Pooling connections
+
+If you want to enable connection pooling, you can append `pool=true` to your TCP connection string
+
+```bash
+DATABASE_URL="postgres://USER:PASSWORD@db.prisma.io:5432/?pool=true"
+```
+
 ## Billing
 
 When using direct TCP to connect to a Prisma Postgres instance, every SQL query is counted as a [billable operation](/postgres/introduction/overview#usage-based-pricing). Learn more on our [pricing page](https://www.prisma.io/pricing).
@@ -55,20 +63,16 @@ Prisma Postgres closes idle connections after an extended period of time. If tha
 
 ### Connection limit
 
-While direct connections are in Early Access, the following connection limits apply:
-
 |                                      | Free             | Starter          | Pro              | Business         |
 | ------------------------------------ | ---------------- | ---------------- | ---------------- | ---------------- |
-| **Connection limit**                 | Max 10            | Max 10           | Max 50           | Max 100           |
+| **Connection limit**                 | Max 10           | Max 10           | Max 50           | Max 100          |
 
 ### Query and transaction timeouts
 
-While direct connections are in Early Access, the following timeouts apply:
-
 |                                      | Free             | Starter          | Pro              | Business         |
 | ------------------------------------ | ---------------- | ---------------- | ---------------- | ---------------- |
-| **Query timeout**                    | Up to 10 seconds  | Up to 10 seconds | Up to 10 seconds | Up to 10 seconds |
-| **Interactive transactions timeout** | Up to 15 seconds  | Up to 15 seconds | Up to 15 seconds | Up to 15 seconds |
+| **Query timeout**                    | Up to 10 seconds | Up to 10 seconds | Up to 10 seconds | Up to 10 seconds |
+| **Interactive transactions timeout** | Up to 15 seconds | Up to 15 seconds | Up to 15 seconds | Up to 15 seconds |
 
 ### Limited user permissions
 
@@ -78,13 +82,6 @@ User permissions are limited to read, write and schema changes. It is not possib
 
 Prisma Postgres can be accessed securely via a TCP tunnel using the [`@prisma/ppg-tunnel`](https://www.npmjs.com/package/@prisma/ppg-tunnel) package, an authentication proxy designed for local database workflows. This package establishes a secure connection to Prisma Postgres through a local TCP server, enabling secure access while automatically handling traffic routing and authentication.
 
-:::note
-
-This is a [Early Access](/platform/maturity-levels#early-access) feature of Prisma Postgres. It is not recommended for production use and is not intended for application-level access.
-
-While in Early Access, usage of the TCP tunnel will be free of charge.
-
-:::
 
 ### Prerequisites
 

--- a/content/250-postgres/300-database/650-direct-connections.mdx
+++ b/content/250-postgres/300-database/650-direct-connections.mdx
@@ -18,7 +18,7 @@ In order to get a direct connection string, you need to:
 
 1. Open a project in your [Prisma Console](https://console.prisma.io) account (or create a new one)
 1. Navigate to your active Prisma Postgres instance.
-1. Click the **Connect to your datatbase** button in your dashboard.
+1. Click the **Connect to your database** button in your dashboard.
 1. Click the **Generate new connection string** button.
 1. If enabling connection pooling, click the toggle button
 1. Copy the connection string starting that is generated below.

--- a/content/300-accelerate/250-connection-pooling.mdx
+++ b/content/300-accelerate/250-connection-pooling.mdx
@@ -4,5 +4,5 @@ metaTitle: 'Prisma Accelerate: Connection Pooling'
 metaDescription: "Learn about everything you need to know to use Accelerate's connection pooling."
 ---
 
-Accelerate provides built-in connection pooling to efficiently manage database connections. It's included as part of [Prisma Postgres](/postgres), but you can also use it with your own database by enabling Accelerate in the [Prisma Data Platform](https://console.prisma.io?utm_source=docs) and [connecting it to your database](/accelerate/getting-started).
+Accelerate provides built-in connection pooling to efficiently manage database connections. Connection Pooling is included as part of [Prisma Postgres](/postgres), but you can also use it with your own database by enabling Accelerate in the [Prisma Data Platform](https://console.prisma.io?utm_source=docs) and [connecting it to your database](/accelerate/getting-started).
 This page has moved, connection pooling in Prisma Accelerate is now documented in the [Prisma Postgres section](/postgres/database/connection-pooling).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that connection pooling is built-in and automatically managed for Prisma Postgres; removed prior fixed-limit wording.
  * Added a plan comparison table showing pooled connection limits by tier.
  * Updated guidance for configuring pool size for Prisma Postgres, non-Postgres, and Accelerate scenarios.
  * Streamlined direct-connection setup to a dashboard/UI flow and added pool toggle examples.
  * Removed Early Access notes and refined timeout, query, and autoscaling guidance; moved Accelerate pooling docs into the Prisma Postgres section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->