### PR TITLE
feat: add mention of mongo support coming for P7

### DIFF
--- a/content/100-getting-started/02-prisma-orm/100-quickstart/100-prisma-postgres.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/100-prisma-postgres.mdx
@@ -90,7 +90,6 @@ This command does a few things:
 - Creates a `prisma/` directory with a `schema.prisma` file containing your database connection and schema models
 - Creates a new Prisma Postgres database (when using `--db` flag)
 - Creates a `.env` file in the root directory for environment variables
-- Generates the Prisma Client in the `generated/prisma/` directory
 - Creates a `prisma.config.ts` file for Prisma configuration
 
 The generated `prisma.config.ts` file looks like this:

--- a/content/100-getting-started/02-prisma-orm/100-quickstart/200-sqlite.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/200-sqlite.mdx
@@ -84,7 +84,6 @@ This command does a few things:
 
 - Creates a `prisma/` directory with a `schema.prisma` file containing your database connection and schema models
 - Creates a `.env` file in the root directory for environment variables
-- Generates the Prisma Client in the `generated/prisma/` directory
 - Creates a `prisma.config.ts` file for Prisma configuration
 
 The generated `prisma.config.ts` file looks like this:

--- a/content/100-getting-started/02-prisma-orm/100-quickstart/300-postgresql.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/300-postgresql.mdx
@@ -94,7 +94,6 @@ This command does a few things:
 
 - Creates a `prisma/` directory with a `schema.prisma` file containing your database connection and schema models
 - Creates a `.env` file in the root directory for environment variables
-- Generates the Prisma Client in the `generated/prisma/` directory
 - Creates a `prisma.config.ts` file for Prisma configuration
 
 The generated `prisma.config.ts` file looks like this:

--- a/content/100-getting-started/02-prisma-orm/100-quickstart/400-mysql.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/400-mysql.mdx
@@ -90,7 +90,6 @@ This command does a few things:
 
 - Creates a `prisma/` directory with a `schema.prisma` file containing your database connection and schema models
 - Creates a `.env` file in the root directory for environment variables
-- Generates the Prisma Client in the `generated/prisma/` directory
 - Creates a `prisma.config.ts` file for Prisma configuration
 
 The generated `prisma.config.ts` file looks like this:

--- a/content/100-getting-started/02-prisma-orm/100-quickstart/500-sql-server.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/500-sql-server.mdx
@@ -89,7 +89,6 @@ This command does a few things:
 
 - Creates a `prisma/` directory with a `schema.prisma` file containing your database connection and schema models
 - Creates a `.env` file in the root directory for environment variables
-- Generates the Prisma Client in the `generated/prisma/` directory
 - Creates a `prisma.config.ts` file for Prisma configuration
 
 The generated `prisma.config.ts` file looks like this:

--- a/content/100-getting-started/02-prisma-orm/100-quickstart/600-planetscale.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/600-planetscale.mdx
@@ -93,7 +93,6 @@ This command does a few things:
 
 - Creates a `prisma/` directory with a `schema.prisma` file containing your database connection and schema models
 - Creates a `.env` file in the root directory for environment variables
-- Generates the Prisma Client in the `generated/prisma/` directory
 - Creates a `prisma.config.ts` file for Prisma configuration
 
 The generated `prisma.config.ts` file looks like this:

--- a/content/100-getting-started/02-prisma-orm/100-quickstart/700-cockroachdb.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/700-cockroachdb.mdx
@@ -88,7 +88,6 @@ This command does a few things:
 
 - Creates a `prisma/` directory with a `schema.prisma` file containing your database connection and schema models
 - Creates a `.env` file in the root directory for environment variables
-- Generates the Prisma Client in the `generated/prisma/` directory
 - Creates a `prisma.config.ts` file for Prisma configuration
 
 The generated `prisma.config.ts` file looks like this:

