### PR TITLE
Fix terminal command syntax in Next.js guide

### DIFF
--- a/content/800-guides/090-nextjs.mdx
+++ b/content/800-guides/090-nextjs.mdx
@@ -457,7 +457,7 @@ To complement the Posts list page, you'll add a Posts detail page.
 In the `posts` directory, create a new `[id]` directory and a new `page.tsx` file inside of that.
 
 ```terminal
-mkdir -p app/posts/[id] && touch app/posts/[id]/page.tsx
+mkdir -p "app/posts/[id]" && touch "app/posts/[id]/page.tsx"
 ```
 
 This page will display a single post's title, content, and author. Just like your other pages, add the following code to the `app/posts/new/page.tsx` file:


### PR DESCRIPTION
The issue was that square brackets [id] are shell globbing characters, so need to quote the path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated shell command examples in the Next.js guide to ensure proper handling of special characters in file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->