### PR TITLE
Explicitly running prisma generate after migrate dev command

### DIFF
--- a/content/800-guides/010-data-migration.mdx
+++ b/content/800-guides/010-data-migration.mdx
@@ -137,6 +137,12 @@ Generate the migration:
 npx prisma migrate dev --name add-status-column
 ```
 
+Then generate Prisma Client:
+
+```bash
+npx prisma generate
+```
+
 ## 3. Migrate the data
 
 ### 3.1. Create migration script
@@ -235,6 +241,12 @@ Create and run the final migration:
 
 ```bash
 npx prisma migrate dev --name drop-published-column
+```
+
+Then generate Prisma Client:
+
+```bash
+npx prisma generate
 ```
 
 ## 5. Deploy to production

--- a/content/800-guides/020-implementing-schema-changes.mdx
+++ b/content/800-guides/020-implementing-schema-changes.mdx
@@ -169,6 +169,7 @@ And generates a migration:
 
 ```terminal
 npx prisma migrate dev --name new-field
+npx prisma generate
 ```
 
 ### 3.2. Developer B's changes
@@ -186,6 +187,7 @@ And generates a migration:
 
 ```terminal
 npx prisma migrate dev --name new-model
+npx prisma generate
 ```
 
 ### 3.3. Merge changes
@@ -224,6 +226,7 @@ Run the migrate command:
 
 ```terminal
 npx prisma migrate dev
+npx prisma generate
 ```
 
 This will:

--- a/content/800-guides/080-turborepo.mdx
+++ b/content/800-guides/080-turborepo.mdx
@@ -364,7 +364,7 @@ Next, export the generated types and an instance of `PrismaClient` so it can use
 In the `packages/database` directory, create a `src` folder and add a `client.ts` file. This file will define an instance of `PrismaClient`:
 
 ```ts file=packages/database/src/client.ts