--- a/content/100-getting-started/02-prisma-orm/100-quickstart/800-mongodb.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/800-mongodb.mdx
@@ -12,18 +12,17 @@ import NextSteps from '../../_components/_next-steps.mdx'
 
 [MongoDB](https://www.mongodb.com) is a popular NoSQL document database. In this guide, you will learn how to set up a new TypeScript project from scratch, connect it to MongoDB using Prisma ORM, and generate a Prisma Client for easy, type-safe access to your database.
 
-:::warning[Do not upgrade to Prisma ORM v7 if you are using MongoDB]
+:::warning[MongoDB support for Prisma ORM v7]
 
-Prisma ORM v7 is not yet compatible with MongoDB. Please use Prisma ORM v6 instead. Support for MongoDB is coming in a future release.
+**MongoDB support for Prisma ORM v7 is coming in the near future.** In the meantime, please use **Prisma ORM v6.19** (the latest v6 release) when working with MongoDB.
+
+This guide uses Prisma ORM v6.19 to ensure full compatibility with MongoDB.
 
 :::
 
 ## Prerequisites
 
-<Prerequisites />
-
-You also need:
-
+- Node.js installed in your system [with the supported version](/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-6#minimum-supported-nodejs-versions)
 - A [MongoDB](https://www.mongodb.com/) database accessible via connection string
 
 ## 1. Create a new project
@@ -35,9 +34,17 @@ You also need:
 Install the packages needed for this quickstart:
 
 ```terminal
-npm install prisma @types/node --save-dev 
-npm install @prisma/client dotenv
+npm install prisma@6.19 @types/node --save-dev 
+npm install @prisma/client@6.19 dotenv
 ```
+
+:::info[Why Prisma v6.19?]
+
+This is the latest stable version of Prisma ORM v6 that fully supports MongoDB. MongoDB support for Prisma ORM v7 is coming soon.
+
+You can also install `prisma@6` and `@prisma/client@6` to automatically get the latest v6 release.
+
+:::
 
 Here's what each package does:
 
@@ -94,10 +101,15 @@ npx prisma init --datasource-provider mongodb --output ../generated/prisma
 
 This command does a few things:
 
-- Creates a `prisma/` directory with a `schema.prisma` file containing your database connection and schema models
+- Creates a `prisma/` directory with a `schema.prisma` file for your database connection and schema models
 - Creates a `.env` file in the root directory for environment variables
-- Generates the Prisma Client in the `generated/prisma/` directory
 - Creates a `prisma.config.ts` file for Prisma configuration
+
+:::note
+
+Prisma Client will be generated in the `generated/prisma/` directory when you run `npx prisma generate` later in this guide.
+
+:::
 
 The generated `prisma.config.ts` file looks like this:
 
@@ -156,7 +168,11 @@ Update your `.env` file with your MongoDB connection string:
 DATABASE_URL="mongodb+srv://username:password@cluster.mongodb.net/mydb"
 ```
 
-Replace with your actual MongoDB connection string.
+:::tip
+
+Replace `username`, `password`, `cluster`, and `mydb` with your actual MongoDB credentials and database name. You can get your connection string from [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) or your MongoDB deployment.
+
+:::
 
 ## 5. Define your data model
 
@@ -194,19 +210,21 @@ model Post {
 
 ## 6. Push your schema to MongoDB
 
-Since MongoDB doesn't use migrations, push your schema directly:
+MongoDB doesn't support migrations like relational databases. Instead, use `db push` to sync your schema:
 
 ```terminal
 npx prisma db push
 ```
 
-This command creates the collections based on your schema.
+This command:
+- Creates the collections in MongoDB based on your schema
+- Automatically generates Prisma Client
 
-Now run the following command to generate the Prisma Client:
+:::info
 
-```terminal
-npx prisma generate
-```
+Unlike relational databases, MongoDB uses a flexible schema. The `db push` command ensures your Prisma schema is reflected in your database without creating migration files.
+
+:::
 
 ## 7. Instantiate Prisma Client
 

--- a/content/100-getting-started/02-prisma-orm/200-add-to-existing-project/800-mongodb.mdx
+++ b/content/100-getting-started/02-prisma-orm/200-add-to-existing-project/800-mongodb.mdx
@@ -165,7 +165,7 @@ Connection URL components:
 
 :::tip
 
-For MongoDB Atlas, you must manually append the database name to the connection URL, as Atlas doesn't include it by default.
+For MongoDB Atlas, you can manually append the database name to the connection URL, as Atlas doesn't include it by default.
 
 :::
 

--- a/content/100-getting-started/02-prisma-orm/200-add-to-existing-project/800-mongodb.mdx
+++ b/content/100-getting-started/02-prisma-orm/200-add-to-existing-project/800-mongodb.mdx
@@ -11,6 +11,14 @@ import NextSteps from '../../_components/_next-steps.mdx'
 
 [MongoDB](https://www.mongodb.com/) is a popular document-based NoSQL database known for its flexibility, scalability, and developer-friendly features. In this guide, you will learn how to add Prisma ORM to an existing TypeScript project, connect it to MongoDB, introspect your existing database schema, and start querying with type-safe Prisma Client.
 
+:::warning[MongoDB support for Prisma ORM v7]
+
+**MongoDB support for Prisma ORM v7 is coming in the near future.** In the meantime, please use **Prisma ORM v6.19** (the latest v6 release) when working with MongoDB.
+
+This guide uses Prisma ORM v6.19 to ensure full compatibility with MongoDB.
+
+:::
+
 :::tip
 
 If you're migrating to Prisma ORM from Mongoose, see our [Migrate from Mongoose guide](/guides/migrate-from-mongoose).
@@ -21,7 +29,7 @@ If you're migrating to Prisma ORM from Mongoose, see our [Migrate from Mongoose 
 
 In order to successfully complete this guide, you need:
 
-- [Node.js](https://nodejs.org/en/) installed on your machine (see [system requirements](/orm/reference/system-requirements) for officially supported versions)
+- [Node.js](https://nodejs.org/en/) installed on your machine (see [system requirements](/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-6#minimum-supported-nodejs-versions) for officially supported versions)
 - An existing TypeScript project with a `package.json` file
 - Access to a MongoDB 4.2+ server with a replica set deployment. We recommend using [MongoDB Atlas](https://www.mongodb.com/cloud/atlas).
 
@@ -44,8 +52,8 @@ If your project contains multiple directories with `package.json` files (e.g., `
 Navigate to your existing project directory and install the required dependencies:
 
 ```terminal
-npm install prisma @types/node --save-dev
-npm install @prisma/client dotenv
+npm install prisma@6.19 @types/node --save-dev
+npm install @prisma/client@6.19 dotenv
 ```
 
 Here's what each package does:
@@ -54,9 +62,11 @@ Here's what each package does:
 - **`@prisma/client`** - The Prisma Client library for querying your database
 - **`dotenv`** - Loads environment variables from your `.env` file
 
-:::info
+:::info[Why Prisma v6.19?]
 
-MongoDB does not require a driver adapter like relational databases. Prisma Client connects directly to MongoDB.
+This is the latest stable version of Prisma ORM v6 that fully supports MongoDB. MongoDB support for Prisma ORM v7 is coming soon.
+
+You can also install `prisma@6` and `@prisma/client@6` to automatically get the latest v6 release.
 
 :::
 
@@ -121,6 +131,7 @@ generator client {
 
 datasource db {
   provider = "mongodb"
+  url = env("DATABASE_URL")
 }
 ```
 
@@ -138,23 +149,23 @@ For MongoDB Atlas, the connection URL format is:
 mongodb+srv://USERNAME:PASSWORD@CLUSTER.mongodb.net/DATABASE
 ```
 
-The [format of the connection URL](/orm/reference/connection-urls) for MongoDB looks as follows (the parts spelled all-uppercased are _placeholders_ for your specific connection details):
+Self-hosted MongoDB connection URL format:
 
 ```
 mongodb://USERNAME:PASSWORD@HOST:PORT/DATABASE
 ```
 
-Here's a short explanation of each component:
+Connection URL components:
 
-- **`USERNAME`**: The name of your database user
-- **`PASSWORD`**: The password for your database user
-- **`HOST`**: The host where a [`mongod`](https://www.mongodb.com/docs/manual/reference/program/mongod/#mongodb-binary-bin.mongod) (or [`mongos`](https://www.mongodb.com/docs/manual/reference/program/mongos/#mongodb-binary-bin.mongos)) instance is running
-- **`PORT`**: The port where your database server is running (typically `27017` for MongoDB)
-- **`DATABASE`**: The name of the database
+- **`USERNAME`**: Your database user name
+- **`PASSWORD`**: Your database user password
+- **`HOST`**: The host where [`mongod`](https://www.mongodb.com/docs/manual/reference/program/mongod/#mongodb-binary-bin.mongod) or [`mongos`](https://www.mongodb.com/docs/manual/reference/program/mongos/#mongodb-binary-bin.mongos) is running
+- **`PORT`**: The port where your database server is running (typically `27017`)
+- **`DATABASE`**: The name of your database
 
 :::tip
 
-If you're using MongoDB Atlas, you need to manually append the database name to the connection URL because the environment link from MongoDB Atlas doesn't contain it.
+For MongoDB Atlas, you must manually append the database name to the connection URL, as Atlas doesn't include it by default.
 
 :::
 
@@ -176,15 +187,20 @@ Run the following command to introspect your existing database:
 npx prisma db pull
 ```
 
-This command reads the `DATABASE_URL` environment variable, connects to your database, and introspects the database schema. Prisma ORM introspects a MongoDB schema by sampling the data stored in the database and inferring the schema.
+This command:
+- Reads the `DATABASE_URL` from your `.env` file
+- Connects to your MongoDB database
+- Samples documents in your collections to infer the schema
+- Generates Prisma models in your `schema.prisma` file
 
 ![Introspect your database with Prisma ORM](/img/getting-started/prisma-db-pull-generate-schema.png)
 
-After introspection, your Prisma schema will contain models that represent your existing MongoDB collections.
-
 :::info
 
-MongoDB introspection works by sampling documents in your collections. You may need to manually add relation fields using the `@relation` attribute to enable relational queries.
+**MongoDB introspection limitations:** Prisma introspects MongoDB by sampling documents. You may need to manually:
+- Add relation fields using the `@relation` attribute
+- Adjust field types if the sampling didn't capture all variations
+- Add indexes and constraints not detected during introspection
 
 :::
 
@@ -244,11 +260,11 @@ npx tsx script.ts
 
 ## 8. Evolve your schema
 
-MongoDB does not use migrations. To make changes to your database schema:
+MongoDB doesn't support migrations like relational databases. Instead, use `db push` to sync schema changes:
 
 ### 8.1. Update your Prisma schema file
 
-Update your Prisma schema file to reflect the changes you want to make to your database schema. For example, add a new model:
+Modify your Prisma schema file with the changes you want. For example, add a new model:
 
 ```prisma file=prisma/schema.prisma
 // add-start
@@ -276,19 +292,19 @@ In MongoDB, the `id` field is mapped to `_id` and uses `@db.ObjectId` type. Rela
 
 :::
 
-### 8.2. Push the changes to your database:
+### 8.2. Push the changes to your database
 
 ```terminal
 npx prisma db push
 ```
 
-This command will:
-- Apply the schema changes to your MongoDB database
-- Regenerate Prisma Client
+This command:
+- Applies schema changes to your MongoDB database
+- Automatically regenerates Prisma Client
 
-:::info
+:::info[Why `db push` instead of migrations?]
 
-Prisma Migrate is not supported for MongoDB. Use `prisma db push` to sync your schema changes.
+MongoDB uses a flexible schema model. Prisma Migrate (which creates migration files) is not supported for MongoDB. Always use `prisma db push` to sync your schema changes.
 
 :::
 

--- a/content/100-getting-started/03-prisma-postgres/100-from-the-cli.mdx
+++ b/content/100-getting-started/03-prisma-postgres/100-from-the-cli.mdx
@@ -129,7 +129,7 @@ Initialize a TypeScript project and add the Prisma CLI as a development dependen
 
 ```terminal
 npm init -y
-npm install typescript tsx @types/node --save-dev
+npm install typescript tsx @types/node @types/pg --save-dev
 ```
 
 This creates a `package.json` file with an initial setup for your TypeScript app.
@@ -173,7 +173,7 @@ Install the required dependencies to use Prisma Postgres:
 
 ```terminal
 npm install prisma --save-dev
-npm install @prisma/client @prisma/adapter-pg dotenv
+npm install @prisma/client @prisma/adapter-pg pg dotenv
 ```
 
 Here's what each package does:
@@ -181,6 +181,8 @@ Here's what each package does:
 - **`prisma`** - The Prisma CLI for running commands like `prisma migrate` and `prisma generate`
 - **`@prisma/client`** - The Prisma Client library for querying your database
 - **`@prisma/adapter-pg`** - The [`node-postgres` driver adapter](/orm/overview/databases/postgresql#using-the-node-postgres-driver) that connects Prisma Client to your database
+- **`pg`** - The node-postgres database driver
+- **`@types/pg`** - TypeScript type definitions for node-postgres
 - **`dotenv`** - Loads environment variables from your `.env` file
 
 ### 2.4. Create prisma.config.ts

--- a/content/200-orm/050-overview/500-databases/600-mongodb.mdx
+++ b/content/200-orm/050-overview/500-databases/600-mongodb.mdx
@@ -12,9 +12,13 @@ codeStyle: false
 
 This guide discusses the concepts behind using Prisma ORM and MongoDB, explains the commonalities and differences between MongoDB and other database providers, and leads you through the process for configuring your application to integrate with MongoDB using Prisma ORM.
 
-:::info
+:::warning[MongoDB support for Prisma ORM v7]
 
-To connect Prisma ORM with MongoDB, refer to our [Getting Started documentation](/getting-started/prisma-orm/quickstart/mongodb).
+**MongoDB support for Prisma ORM v7 is coming in the near future.** In the meantime, please use **Prisma ORM v6.19** (the latest v6 release) when working with MongoDB.
+
+For getting started guides using Prisma ORM v6.19 with MongoDB, see:
+- [Quickstart with MongoDB](/getting-started/prisma-orm/quickstart/mongodb)
+- [Add to existing MongoDB project](/getting-started/prisma-orm/add-to-existing-project/mongodb)
 
 :::
 

--- a/content/250-postgres/100-introduction/225-import-from-existing-database.mdx
+++ b/content/250-postgres/100-introduction/225-import-from-existing-database.mdx
@@ -1,0 +1,14 @@
+---
+title: 'Import data from an existing PostgreSQL database'
+sidebar_label: 'Import from existing database'
+metaTitle: 'Import from existing Postgres database into Prisma Postgres'
+metaDescription: 'Learn how to import data from an existing database into Prisma Postgres.'
+tocDepth: 3
+toc: true
+search: true
+---
+
+If you have an existing database and want to import your data into Prisma Postgres, you can use one of our guides:
+
+- [Import from PostgreSQL](/getting-started/prisma-postgres/import-from-existing-database-postgresql)
+- [Import from MySQL](/getting-started/prisma-postgres/import-from-existing-database-mysql)

--- a/content/800-guides/050-migrate-from-mongoose.mdx
+++ b/content/800-guides/050-migrate-from-mongoose.mdx
@@ -12,6 +12,14 @@ community_section: true
 
 This guide shows you how to migrate your application from Mongoose to Prisma ORM. We'll use an extended version of the [Mongoose Express example](https://github.com/Automattic/mongoose/tree/master/examples/express) as a [sample project](https://github.com/prisma/migrate-from-mongoose-to-prisma) to demonstrate the migration steps.
 
+:::warning[MongoDB support for Prisma ORM v7]
+
+**MongoDB support for Prisma ORM v7 is coming in the near future.** In the meantime, please use **Prisma ORM v6.19** (the latest v6 release) when working with MongoDB.
+
+This guide uses Prisma ORM v6.19 to ensure full compatibility with MongoDB.
+
+:::
+
 You can learn how Prisma ORM compares to Mongoose on the [Prisma ORM vs Mongoose](/orm/more/comparisons/prisma-and-mongoose) page.
 
 ## Prerequisites
@@ -19,8 +27,8 @@ You can learn how Prisma ORM compares to Mongoose on the [Prisma ORM vs Mongoose
 Before starting this guide, make sure you have:
 
 - A Mongoose project you want to migrate
-- Node.js installed (version 18 or higher)
-- MongoDB database
+- Node.js installed [with the supported version](/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-6#minimum-supported-nodejs-versions)
+- MongoDB database (4.2+ with replica set deployment recommended)
 - Basic familiarity with Mongoose and Express.js
 
 ## 1. Prepare for migration
@@ -36,7 +44,24 @@ The steps for migrating from Mongoose to Prisma ORM are always the same, no matt
 
 These steps apply whether you're building a REST API (e.g., with Express, Koa, or NestJS), a GraphQL API (e.g., with Apollo Server, TypeGraphQL, or Nexus), or any other kind of application that uses Mongoose for database access.
 
-### 1.2. Set up Prisma configuration
+### 1.2. Install Prisma dependencies
+
+First, install the required Prisma packages:
+
+```terminal
+npm install prisma@6.19 @types/node --save-dev
+npm install @prisma/client@6.19 dotenv
+```
+
+:::info[Why Prisma v6.19?]
+
+This is the latest stable version of Prisma ORM v6 that fully supports MongoDB. MongoDB support for Prisma ORM v7 is coming soon.
+
+You can also install `prisma@6` and `@prisma/client@6` to automatically get the latest v6 release.
+
+:::
+
+### 1.3. Set up Prisma configuration
 
 Create a new Prisma schema file:
 
@@ -48,20 +73,19 @@ This command creates:
 
 - A new directory called `prisma` that contains a `schema.prisma` file; your Prisma schema specifies your database connection and models
 - `.env`: A [`dotenv`](https://github.com/motdotla/dotenv) file at the root of your project (if it doesn't already exist), used to configure your database connection URL as an environment variable
+- `prisma.config.ts`: Configuration file for Prisma
 
-The Prisma schema currently looks as follows:
+The Prisma schema uses the ESM-first `prisma-client` generator:
 
 ```prisma file=prisma/schema.prisma showLineNumbers
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
+generator client {
+  provider = "prisma-client"
+  output   = "../generated/prisma"
+}
 
 datasource db {
   provider = "mongodb"
   url      = env("DATABASE_URL")
-}
-
-generator client {
-  provider = "prisma-client-js"
 }
 ```
 <br/>
@@ -75,37 +99,53 @@ For an optimal development experience when working with Prisma ORM, refer to [ed
 Update the `DATABASE_URL` in the `.env` file with your MongoDB connection string:
 
 ```env
-DATABASE_URL="mongodb://USER:PASSWORD@HOST:PORT/DATABASE"
+DATABASE_URL="mongodb+srv://username:password@cluster.mongodb.net/mydb"
 ```
 
-### 1.3. Configure Prisma
+:::tip
 
-Create a `prisma.config.ts` file in the root of your project with the following content:
+Replace `username`, `password`, `cluster`, and `mydb` with your actual MongoDB credentials and database name. You can get your connection string from [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) or your MongoDB deployment.
+
+:::
+
+### 1.4. Configure Prisma
+
+The generated `prisma.config.ts` file should look like this:
 
 ```typescript file=prisma.config.ts
-import 'dotenv/config'
-import { defineConfig, env } from 'prisma/config';
+import { defineConfig, env } from 'prisma/config'
 
 export default defineConfig({
   schema: 'prisma/schema.prisma',
   migrations: {
     path: 'prisma/migrations',
   },
+  engine: "classic",
   datasource: {
     url: env('DATABASE_URL'),
   },
-});
+})
 ```
 
-:::note
+Add `dotenv` to load environment variables from your `.env` file:
 
-You'll need to install the `dotenv` package to load environment variables. If you haven't already, install it using your package manager:
+```typescript file=prisma.config.ts
+// add-start
+import 'dotenv/config'
+// add-end
+import { defineConfig, env } from 'prisma/config'
 
-```bash
-npm install dotenv
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  migrations: {
+    path: 'prisma/migrations',
+  },
+  engine: "classic",
+  datasource: {
+    url: env('DATABASE_URL'),
+  },
+})
 ```
-
-:::
 
 ## 2. Migrate the database schema
 
@@ -261,19 +301,15 @@ model users {
 
 ## 3. Update your application code
 
-### 3.1. Install Prisma Client
+### 3.1. Generate Prisma Client
 
-Install the Prisma Client package:
-
-```terminal
-npm install @prisma/client
-```
-
-After installing the Prisma Client package, generate Prisma Client:
+Generate Prisma Client based on your schema:
 
 ```terminal
 npx prisma generate
 ```
+
+This creates a type-safe Prisma Client in the `generated/prisma` directory.
 
 ### 3.2. Replace Mongoose queries
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed explicit mention of Prisma Client generation from multiple quickstart initialization steps and adjusted wording to indicate client generation occurs later where relevant.
  * Updated MongoDB guidance to mark v7 support as forthcoming and recommend using Prisma v6.19, with expanded MongoDB-specific tips and examples.
  * Added a new guide for importing data from existing PostgreSQL databases.
  * Reworked Mongoose-to-Prisma migration guide with modernized configuration, generation-first workflow, and updated examples.
  * Clarified PostgreSQL driver installation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->