### PR TITLE
Include Prisma init commands for npm, yarn, and pnpm wihtout prisma+postgres

### DIFF
--- a/apps/docs/content/docs.v6/guides/turborepo.mdx
+++ b/apps/docs/content/docs.v6/guides/turborepo.mdx
@@ -111,6 +111,36 @@ yarn prisma init --db --output ../generated/prisma
 pnpm prisma init --db --output ../generated/prisma
 ```
 
+or you can skip `prisma+postgres`
+
+<TabbedContent code groupId="packageManager">
+
+  <TabItem value="npm">
+
+  ```terminal
+  npx prisma init --datasource-provider postgresql --output ../generated/prisma
+  ```
+
+  </TabItem>
+
+  <TabItem value="yarn">
+
+  ```terminal
+  yarn prisma init --datasource-provider postgresql --output ../generated/prisma
+  ```
+
+  </TabItem>
+
+  <TabItem value="pnpm">
+
+  ```terminal
+  pnpm prisma init --datasource-provider postgresql --output ../generated/prisma
+  ```
+
+  </TabItem>
+
+</TabbedContent>
+
 This will create several files inside `packages/database`:
 
 - A `prisma` directory with a `schema.prisma` file.

--- a/apps/docs/content/docs.v6/guides/turborepo.mdx
+++ b/apps/docs/content/docs.v6/guides/turborepo.mdx
@@ -113,33 +113,17 @@ pnpm prisma init --db --output ../generated/prisma
 
 To initialize without Prisma Postgres:
 
-<TabbedContent code groupId="packageManager">
+```npm tab="npm"
+npx prisma init --datasource-provider postgresql --output ../generated/prisma
+```
 
-  <TabItem value="npm">
+```bash tab="yarn"
+yarn prisma init --datasource-provider postgresql --output ../generated/prisma
+```
 
-  ```terminal
-  npx prisma init --datasource-provider postgresql --output ../generated/prisma
-  ```
-
-  </TabItem>
-
-  <TabItem value="yarn">
-
-  ```terminal
-  yarn prisma init --datasource-provider postgresql --output ../generated/prisma
-  ```
-
-  </TabItem>
-
-  <TabItem value="pnpm">
-
-  ```terminal
-  pnpm prisma init --datasource-provider postgresql --output ../generated/prisma
-  ```
-
-  </TabItem>
-
-</TabbedContent>
+```bash tab="pnpm"
+pnpm prisma init --datasource-provider postgresql --output ../generated/prisma
+```
 
 This will create several files inside `packages/database`:
 

--- a/apps/docs/content/docs.v6/guides/turborepo.mdx
+++ b/apps/docs/content/docs.v6/guides/turborepo.mdx
@@ -111,7 +111,7 @@ yarn prisma init --db --output ../generated/prisma
 pnpm prisma init --db --output ../generated/prisma
 ```
 
-or you can skip `prisma+postgres`
+To initialize without Prisma Postgres:
 
 <TabbedContent code groupId="packageManager">
 


### PR DESCRIPTION
Added instructions for initializing Prisma with different package managers without `prisma+postgres`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an alternative PostgreSQL initialization path for Prisma setup in the Turborepo guide with additional command examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->