### PR TITLE
Remove MCP server exploration tip

### DIFF
--- a/content/250-postgres/350-integrations/400-mcp-server.mdx
+++ b/content/250-postgres/350-integrations/400-mcp-server.mdx
@@ -56,11 +56,6 @@ The remote Prisma MCP server follows the standard JSON-based configuration for M
 }
 ```
 
-
-:::tip
-If you want to try it the remote MCP server and explore it's capabilities, we recommend [Cloudflare's AI Playground](https://playground.ai.cloudflare.com/) for that. Add the `https://mcp.prisma.io/mcp` URL into the text field with the **Enter MCP server URL** placeholder, click **Connect**, and then authenticate with the [Prisma Console](https://console.prisma.io) in the popup window. Once connected, you can send prompts to the Playground and see what MCP tools the LLM chooses based on your prompts.
-:::
-
 ### Sample prompts
 
 - "Show me a list of all the databases in my account."


### PR DESCRIPTION
Removed tip about using Cloudflare's AI Playground for MCP server exploration, as it no longer seems to reliably work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed a documentation tip that included steps for connecting to and authenticating with a remote service integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->