### PR TITLE
Refactor Posts component for consistent styling

### DIFF
--- a/content/800-guides/090-nextjs.mdx
+++ b/content/800-guides/090-nextjs.mdx
@@ -402,8 +402,8 @@ import prisma from "@/lib/prisma";
 
 export default async function Posts() {
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center -mt-16">
-      <h1 className="text-4xl font-bold mb-8 font-[family-name:var(--font-geist-sans)] text-[#333333]">
+    <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center -mt-16 text-[#333333]">
+      <h1 className="text-4xl font-bold mb-8 font-[family-name:var(--font-geist-sans)]">
         Posts
       </h1>
       <ul className="font-[family-name:var(--font-geist-sans)] max-w-2xl space-y-4">
@@ -427,8 +427,8 @@ export default async function Posts() {
   });
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center -mt-16">
-      <h1 className="text-4xl font-bold mb-8 font-[family-name:var(--font-geist-sans)] text-[#333333]">
+    <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center -mt-16 text-[#333333]">
+      <h1 className="text-4xl font-bold mb-8 font-[family-name:var(--font-geist-sans)]">
         Posts
       </h1>
       <ul className="font-[family-name:var(--font-geist-sans)] max-w-2xl space-y-4">


### PR DESCRIPTION
The nested divs' text is not visible since the background is white. Adding text-[#333333] makes the text clear.

Before:

<img width="1387" height="657" alt="Screenshot 2025-11-16 at 3 06 24 PM" src="https://github.com/user-attachments/assets/ca3733ee-001a-4c0c-aff8-b6766b398e1b" />

After:

<img width="1443" height="589" alt="Screenshot 2025-11-16 at 3 06 56 PM" src="https://github.com/user-attachments/assets/34d56eec-c22b-4818-966f-be874c655fab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling organization in Next.js guide documentation for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->