-import { PrismaClient } from "../generated/prisma";
+import { PrismaClient } from "../generated/prisma/client";
 import { PrismaPg } from '@prisma/adapter-pg';
 
 const adapter = new PrismaPg({
@@ -384,8 +384,8 @@ if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
 Then create an `index.ts` file in the `src` folder to re-export the generated prisma types and the `PrismaClient` instance:
 
 ```ts file=packages/database/src/index.ts
-export { prisma } from './client' // exports instance of prisma 
-export * from "../generated/prisma" // exports generated types from prisma
+export { prisma } from './client' // exports instance of prisma
+export * from "../generated/prisma/client" // exports generated types from prisma
 ```
 
 Follow the [Just-in-Time packaging pattern](https://turbo.build/repo/docs/core-concepts/internal-packages#just-in-time-packages) and create an entrypoint to the package inside `packages/database/package.json`:

--- a/content/800-guides/090-nextjs.mdx
+++ b/content/800-guides/090-nextjs.mdx
@@ -151,13 +151,20 @@ export default defineConfig({
 });
 ```
 
-### 2.4. Configure the Prisma Client generator
+### 2.4. Run migrations and generate Prisma Client
 
-Now, run the following command to create the database tables and generate the Prisma Client:
+Now, run the following command to create the database tables:
 
 ```terminal
 npx prisma migrate dev --name init
 ```
+
+Then generate Prisma Client:
+
+```terminal
+npx prisma generate
+```
+
 ### 2.5. Seed the database
 
 Add some seed data to populate the database with sample users and posts.
@@ -165,7 +172,7 @@ Add some seed data to populate the database with sample users and posts.
 Create a new file called `seed.ts` in the `prisma/` directory:
 
 ```typescript file=prisma/seed.ts
-import { PrismaClient, Prisma } from "../app/generated/prisma";
+import { PrismaClient, Prisma } from "../app/generated/prisma/client";
 import { PrismaPg } from '@prisma/adapter-pg'
 import 'dotenv/config'
 
@@ -285,7 +292,7 @@ Now, add the following code to your `lib/prisma.ts` file:
 
 ```typescript file=lib/prisma.ts showLineNumbers
 //add-start
-import { PrismaClient } from '../app/generated/prisma'
+import { PrismaClient } from '../app/generated/prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
 
 const globalForPrisma = global as unknown as {

--- a/content/800-guides/130-docker.mdx
+++ b/content/800-guides/130-docker.mdx
@@ -171,7 +171,7 @@ Add the following code to set up a basic Express server:
 ```js file=index.js
 //add-start
 const express = require("express");
-const { PrismaClient } = require("./generated/prisma_client");
+const { PrismaClient } = require("./generated/prisma_client/client");
 const { PrismaPg } = require("@prisma/adapter-pg");
 
 const adapter = new PrismaPg({
@@ -286,7 +286,13 @@ Run the migration to create the database schema:
 npx prisma migrate dev --name init
 ```
 
-This should generate a `migrations` folder in the `prisma` folder.
+Then generate Prisma Client:
+
+```terminal
+npx prisma generate
+```
+
+This should generate a `migrations` folder in the `prisma` folder and the Prisma Client in the `generated/prisma_client` directory.
 
 ### 2.4. Test the application
 

--- a/content/800-guides/150-multiple-databases.mdx
+++ b/content/800-guides/150-multiple-databases.mdx
@@ -93,7 +93,7 @@ The `prisma@latest init --db` command:
 
 - Connects your CLI to your [Prisma Data Platform](https://console.prisma.io) account. If you are not logged in or do not have an account, your browser will open to guide you through creating a new account or signing into your existing one.
 - Creates a `prisma` directory containing a `schema.prisma` file for your database models.
-- Creates a `.env` file with your `DATABASE_URL` (e.g., for Prisma Postgres it should have something similar to `DATABASE_URL="prisma+postgres://accelerate.prisma-data.net/?api_key=eyJhbGciOiJIUzI..."`).
+- Creates a `.env` file with your `DATABASE_URL` (e.g., `DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require"`).
 
 Rename the `prisma` folder to `prisma-user-database`:
 
@@ -105,10 +105,10 @@ Edit your `.env` file to rename `DATABASE_URL` to `PPG_USER_DATABASE_URL`:
 
 ```text file=.env
 //delete-start
-DATABASE_URL="prisma+postgres://accelerate.prisma-data.net/?api_key=eyJhbGciOiJIUzI...
+DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require"
 //delete-end
 //add-start
-PPG_USER_DATABASE_URL="prisma+postgres://accelerate.prisma-data.net/?api_key=eyJhbGciOiJIUzI...
+PPG_USER_DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require"
 //add-end
 ```
 
@@ -184,10 +184,10 @@ Rename the `DATABASE_URL` variable in `.env` to `PPG_POST_DATABASE_URL`:
 
 ```text file=.env
 //delete-start
-DATABASE_URL="prisma+postgres://accelerate.prisma-data.net/?api_key=eyJhbGciOiJIUzI...
+DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require"
 //delete-end
 //add-start
-PPG_POST_DATABASE_URL="prisma+postgres://accelerate.prisma-data.net/?api_key=eyJhbGciOiJIUzI...
+PPG_POST_DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require"
 //add-end
 ```
 
@@ -287,7 +287,7 @@ In `lib/user-prisma-client.ts`, add the following code:
 
 ```ts file=lib/user-prisma-client.ts
 //add-start
-import { PrismaClient } from "../prisma-user-database/user-database-client-types";
+import { PrismaClient } from "../prisma-user-database/user-database-client-types/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
 const adapter = new PrismaPg({
@@ -316,7 +316,7 @@ In `lib/post-prisma-client.ts`, add this code:
 
 ```ts file=lib/post-prisma-client.ts
 //add-start
-import { PrismaClient } from "../prisma-post-database/post-database-client-types";
+import { PrismaClient } from "../prisma-post-database/post-database-client-types/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
 const adapter = new PrismaPg({

--- a/content/800-guides/160-tanstack-start.mdx
+++ b/content/800-guides/160-tanstack-start.mdx
@@ -397,6 +397,7 @@ Now, run the following command to create the database tables and generate the Pr
 
 ```terminal
 npx prisma migrate dev --name init
+npx prisma generate
 ```
 ### 2.5. Seed the database
 

--- a/content/800-guides/170-react-router-7.mdx
+++ b/content/800-guides/170-react-router-7.mdx
@@ -136,6 +136,7 @@ Now, run the following command to create the database tables and generate the Pr
 
 ```terminal
 npx prisma migrate dev --name init
+npx prisma generate
 ```
 ### 2.5. Seed the database
 

--- a/content/800-guides/180-solid-start.mdx
+++ b/content/800-guides/180-solid-start.mdx
@@ -157,6 +157,7 @@ Now, run the following command to create the database tables and generate the Pr
 
 ```terminal
 npx prisma migrate dev --name init
+npx prisma generate
 ```
 ### 2.5. Seed the database
 

--- a/content/800-guides/190-data-dog.mdx
+++ b/content/800-guides/190-data-dog.mdx
@@ -80,18 +80,7 @@ Run the following commands to install Prisma and a minimal TypeScript runner:
 npm install -D prisma tsx
 ```
 
-Then initialize Prisma:
-
-:::note
-
-You can use the `--db` flag to create a [new Prisma Postgres](/postgres) instance when initializing Prisma in your project.
-
-:::
-
-<TabbedContent code>
-<TabItem value="Prisma Postgres (recommended)">
-
-<br />
+Then initialize Prisma with the `--db` flag to create a [new Prisma Postgres](/postgres) instance:
 
 ```terminal
 npx prisma init --db --output ../src/generated/prisma
@@ -102,42 +91,19 @@ npx prisma init --db --output ../src/generated/prisma
 You will be prompted to name your database and select the closest region. For clarity, choose a memorable name (e.g., `My Datadog Project`).
 
 :::
-</TabItem>
-<TabItem value="Your own database">
-
-```terminal
-npx prisma init --output ../src/generated/prisma
-```
-
-</TabItem>
-</TabbedContent>
-
 
 This command does the following:
 
-- Creates a `prisma` directory with a `schema.prisma` file.  
+- Creates a `prisma` directory with a `schema.prisma` file.
 - Generates the Prisma Client in the `/src/generated/prisma` directory (as specified in the `--output` flag).
-- Creates a `.env` file at the project root with your database connection string (`DATABASE_URL`). 
+- Creates a `.env` file at the project root with your database connection string (`DATABASE_URL`).
 
-If you did not use the `--db` flag, replace the placeholder database URL in the `.env` file:
-
-<TabbedContent code>
-<TabItem value="Prisma Postgres">
+The `.env` file should contain a standard connection string:
 
 ```bash file=.env
-DATABASE_URL="prisma+postgres://accelerate.prisma-data.net/?api_key=..." 
+# Placeholder url you have to replace
+DATABASE_URL="postgresql://janedoe:mypassword@localhost:5432/mydb?schema=sample"
 ```
-
-</TabItem>
-<TabItem value="Your own database">
-
-```bash file=.env
-# Placeholder url you have to replace 
-DATABASE_URL="postgresql://janedoe:mypassword@localhost:5432/mydb?schema=sample" 
-```
-
-</TabItem>
-</TabbedContent>
 
 Install the driver adapter for PostgreSQL:
 
@@ -289,7 +255,7 @@ Create a `src/client.ts` to hold your Prisma Client instantiation:
 
 ```ts file=src/client.ts
 import { tracer } from "./tracer";
-import { PrismaClient } from "./generated/prisma";
+import { PrismaClient } from "./generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
 const adapter = new PrismaPg({

--- a/content/800-guides/190-sveltekit.mdx
+++ b/content/800-guides/190-sveltekit.mdx
@@ -150,6 +150,7 @@ Now, run the following command to create the database tables and generate the Pr
 
 ```terminal
 npx prisma migrate dev --name init
+npx prisma generate
 ```
 ### 2.5. Seed the database
 

--- a/content/800-guides/200-clerk-nextjs.mdx
+++ b/content/800-guides/200-clerk-nextjs.mdx
@@ -313,6 +313,7 @@ Now, run the following command to create the database tables and generate the Pr
 
 ```terminal
 npx prisma migrate dev --name init
+npx prisma generate
 ```
 
 :::warning
@@ -327,7 +328,7 @@ In the root directory, create a `lib` directory and a `prisma.ts` file inside it
 
 ```tsx file=lib/prisma.ts showLineNumbers
 //add-start
-import { PrismaClient } from "../app/generated/prisma";
+import { PrismaClient } from "../app/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
 const adapter = new PrismaPg({

--- a/content/800-guides/210-shopify.mdx
+++ b/content/800-guides/210-shopify.mdx
@@ -76,8 +76,6 @@ datasource db {
   provider = "postgresql"
   //delete-next-line
   url      = "file:../dev.db"
-  //add-next-line
-  url      = env("DATABASE_URL")
 }
 
 model Session {
@@ -126,7 +124,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model Session {
@@ -146,8 +143,15 @@ model ProductNote {
 Next, Prisma will need to be updated to the latest version. Run:
 
 ```terminal
-npm install prisma --save-dev && npm install @prisma/client
+npm install prisma @types/pg --save-dev
+npm install @prisma/client @prisma/adapter-pg pg
 ```
+
+:::info
+
+If you are using a different database provider (MySQL, SQL Server, SQLite), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/overview/databases/database-drivers).
+
+:::
 
 Prisma Postgres allows you to create a new database on the fly, you can create a new database at the same time you initialize your project by adding the `--db` flag:
 
@@ -158,37 +162,55 @@ npx prisma init --db
 Once you've completed the prompts, it's time to access your new database:
 
 1. **Open the [Prisma Console](https://console.prisma.io):**
-   - Log in and find your newly created database project.
-2. **Set up your database credentials:**
-   - In the sidebar, click **Database**, then select **Setup**.
-   - Choose **Existing project** and press **Generate database credentials**.
+   - Log in and select your newly created database project.
+2. **Get your database connection string:**
+   - Click the **Connect** button.
+   - Copy the connection string that appears. It should look similar to this:
+   ```env
+   DATABASE_URL="postgresql://user:password@host:5432/database?sslmode=require"
+   ```
 3. **Configure your environment:**
    - Create a new `.env` file in the root of your project.
-   - Copy and paste the `DATABASE_URL` you just generated into this file. It should look similar to this:
-   ```env
-   DATABASE_URL="prisma+postgres://accelerate.prisma-data.net/?api_key=..."
-   ```
+   - Paste the `DATABASE_URL` you just copied into this file.
 4. **Apply your database schema:**
    - Run the following command to create your tables and get your database ready:
    ```terminal
    npx prisma migrate dev --name init
    ```
 
-Now, before moving on, let's update your `db.server.ts` file to use the newly generated Prisma client.
+   Then generate Prisma Client:
+   ```terminal
+   npx prisma generate
+   ```
+
+Now, before moving on, let's update your `db.server.ts` file to use the newly generated Prisma client with the driver adapter:
 
 ```tsx file=app/db.server.ts
-//delete-next-line
+//delete-start
 import { PrismaClient } from "@prisma/client";
-//add-next-line
+//delete-end
+//add-start
 import { PrismaClient } from "./generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL,
+});
+//add-end
 
 if (process.env.NODE_ENV !== "production") {
   if (!global.prismaGlobal) {
+    //delete-next-line
     global.prismaGlobal = new PrismaClient();
+    //add-next-line
+    global.prismaGlobal = new PrismaClient({ adapter });
   }
 }
 
+//delete-next-line
 const prisma = global.prismaGlobal ?? new PrismaClient();
+//add-next-line
+const prisma = global.prismaGlobal ?? new PrismaClient({ adapter });
 
 export default prisma;
 ```

--- a/content/800-guides/220-astro.mdx
+++ b/content/800-guides/220-astro.mdx
@@ -43,6 +43,12 @@ npx create-astro@latest
 
 :::
 
+Navigate into the newly created project directory:
+
+```terminal
+cd astro-prisma
+```
+
 ## 2. Install and Configure Prisma
 
 ### 2.1. Install dependencies
@@ -131,13 +137,20 @@ export default defineConfig({
 });
 ```
 
-### 2.4. Configure the Prisma Client generator
+### 2.4. Run migrations and generate Prisma Client
 
-Now, run the following command to create the database tables and generate the Prisma Client:
+Now, run the following command to create the database tables:
 
 ```terminal
 npx prisma migrate dev --name init
 ```
+
+Then generate Prisma Client:
+
+```terminal
+npx prisma generate
+```
+
 ### 2.5. Seed the database
 
 Let's add some seed data to populate the database with sample users and posts.
@@ -145,7 +158,7 @@ Let's add some seed data to populate the database with sample users and posts.
 Create a new file called `seed.ts` in the `prisma/` directory:
 
 ```typescript file=prisma/seed.ts
-import { PrismaClient, Prisma } from "../prisma/generated/client.js";
+import { PrismaClient, Prisma } from "../prisma/generated/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
 const adapter = new PrismaPg({
@@ -364,6 +377,18 @@ const users: UserWithPosts[] = await response.json();
   </body>
 </html>
 ```
+
+### 3.5. Run your app
+
+Now start your development server to see your Astro app in action:
+
+```terminal
+npm run dev
+```
+
+Open your browser at [`http://localhost:4321`](http://localhost:4321) to see the users and their posts displayed on the page.
+
+## Summary
 
 You're done! You've just created an Astro app with Prisma that's connected to a Prisma Postgres database. Below are some next steps to explore, as well as some more resources to help you get started expanding your project.
 

--- a/content/800-guides/230-betterauth-nextjs.mdx
+++ b/content/800-guides/230-betterauth-nextjs.mdx
@@ -133,7 +133,7 @@ touch src/lib/prisma.ts
 Set up the Prisma client like this:
 
 ```tsx file=src/lib/prisma.ts
-import { PrismaClient } from "@/generated/prisma";
+import { PrismaClient } from "@/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
 const adapter = new PrismaPg({
@@ -334,6 +334,7 @@ With the new models in your schema, you need to update your database. Run a migr
 
 ```terminal
 npx prisma migrate dev --name add-auth-models
+npx prisma generate
 ```
 
 ## 4. Set up the API routes

--- a/content/800-guides/300-supabase-accelerate.mdx
+++ b/content/800-guides/300-supabase-accelerate.mdx
@@ -169,7 +169,7 @@ In Prisma 7, the `--no-engine` flag is no longer required when using Prisma Acce
 In your application code, you now need to apply the Accelerate extension to your Prisma Client instance:
 
 ```ts
-import { PrismaClient } from "./generated/prisma"
+import { PrismaClient } from "./generated/prisma/client"
 import { withAccelerate } from "@prisma/extension-accelerate"
 
 const prisma = new PrismaClient({

--- a/content/800-guides/310-neon-accelerate.mdx
+++ b/content/800-guides/310-neon-accelerate.mdx
@@ -169,7 +169,7 @@ In Prisma 7, the `--no-engine` flag is no longer required when using Prisma Acce
 In your application code, you now need to apply the Accelerate extension to your Prisma Client instance:
 
 ```ts
-import { PrismaClient } from "./generated/prisma"
+import { PrismaClient } from "./generated/prisma/client"
 import { withAccelerate } from "@prisma/extension-accelerate"
 
 const prisma = new PrismaClient({

--- a/content/800-guides/320-permit-io-access-control.mdx
+++ b/content/800-guides/320-permit-io-access-control.mdx
@@ -229,6 +229,7 @@ To create the database schema:
 
 ```terminal
 npx prisma migrate dev --name init
+npx prisma generate
 ```
 
 This will:

--- a/content/800-guides/330-github-actions.mdx
+++ b/content/800-guides/330-github-actions.mdx
@@ -133,6 +133,12 @@ npm install dotenv
 npx prisma migrate dev --name init
 ```
 
+Then generate Prisma Client:
+
+```terminal
+npx prisma generate
+```
+
 This pushes your schema and prepares the client.
 
 ### 2.4. Seed the database

--- a/content/800-guides/340-ai-sdk-nextjs.mdx
+++ b/content/800-guides/340-ai-sdk-nextjs.mdx
@@ -147,6 +147,7 @@ Now, run the following command to create the database tables and generate the Pr
 
 ```terminal
 npx prisma migrate dev --name init
+npx prisma generate
 ```
 
 ## 3. Integrate Prisma into Next.js

--- a/content/800-guides/350-authjs-nextjs.mdx
+++ b/content/800-guides/350-authjs-nextjs.mdx
@@ -194,6 +194,7 @@ Now, run the following command to create the database tables and generate the Pr
 
 ```terminal
 npx prisma migrate dev --name init
+npx prisma generate
 ```
 
 ### 2.5 Create a Prisma Client
@@ -202,7 +203,7 @@ Create a new folder in the root called `lib` and create a new file called `prism
 
 ```typescript file=lib/prisma.ts showLineNumbers
 //add-start
-import { PrismaClient } from '../app/generated/prisma'
+import { PrismaClient } from '../app/generated/prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
 
 const adapter = new PrismaPg({

--- a/content/800-guides/360-embed-studio-nextjs.mdx
+++ b/content/800-guides/360-embed-studio-nextjs.mdx
@@ -175,6 +175,7 @@ Generate the Prisma Client and apply the schema:
 
 ```terminal
 npx prisma migrate dev --name init
+npx prisma generate
 ```
 
 This creates the tables in your Prisma Postgres database and generates the Prisma Client.
@@ -184,7 +185,7 @@ This creates the tables in your Prisma Postgres database and generates the Prism
 Create a seed file to add some sample data. Create a `seed.ts` file in the `prisma` folder and add the following code:
 
 ```typescript file=prisma/seed.ts
-import { PrismaClient } from '../app/generated/prisma'
+import { PrismaClient } from '../app/generated/prisma/client'
 import { PrismaPg } from '@prisma/adapter-pg'
 
 const adapter = new PrismaPg({

--- a/content/800-guides/370-bun.mdx
+++ b/content/800-guides/370-bun.mdx
@@ -114,12 +114,26 @@ model User {
   email String  @unique
   name  String?
 }
-//add-end  
+//add-end
 ```
 
-## 3. Setting up database configuration and creating a seed script
+## 3. Generate Prisma Client and run migrations
 
-### 3.1. Create a database utility file
+Generate the Prisma client and apply your schema to the database:
+
+```terminal
+bunx --bun prisma migrate dev --name init
+bunx --bun prisma generate
+```
+
+This command:
+
+- Creates the database tables based on your schema
+- Generates the Prisma client in the `generated/prisma` directory
+
+## 4. Setting up database configuration and creating a seed script
+
+### 4.1. Create a database utility file
 
 Create a `db.ts` file in your project root to configure `PrismaClient`:
 
@@ -136,7 +150,7 @@ export const prisma = new PrismaClient({
 });
 ```
 
-### 3.2. Create a seed script
+### 4.2. Create a seed script
 
 Create a seed script in the `prisma` folder to populate your database with sample data:
 
@@ -204,19 +218,6 @@ export default defineConfig({
   },
 });
 ```
-
-## 4. Generate Prisma client and run migrations
-
-Generate the Prisma client and apply your schema to the database:
-
-```terminal
-bunx --bun prisma migrate dev --name init
-```
-
-This command:
-
-- Creates the database tables based on your schema
-- Generates the Prisma client in the `generated/prisma` directory
 
 Run the seed script to populate your database:
 

--- a/content/800-guides/390-hono.mdx
+++ b/content/800-guides/390-hono.mdx
@@ -124,6 +124,7 @@ Now, run the following command to create the database tables and generate the Pr
 
 ```terminal
 npx prisma migrate dev --name init
+npx prisma generate
 ```
 ### 2.4. Seed the database
 

--- a/content/800-guides/400-betterauth-astro.mdx
+++ b/content/800-guides/400-betterauth-astro.mdx
@@ -285,6 +285,7 @@ With the new models in your schema, you need to update your database. Run a migr
 
 ```terminal
 npx prisma migrate dev --name add-auth-models
+npx prisma generate
 ```
 
 <br />

--- a/content/800-guides/400-deno-integration.mdx
+++ b/content/800-guides/400-deno-integration.mdx
@@ -156,6 +156,7 @@ Migrations create the actual database tables based on your Prisma schema. This c
 
 ```terminal
 deno run -A npm:prisma migrate dev --name init
+deno run -A npm:prisma generate
 ```
 
 ## 5. Update the application to use Prisma

--- a/content/800-guides/999-making-guides.mdx
+++ b/content/800-guides/999-making-guides.mdx
@@ -386,6 +386,7 @@ Now, run the following command to create the database tables and generate the Pr
 
 ```terminal
 npx prisma migrate dev --name init
+npx prisma generate
 ```
 ### 2.5. Seed the database
 


### PR DESCRIPTION
- Fixes some import issues
- Explicitly running `npx prisma generate` after migrate command as it is not run implicitly after Prisma 7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated multiple framework integration guides with clarified Prisma Client generation steps after database migrations.
  * Revised import paths in code examples for consistency across guides.
  * Restructured setup instructions to improve workflow clarity in several framework guides.
  * Updated database configuration examples for enhanced accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->