### PR TITLE
feat: add mentions of new Prisma Studio

### DIFF
--- a/content/100-getting-started/02-prisma-orm/100-quickstart/200-sqlite.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/200-sqlite.mdx
@@ -266,6 +266,14 @@ You should see the created user and all users printed to the console!
 
 <ExploreData />
 
+:::note[SQLite requirements for Prisma Studio]
+
+- Node.js 22.5+: Works out of the box with the built-in `node:sqlite` module
+- Node.js 20: Requires installing `better-sqlite3` as a dependency
+  - If using pnpm 10+, you'll also need to allow the `better-sqlite3` install script
+
+:::
+
 ## Next steps
 
 <NextSteps />

--- a/content/100-getting-started/02-prisma-orm/100-quickstart/200-sqlite.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/200-sqlite.mdx
@@ -267,7 +267,7 @@ You should see the created user and all users printed to the console!
 <ExploreData />
 
 :::note[SQLite requirements for Prisma Studio]
-
+- File paths must have a `file:` protocol right now in the database url for SQLite
 - Node.js 22.5+: Works out of the box with the built-in `node:sqlite` module
 - Node.js 20: Requires installing `better-sqlite3` as a dependency
   - If using pnpm 10+, you'll also need to allow the `better-sqlite3` install script

--- a/content/100-getting-started/02-prisma-orm/100-quickstart/700-cockroachdb.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/700-cockroachdb.mdx
@@ -268,9 +268,11 @@ npx tsx script.ts
 
 You should see the created user and all users printed to the console!
 
-## 9. Explore your data with Prisma Studio
+## 9. Explore your data
 
-<ExploreData />
+Explore the options suggested by [CockroachDB](https://www.cockroachlabs.com/blog/cockroachdb-gui-options/) to view and manage your data.
+
+[Prisma Studio](/orm/tools/prisma-studio) does not currently support CockroachDB. Support may be added in a future release. See [Databases supported by Prisma Studio](/orm/tools/prisma-studio#databases-supported-by-prisma-studio) for more information.
 
 ## Next steps
 

--- a/content/100-getting-started/02-prisma-orm/100-quickstart/800-mongodb.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/800-mongodb.mdx
@@ -276,9 +276,11 @@ npx tsx script.ts
 
 You should see the created user and all users printed to the console!
 
-## 9. Explore your data with Prisma Studio
+## 9. Explore your data
 
-<ExploreData />
+You can use [MongoDB Atlas](https://www.mongodb.com/cloud/atlas), the MongoDB shell, or MongoDB Compass to view and manage your data.
+
+[Prisma Studio](/orm/tools/prisma-studio) does not currently support MongoDB. Support may be added in a future release. See [Databases supported by Prisma Studio](/orm/tools/prisma-studio#databases-supported-by-prisma-studio) for more information.
 
 ## Next steps
 

--- a/content/100-getting-started/02-prisma-orm/200-add-to-existing-project/200-sqlite.mdx
+++ b/content/100-getting-started/02-prisma-orm/200-add-to-existing-project/200-sqlite.mdx
@@ -251,6 +251,7 @@ This command will:
 
 :::note[SQLite requirements for Prisma Studio]
 
+- File paths must have a `file:` protocol right now in the database url for SQLite
 - Node.js 22.5+: Works out of the box with the built-in `node:sqlite` module
 - Node.js 20: Requires installing `better-sqlite3` as a dependency
   - If using pnpm 10+, you'll also need to allow the `better-sqlite3` install script

--- a/content/100-getting-started/02-prisma-orm/200-add-to-existing-project/200-sqlite.mdx
+++ b/content/100-getting-started/02-prisma-orm/200-add-to-existing-project/200-sqlite.mdx
@@ -249,6 +249,14 @@ This command will:
 
 <ExploreData />
 
+:::note[SQLite requirements for Prisma Studio]
+
+- Node.js 22.5+: Works out of the box with the built-in `node:sqlite` module
+- Node.js 20: Requires installing `better-sqlite3` as a dependency
+  - If using pnpm 10+, you'll also need to allow the `better-sqlite3` install script
+
+:::
+
 ## Next steps
 
 <NextSteps />

--- a/content/100-getting-started/02-prisma-orm/200-add-to-existing-project/700-cockroachdb.mdx
+++ b/content/100-getting-started/02-prisma-orm/200-add-to-existing-project/700-cockroachdb.mdx
@@ -246,9 +246,11 @@ This command will:
 - Apply the migration to your database
 - Regenerate Prisma Client
 
-## 10. Explore your data with Prisma Studio
+## 10. Explore your data
 
-<ExploreData />
+Explore the options suggested by [CockroachDB](https://www.cockroachlabs.com/blog/cockroachdb-gui-options/) to view and manage your data.
+
+[Prisma Studio](/orm/tools/prisma-studio) does not currently support CockroachDB. Support may be added in a future release. See [Databases supported by Prisma Studio](/orm/tools/prisma-studio#databases-supported-by-prisma-studio) for more information.
 
 ## Next steps
 

--- a/content/100-getting-started/02-prisma-orm/200-add-to-existing-project/800-mongodb.mdx
+++ b/content/100-getting-started/02-prisma-orm/200-add-to-existing-project/800-mongodb.mdx
@@ -292,9 +292,11 @@ Prisma Migrate is not supported for MongoDB. Use `prisma db push` to sync your s
 
 :::
 
-## 9. Explore your data with Prisma Studio
+## 9. Explore your data
 
-<ExploreData />
+You can use [MongoDB Atlas](https://www.mongodb.com/cloud/atlas), the MongoDB shell, or MongoDB Compass to view and manage your data.
+
+[Prisma Studio](/orm/tools/prisma-studio) does not currently support MongoDB. Support may be added in a future release. See [Databases supported by Prisma Studio](/orm/tools/prisma-studio#databases-supported-by-prisma-studio) for more information.
 
 ## Next steps
 

--- a/content/100-getting-started/_components/_explore-data.mdx
+++ b/content/100-getting-started/_components/_explore-data.mdx
@@ -5,3 +5,9 @@ npx prisma studio --config ./prisma.config.ts
 ```
 
 This opens a web interface where you can view and edit your data.
+
+:::info[Supported databases]
+
+Prisma Studio currently supports PostgreSQL, MySQL, and SQLite. For more details, see [Databases supported by Prisma Studio](/orm/tools/prisma-studio#databases-supported-by-prisma-studio).
+
+:::

--- a/content/200-orm/400-tools/06-prisma-studio.mdx
+++ b/content/200-orm/400-tools/06-prisma-studio.mdx
@@ -5,262 +5,138 @@ metaDescription: 'Prisma Studio is a visual database editor.'
 toc_max_heading_level: 2
 ---
 
-import StudioStringSvg from '/img/studio/string.svg';
-import StudioNumberSvg from '/img/studio/number.svg';
-import StudioDatetimeSvg from '/img/studio/datetime.svg';
-import StudioBooleanSvg from '/img/studio/boolean.svg';
-import StudioEnumSvg from '/img/studio/enum.svg';
-import StudioArraySvg from '/img/studio/array.svg';
-import StudioObjectSvg from '/img/studio/object.svg';
+Prisma Studio is a visual editor for your database that lets you view and manipulate data directly in your browser. Prisma ORM v7 introduces a more stable version of Prisma Studio with improved performance and a modernized architecture.
 
-Prisma Studio is a visual editor for the data in your database. Note that Prisma Studio is not open source but you can still create issues in the [`prisma/studio`](https://github.com/prisma/studio) repo.
+Note that Prisma Studio is not open source but you can still create issues in the [`prisma/studio`](https://github.com/prisma/studio) repo.
 
-Run `npx prisma studio` in your terminal.
+## Prerequisites
 
-## Models (tables or collections)
+Before using Prisma Studio, you need:
 
-When you first open Prisma Studio, you will see a data table layout with a sidebar showing a list of all models defined in your Prisma schema file.
+- [Node.js](https://nodejs.org/en/) v20.19+, v22.12+, or v24.0+ installed on your machine
+- A Prisma project with:
+  - A `prisma/schema.prisma` file with at least one model defined
+  - A `prisma.config.ts` configuration file
+  - A configured database connection
 
-![Prisma Studio - Models view](/img/studio/01-models-view.png)
+## Getting started
 
-:::info
-**What is a model?**<br /><br />
+To launch Prisma Studio, run the following command in your project directory:
 
-The term **model** refers to the data model definitions that you add to the Prisma schema file. Depending on the database that you use, a model definition, such as `model User`, refers to a **table** in a relational database (PostgreSQL, MySQL, SQL Server, SQLite, CockroachDB) or a **collection** in MongoDB.<br /><br />
-For more information, see [Defining models](/orm/prisma-schema/data-model/models#defining-models).
-:::
+```terminal
+npx prisma studio --config ./prisma.config.ts
+```
 
-You can select a model and its data opens in a new tab. In this example, the `User` model is selected.
+This starts a local web server (default port `5555`) and opens Prisma Studio in your browser. Studio reads your Prisma config and connects to your database using the connection string from your configuration.
 
+## Core features
 
-![Prisma Studio - Models view with model open](/img/studio/02-open-model.png)
+Prisma Studio provides several key capabilities for working with your database:
 
+### Browse your data
 
-### Open and close models
+Studio displays all models from your Prisma schema in a sidebar. Select any model to view its data in a table format. You can open multiple models in separate tabs to work with related data simultaneously.
 
-To open another model, locate the model in the sidebar and click on it.
+### View and edit records
 
-To close a model, click the the **X** button in the model tab. If there are multiple models open, you can also click "Close all" to close all models.
+You can edit data in two ways:
 
+- **Inline editing**: Double-click any cell to edit its value directly in the table
+- **Side panel editing**: Click the edit icon next to a record to open a detailed view with all fields
 
-![Prisma Studio - Open and close models](/img/studio/03-open-close-models.png)
+Changes are accumulated and must be saved explicitly using the save button. This lets you make multiple edits before committing them to the database.
 
-### Icons of data types in models
+### Add new records
 
-The data type for each field is indicated with an icon in the header.
+Create new records by clicking the "Add record" button. Studio provides appropriate input controls based on each field's data type:
 
-The table below lists all data types and their identifying icon.
-
-| Field data type | Description |
-| :-------------------------------------------------------------------------------: | ------------------------------------ |
-|   <StudioStringSvg width="10px" alt="String type" className="table-icon"/>   | Text                                                                                                        |
-|   <StudioNumberSvg width="10px" alt="Number type" className="table-icon"/>   | Integer                                                                                                     |
-| <StudioDatetimeSvg width="10px" alt="Datetime type" className="table-icon"/> | Date-time<br /><br />                                                                                       |
-|  <StudioBooleanSvg width="10px" alt="Boolean type" className="table-icon"/>  | Boolean<br />                                                                                               |
-|     <StudioEnumSvg width="10px" alt="Enum type" className="table-icon"/>     | Pre-defined list of values (`enum` data type)                                                               |
-|    <StudioArraySvg width="10px" alt="Array type" className="table-icon"/>    | List of related records from another model                                                                  |
-|   <StudioObjectSvg width="10px" alt="Object type" className="table-icon"/>   | The `{}` symbol can refer to one of the two types of fields.<br /><br /> • Relation field<br />• JSON field |
-
-### Keyboard shortcuts in models
-
-When you open a model, a number of keyboard shortcuts are available to browse and manipulate the data in the model.
-
-
-:::info
-**Note**<br /><br />
-With Prisma Studio open, you can open the keyboard shortcuts modal by pressing <kbd>Cmd &#8984;</kbd>+<kbd>/</kbd> on macOS or <kbd>Ctrl</kbd>+<kbd>/</kbd> on Windows.
-:::
-
-
-![Prisma Studio - Keyboard shortcuts](/img/studio/04-model-view-keyboard-shortcuts.png)
-
-## Edit data
-
-Prisma Studio offers two mechanisms for editing existing data: [in-line editing](#in-line-editing) and [side panel editing](#side-panel-editing).
-
-### In-line editing
-
-To edit data in-line, double-click a cell to enter edit mode. Doing so will place your cursor in the cell and allow you to edit the data. Data can be copied and pasted into cells. 
-
-All changes (add, edit, or delete) must be confirmed before they will take effect. Confirm added and edited records with the **Save change** button. When you select records and click **Delete records**, confirm the deletion in a dialog box.
-
-You can accumulate multiple added records and edited cells, which you can then finalize with the **Save changes** button.
-
-
-![Prisma Studio - Save inline changes](/img/studio/11-save-inline-changes.png)
-Once you have finished editing the data, click the green **Save** button.
-
-
-![Prisma Studio - Save inline changes](/img/studio/11-save-inline-changes.png)
-
-### Batch editing
-
-Multiple records can be edited at once. Double click any cell to edit values, moving to any additional cells as necessary. Once complete, click the green **Save** button.
-
-
-![Prisma Studio - Save multiple inline changes](/img/studio/12-save-multiple-inline-changes.png)
-
-### Side panel editing
-
-Prisma Studio also offers a side panel for editing data. To open the side panel, click the **Edit side panel** icon located beside the select checkbox at the far left of every visible record.
-
-
-![Prisma Studio - Open side panel](/img/studio/13-edit-side-panel-icon.png)
-
-Clicking the icon will open the side panel on the right where edits can be performed. Once complete, click outside the side panel and click the green **Save** button to save the changes.
-
-
-![Prisma Studio - Edit side panel](/img/studio/14-edit-data-in-sidepanel.png)
+- Text fields for strings
+- Number inputs for integers and decimals
+- Date pickers for datetime fields
+- Dropdowns for enums and boolean values
+- Relation selectors for foreign keys
 
 ### Delete records
 
-1. From the left column, select the check box for the records you want to delete.
-2. Click **Delete _n_ record(s)**.
-3. Click **Delete** in the confirmation dialog.
+Select one or more records using the checkboxes and click the delete button. Deletions require confirmation and are applied immediately (they cannot be batched with other changes).
 
-You can select multiple records and delete them at once with the **Delete records** button. When you delete multiple records, the operation completes immediately (after you confirm it).
+### Filter and search
 
-In addition, if you have any accumulated added or edited records and then decide to delete records, the deletion also force-saves the accumulated edits.
+Use the Filters menu to narrow down your data:
 
-:::warning
-**Warning**<br /><br />
-Deleting a record is a separate operation that cannot be accumulated. If you delete a record while having unsaved edits, the delete operation first force-saves the unsaved edits and then completes.
-:::
+- Add conditions using comparison operators (equals, greater than, less than, etc.)
+- Combine multiple filters with AND logic
+- Clear individual filters or all filters at once
 
+### Control visibility
 
-![Prisma Studio - Delete records](/img/studio/15-delete-records.png)
+Customize your view:
 
-You can discard any accumulated changes with the **Discard changes** button.
+- **Fields menu**: Show or hide specific columns
+- **Showing menu**: Control pagination with "Take" (limit) and "Skip" (offset) options
 
-![Prisma Studio - Discard changes](/img/studio/16-discard-changes.png)
+### Sort data
 
-### Copy and paste
+Click any column header to sort by that field. Click again to toggle between ascending and descending order.
 
-You can copy the value of any table cell using:
+### Keyboard shortcuts
 
-- <kbd>Cmd &#8984;</kbd> + <kbd>C</kbd>&nbsp;&nbsp;&nbsp;on macOS
-- <kbd>Ctrl</kbd> + <kbd>C</kbd>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;on Windows
+Studio supports keyboard shortcuts for common operations. Press <kbd>Cmd</kbd>+<kbd>/</kbd> (macOS) or <kbd>Ctrl</kbd>+<kbd>/</kbd> (Windows) to view all available shortcuts.
 
-To paste in another cell, first double-click the cell to enter edit mode, and then use:
+## Understanding data types
 
-- <kbd>Cmd &#8984;</kbd> + <kbd>V</kbd>&nbsp;&nbsp;&nbsp;on macOS
-- <kbd>Ctrl</kbd> + <kbd>V</kbd>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;on Windows
+Studio displays visual indicators for different field types in your schema:
 
-### Add a record
+- **Text fields**: String values
+- **Number fields**: Integers and decimals
+- **Date/time fields**: Timestamps and dates
+- **Boolean fields**: True/false values
+- **Enum fields**: Predefined list of options
+- **Relation fields**: References to records in other models
+- **JSON fields**: Structured JSON data
 
-1. In the model view, click **Add record**.
-2. Based on the data allowed in each field, type the data for the record.
+These visual cues help you quickly understand your data structure without referring back to your schema file.
 
-   |                                  Field data type                                  | Description        |
-   | :-------------------------------------------------------------------------------: | ------------------ |
-   |   <StudioStringSvg width="10px" alt="String type" className="table-icon"/>   | Text               |
-   |   <StudioNumberSvg width="10px" alt="Number type" className="table-icon"/>   | Integer<br /><br />If such a field has `autoincrement()` pre-filled, do not edit the cell and do not add a number manually.                                                                        |
-   | <StudioDatetimeSvg width="10px" alt="Datetime type" className="table-icon"/> | Date-time<br /><br />Date-time fields contain a long string of numbers, letters, and others. As a best practice, copy the value of another date-time cell and modify it as necessary before pasting in the field.                                                                                                                                                                        |
-   |  <StudioBooleanSvg width="10px" alt="Boolean type" className="table-icon"/>  | Boolean<br /><br />Select `true` or `false`.                  |
-   |     <StudioEnumSvg width="10px" alt="Enum type" className="table-icon"/>     | Pre-defined list<br /><br />Double-click a cell in the field and select one of the pre-defined options. |
-   |    <StudioArraySvg width="10px" alt="Array type" className="table-icon"/>    | List of related records from another model<br /><br />It typically refers to a list of records that exist in another model in the database. If you are adding a new record and records from the related model do not yet exist, you do not need to enter anything in the current model. |
-   |   <StudioObjectSvg width="10px" alt="Object type" className="table-icon"/>   | The `{}` symbol can refer to one of the two types of fields.<br /><br /> • Relation field<br />• JSON field<br /><br />**Relation with a model defined separately in the database**<br /><br />Typically, you need to select the same value as any of the previous records<br />Click the name of the model to see the list of values which you can then select for the related field.<br /><br />**JSON field**<br /><br /> Double-click the field to edit the JSON data. As a best practice, validate the edited JSON data in a validator and paste it back in the cell. |
+## Working with relations
 
-3. (Optional) If you are unhappy with your changes, click **Discard changes** and start over.
-4. Click **Save 1 change**.
+When your models have relationships defined in your Prisma schema, Studio provides tools to navigate and edit related data:
 
-## Filters
+- Click on a relation field to view the related record
+- Use relation selectors when creating or editing records to link to existing data
+- Open related models in separate tabs to work with connected data simultaneously
 
-### Filter data
+## Data integrity
 
-Use the **Filters** menu to filter data in the model by adding conditions.
+Studio respects your schema constraints:
 
-In the **Filters** menu, the first condition that you add is the `where` clause.
+- Required fields must be filled before saving
+- Unique constraints are validated
+- Foreign key relationships are maintained
+- Default values are automatically applied
+- Auto-increment fields are handled automatically
 
-When you add multiple conditions, Prisma Studio filters the results so that all conditions apply in combination. Each new condition indicates this with the `and` operator, which appears in front.
+If you attempt an operation that would violate a constraint, Studio will display an error message explaining the issue.
 
-**Steps**
+## Databases supported by Prisma Studio
 
-1. Click **Filters** to open the **Filters** menu.
+Prisma Studio currently supports the following databases:
 
-   :::info
-   **Note**<br />
-   Click **Filters** again if you want to hide the menu.
-   :::
+- PostgreSQL: Full support for all PostgreSQL features
+- MySQL: Full support for all MySQL features  
+- SQLite: Full support (see requirements below)
 
-2. Click **Add a new filter**.
-3. Configure the condition.
-   1. Select the field by which you want to filter.
-   2. Select a comparison operator.
-      - **equals**
-      - **in**
-      - **notin**
-      - **lt**
-      - **lte**
-      - **gt**
-      - **gte**
-      - **not**
-   3. Type the value you want to use for the condition.<br />
-      **Step result**: **Prisma Studio** updates the data in the model immediately, based on the condition.
-4. To add a new filter, click **Add a new filter** and repeat the steps above.
-5. To remove a filter, click the **x** button on the right.
-   ![Prisma Studio - Add and remove filters](/img/studio/06-add-remove-filters.png)
-6. To remove all filters, click **Clear all**.
+### SQLite requirements for Prisma Studio
 
-**Result**
+- Node.js 22.5+: Works out of the box with the built-in `node:sqlite` module
+- Node.js 20: Requires installing `better-sqlite3` as a dependency
+  - If using pnpm 10+, you'll also need to allow the `better-sqlite3` install script
 
-- The data in the model is filtered based on the combination of all conditions you add.
-- In the **Filters** menu, the default value of **None** changes to display the number of filters you add.
+### Databases not yet supported
 
-### Show and hide fields
+Support for CockroachDB and MongoDB is not currently available but may be added in future releases. If you're using these databases:
 
-You can select which fields to view or hide by using the **Fields** menu.
-
-:::info
-**What is a field?**<br />
-
-A **field** is a property of a model which you add in the data model definitions in the Prisma schema file. Depending on the database that you use, a field, such as the `title` field in `model User { title String }`, refers to a **column** in a relational database (PostgreSQL, MySQL, SQL Server, SQLite, CockroachDB) or a **document field** in MongoDB.<br />
-For more information, see [Defining fields](/orm/prisma-schema/data-model/models#defining-fields).
-:::
-
-**Steps**
-
-1. Click the **Fields** menu.
-2. Select only the fields you want to see and deselect any fields you want to hide.
-   ![Prisma Studio - Show and hide fields](/img/studio/07-show-hide-fields.png)
-
-**Result**
-
-The model is immediately filtered to hide the data from any fields you have deselected.
-
-Also, the **Fields** menu shows the number of fields that are currently selected.
-
-### Show and hide records
-
-You can also select to show or skip a specific number of records in the model view.
-
-:::info
-**What is a record?**<br />
-
-A **record** refers to a **row of data in a table** in a relational database (PostgreSQL, MySQL, SQL Server, SQLite, CockroachDB) or a **document** in MongoDB.
-:::
-
-**Steps**
-
-1. Click the **Showing** menu.
-2. In the **Take** box, specify the maximum number of records that you want the model view to show.
-3. In the **Skip** box, specify how many of the first records you want to hide.
-   ![Prisma Studio - Show and hide records](/img/studio/08-show-hide-records.png)
-
-**Result**
-
-The model is immediately filtered to show or hide records based on your selection.
-
-The **Showing** menu indicates how many records are shown out of how many available records are in the model.
-
-## Sort data
-
-Click a field title to sort by the field data.
-
-The first click sorts the data in ascending order, the second - in descending order.
-
-
-![Prisma Studio - Sort data](/img/studio/09-model-sort.png)
+- CockroachDB: Explore the options suggested by [CockroachDB](https://www.cockroachlabs.com/blog/cockroachdb-gui-options/)
+- MongoDB: Use [MongoDB Atlas](https://www.mongodb.com/cloud/atlas), MongoDB Compass, or the MongoDB shell
 
 ## Troubleshooting
 

--- a/content/200-orm/400-tools/06-prisma-studio.mdx
+++ b/content/200-orm/400-tools/06-prisma-studio.mdx
@@ -129,7 +129,7 @@ When your database tables have foreign key relationships, Studio provides tools 
 
 ## Databases supported by Prisma Studio
 
-Prisma Studio currently supports the following databases PostgreSQL, MySQL, and SQLite.
+Prisma Studio currently supports the following databases: PostgreSQL, MySQL, and SQLite.
 
 ### SQLite requirements for Prisma Studio
 

--- a/content/200-orm/400-tools/06-prisma-studio.mdx
+++ b/content/200-orm/400-tools/06-prisma-studio.mdx
@@ -5,29 +5,51 @@ metaDescription: 'Prisma Studio is a visual database editor.'
 toc_max_heading_level: 2
 ---
 
-Prisma Studio is a visual editor for your database that lets you view and manipulate data directly in your browser. Prisma ORM v7 introduces a more stable version of Prisma Studio with improved performance and a modernized architecture.
+Prisma Studio is a standalone visual database editor that lets you view and manipulate data directly in your browser. Unlike previous versions, Prisma Studio is now SQL-driven and works independently of Prisma ORM—you can use it with any database without needing a Prisma schema or project.
 
 Note that Prisma Studio is not open source but you can still create issues in the [`prisma/studio`](https://github.com/prisma/studio) repo.
 
 ## Prerequisites
 
-Before using Prisma Studio, you need:
+Prisma Studio is a standalone tool that only requires a database connection. You have two options:
 
-- [Node.js](https://nodejs.org/en/) v20.19+, v22.12+, or v24.0+ installed on your machine
-- A Prisma project with:
-  - A `prisma/schema.prisma` file with at least one model defined
-  - A `prisma.config.ts` configuration file
-  - A configured database connection
+### Option 1: Use with any database (no Prisma project required)
+
+Connect directly to any supported database using the `--url` flag:
+
+```terminal
+npx prisma studio --url="postgresql://user:password@localhost:5432/dbname"
+```
+
+This approach works without any Prisma ORM setup—Studio will introspect your database schema directly.
+
+### Option 2: Use with a Prisma ORM project
+
+If you have an existing Prisma project, Studio can read your configuration:
+
+- A `prisma/schema.prisma` file with at least one model defined
+- A `prisma.config.ts` configuration file
+- A configured database connection
 
 ## Getting started
 
-To launch Prisma Studio, run the following command in your project directory:
+### Standalone usage (without Prisma ORM)
+
+To launch Prisma Studio with any database, provide a connection URL:
+
+```terminal
+npx prisma studio --url="postgresql://user:password@localhost:5432/dbname"
+```
+
+### With a Prisma ORM project
+
+If you have a Prisma project, run the following command in your project directory:
 
 ```terminal
 npx prisma studio --config ./prisma.config.ts
 ```
 
-This starts a local web server (default port `5555`) and opens Prisma Studio in your browser. Studio reads your Prisma config and connects to your database using the connection string from your configuration.
+Both commands start a local web server (default port `5555`) and open Prisma Studio in your browser. Studio connects to your database and introspects the schema to provide a visual interface for your data.
 
 ## Core features
 
@@ -35,7 +57,7 @@ Prisma Studio provides several key capabilities for working with your database:
 
 ### Browse your data
 
-Studio displays all models from your Prisma schema in a sidebar. Select any model to view its data in a table format. You can open multiple models in separate tabs to work with related data simultaneously.
+Studio displays all tables from your database in a sidebar. Select any table to view its data in a table format. You can open multiple tables in separate tabs to work with related data simultaneously.
 
 ### View and edit records
 
@@ -85,48 +107,33 @@ Studio supports keyboard shortcuts for common operations. Press <kbd>Cmd</kbd>+<
 
 ## Understanding data types
 
-Studio displays visual indicators for different field types in your schema:
+Studio displays visual indicators for different field types in your database:
 
 - **Text fields**: String values
 - **Number fields**: Integers and decimals
 - **Date/time fields**: Timestamps and dates
 - **Boolean fields**: True/false values
 - **Enum fields**: Predefined list of options
-- **Relation fields**: References to records in other models
+- **Relation fields**: References to records in other tables (foreign keys)
 - **JSON fields**: Structured JSON data
 
-These visual cues help you quickly understand your data structure without referring back to your schema file.
+These visual cues help you quickly understand your data structure as Studio introspects it directly from your database.
 
 ## Working with relations
 
-When your models have relationships defined in your Prisma schema, Studio provides tools to navigate and edit related data:
+When your database tables have foreign key relationships, Studio provides tools to navigate and edit related data:
 
 - Click on a relation field to view the related record
 - Use relation selectors when creating or editing records to link to existing data
-- Open related models in separate tabs to work with connected data simultaneously
-
-## Data integrity
-
-Studio respects your schema constraints:
-
-- Required fields must be filled before saving
-- Unique constraints are validated
-- Foreign key relationships are maintained
-- Default values are automatically applied
-- Auto-increment fields are handled automatically
-
-If you attempt an operation that would violate a constraint, Studio will display an error message explaining the issue.
+- Open related tables in separate tabs to work with connected data simultaneously
 
 ## Databases supported by Prisma Studio
 
-Prisma Studio currently supports the following databases:
-
-- PostgreSQL: Full support for all PostgreSQL features
-- MySQL: Full support for all MySQL features  
-- SQLite: Full support (see requirements below)
+Prisma Studio currently supports the following databases PostgreSQL, MySQL, and SQLite.
 
 ### SQLite requirements for Prisma Studio
 
+- File paths must have a `file:` protocol right now in the database url for SQLite
 - Node.js 22.5+: Works out of the box with the built-in `node:sqlite` module
 - Node.js 20: Requires installing `better-sqlite3` as a dependency
   - If using pnpm 10+, you'll also need to allow the `better-sqlite3` install script

--- a/content/200-orm/500-reference/200-prisma-cli-reference.mdx
+++ b/content/200-orm/500-reference/200-prisma-cli-reference.mdx
@@ -1707,6 +1707,16 @@ Starts the [Prisma MCP server](/postgres/integrations/mcp-server).
 
 The `studio` command allows you to interact with and manage your data interactively. It does this by starting a local web server with a web app configured with your project's data schema and records.
 
+Prisma ORM v7 introduces a more stable version of Prisma Studio with improved performance and a modernized architecture.
+
+:::info[Supported databases]
+
+Prisma Studio currently supports PostgreSQL, MySQL, and SQLite. Support for CockroachDB and MongoDB is not available yet but may be added in future releases.
+
+For detailed database support information, including SQLite requirements, see [Databases supported by Prisma Studio](/orm/tools/prisma-studio#databases-supported-by-prisma-studio).
+
+:::
+
 #### Prerequisites
 
 Before using the `studio` command, you must configure your database connection in your `prisma.config.ts` file.
@@ -1742,11 +1752,13 @@ export default defineConfig({
 
 The `studio` command recognizes the following options:
 
-| Option            | Required | Description                         | Default                  |
-| ----------------- | -------- | ----------------------------------- | ------------------------ |
-| `-b`, `--browser` | No       | The browser to auto-open Studio in. | `<your-default-browser>` |
-| `-h`, `--help`    | No       | Show all available options and exit |                          |
-| `-p`, `--port`    | No       | The port number to start Studio on. | 5555                     |
+| Option            | Required | Description                                                                      | Default                  |
+| ----------------- | -------- | -------------------------------------------------------------------------------- | ------------------------ |
+| `-b`, `--browser` | No       | The browser to auto-open Studio in.                                              | `<your-default-browser>` |
+| `-h`, `--help`    | No       | Show all available options and exit                                              |                          |
+| `-p`, `--port`    | No       | The port number to start Studio on.                                              | 5555                     |
+| `--config`        | No       | Custom path to your Prisma config file                                           |                          |
+| `--url`           | No       | Database connection string (overrides the one in your Prisma config)             |                          |
 
 #### Arguments
 
@@ -1778,6 +1790,18 @@ prisma studio --browser firefox
 
 ```terminal
 prisma studio --browser none
+```
+
+#### Start Studio with a custom Prisma config file
+
+```terminal
+prisma studio --config=./prisma.config.ts
+```
+
+#### Start Studio with a direct database connection string
+
+```terminal
+prisma studio --url="postgresql://user:password@localhost:5432/dbname"
 ```
 
 ## `package.json` entry options

--- a/content/250-postgres/300-database/675-prisma-studio/50-studio-in-vs-code.mdx
+++ b/content/250-postgres/300-database/675-prisma-studio/50-studio-in-vs-code.mdx
@@ -10,6 +10,14 @@ toc: true
 
 You can use Prisma Studio directly in VS Code via the [Prisma VS Code extension](https://marketplace.visualstudio.com/items?itemName=Prisma.prisma).
 
+:::info[Supported databases]
+
+Prisma Studio currently supports PostgreSQL, MySQL, and SQLite. Support for CockroachDB and MongoDB is not available yet but may be added in future releases.
+
+For detailed database support information, including SQLite requirements, see [Databases supported by Prisma Studio](/orm/tools/prisma-studio#databases-supported-by-prisma-studio).
+
+:::
+
 ## Usage
 
 1. Install the [Prisma VS Code extension](https://marketplace.visualstudio.com/items?itemName=Prisma.prisma)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Prisma Studio supported databases (Postgres, MySQL, SQLite); noted CockroachDB and MongoDB are not yet supported and linked to guidance.
  * Added SQLite-specific Studio notes (use file: URLs for SQLite, Node.js 22.5+ built‑in support; Node.js 20 requires better-sqlite3; pnpm 10+ install-script note).
  * Streamlined Studio content across guides into a concise Getting Started / Core Features flow and replaced embedded walkthroughs with database-specific guidance.

* **New Features**
  * Documented new --config and --url options for starting Prisma Studio with a custom config or direct connection string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->