### PR TITLE
DC-6305 Quickstart broken redirect

### DIFF
--- a/content/200-orm/025-getting-started/10-quickstart.mdx
+++ b/content/200-orm/025-getting-started/10-quickstart.mdx
@@ -8,4 +8,4 @@ hide_table_of_contents: true
 
 import { Redirect } from '@docusaurus/router';
 
-<Redirect to="/docs/getting-started/prisma-orm/quickstart/prisma-postgres" />
+{/* <Redirect to="/docs/getting-started/prisma-orm/quickstart/prisma-postgres" /> */}

--- a/content/200-orm/025-getting-started/10-quickstart.mdx
+++ b/content/200-orm/025-getting-started/10-quickstart.mdx
@@ -8,4 +8,4 @@ hide_table_of_contents: true
 
 import { Redirect } from '@docusaurus/router';
 
-<Redirect to="/getting-started/prisma-orm/quickstart/prisma-postgres" />
+<Redirect to="/docs/getting-started/prisma-orm/quickstart/prisma-postgres" />

--- a/content/200-orm/025-getting-started/10-quickstart.mdx
+++ b/content/200-orm/025-getting-started/10-quickstart.mdx
@@ -5,3 +5,7 @@ metaTitle: 'Quickstart with Prisma ORM'
 metaDescription: "This section provides a quick step-by-step guide to get started with Prisma ORM."
 hide_table_of_contents: true
 ---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/docs/getting-started/prisma-orm/quickstart/prisma-postgres" />

--- a/content/200-orm/025-getting-started/10-quickstart.mdx
+++ b/content/200-orm/025-getting-started/10-quickstart.mdx
@@ -5,7 +5,3 @@ metaTitle: 'Quickstart with Prisma ORM'
 metaDescription: "This section provides a quick step-by-step guide to get started with Prisma ORM."
 hide_table_of_contents: true
 ---
-
-import { Redirect } from '@docusaurus/router';
-
-{/* <Redirect to="/docs/getting-started/prisma-orm/quickstart/prisma-postgres" /> */}

--- a/content/200-orm/025-getting-started/20-add-to-existing-project.mdx
+++ b/content/200-orm/025-getting-started/20-add-to-existing-project.mdx
@@ -8,4 +8,4 @@ hide_table_of_contents: true
 
 import { Redirect } from '@docusaurus/router';
 
-<Redirect to="/getting-started/prisma-orm/add-to-existing-project/prisma-postgres" />
+<Redirect to="/docs/getting-started/prisma-orm/add-to-existing-project/prisma-postgres" />

--- a/content/200-orm/025-getting-started/20-add-to-existing-project.mdx
+++ b/content/200-orm/025-getting-started/20-add-to-existing-project.mdx
@@ -5,7 +5,3 @@ metaTitle: 'Add Prisma ORM to an existing project'
 metaDescription: "This section provides a step-by-step guide to add Prisma ORM to an existing project."
 hide_table_of_contents: true
 ---
-
-import { Redirect } from '@docusaurus/router';
-
-{/* <Redirect to="/docs/getting-started/prisma-orm/add-to-existing-project/prisma-postgres" /> */}

--- a/content/200-orm/025-getting-started/20-add-to-existing-project.mdx
+++ b/content/200-orm/025-getting-started/20-add-to-existing-project.mdx
@@ -5,3 +5,7 @@ metaTitle: 'Add Prisma ORM to an existing project'
 metaDescription: "This section provides a step-by-step guide to add Prisma ORM to an existing project."
 hide_table_of_contents: true
 ---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/docs/getting-started/prisma-orm/add-to-existing-project/prisma-postgres" />

--- a/content/200-orm/025-getting-started/20-add-to-existing-project.mdx
+++ b/content/200-orm/025-getting-started/20-add-to-existing-project.mdx
@@ -8,4 +8,4 @@ hide_table_of_contents: true
 
 import { Redirect } from '@docusaurus/router';
 
-<Redirect to="/docs/getting-started/prisma-orm/add-to-existing-project/prisma-postgres" />
+{/* <Redirect to="/docs/getting-started/prisma-orm/add-to-existing-project/prisma-postgres" /> */}

--- a/content/250-postgres/50-getting-started/100-quickstart.mdx
+++ b/content/250-postgres/50-getting-started/100-quickstart.mdx
@@ -5,7 +5,3 @@ metaTitle: 'Quickstart: Prisma ORM with Prisma Postgres (5 min)'
 metaDescription: 'Create a new TypeScript project from scratch by connecting Prisma ORM to Prisma Postgres and generating a Prisma Client for database access.'
 hide_table_of_contents: true
 ---
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/docs/getting-started/prisma-postgres/quickstart/prisma-orm" />

--- a/content/250-postgres/50-getting-started/100-quickstart.mdx
+++ b/content/250-postgres/50-getting-started/100-quickstart.mdx
@@ -8,4 +8,4 @@ hide_table_of_contents: true
 
 import { Redirect } from '@docusaurus/router';
 
-<Redirect to="/getting-started/prisma-postgres/quickstart/prisma-orm" />
+<Redirect to="/docs/getting-started/prisma-postgres/quickstart/prisma-orm" />

--- a/content/250-postgres/50-getting-started/100-quickstart.mdx
+++ b/content/250-postgres/50-getting-started/100-quickstart.mdx
@@ -5,3 +5,7 @@ metaTitle: 'Quickstart: Prisma ORM with Prisma Postgres (5 min)'
 metaDescription: 'Create a new TypeScript project from scratch by connecting Prisma ORM to Prisma Postgres and generating a Prisma Client for database access.'
 hide_table_of_contents: true
 ---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/docs/getting-started/prisma-postgres/quickstart/prisma-orm" />

--- a/content/250-postgres/50-getting-started/200-import-from-existing-database.mdx
+++ b/content/250-postgres/50-getting-started/200-import-from-existing-database.mdx
@@ -5,3 +5,7 @@ metaTitle: 'Import from existing Postgres database into Prisma Postgres'
 metaDescription: 'Learn how to import data from an existing PostgreSQL database into Prisma Postgres.'
 hide_table_of_contents: true
 ---
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="/docs/getting-started/prisma-postgres/import-from-existing-database-postgresql" />

--- a/content/250-postgres/50-getting-started/200-import-from-existing-database.mdx
+++ b/content/250-postgres/50-getting-started/200-import-from-existing-database.mdx
@@ -8,4 +8,4 @@ hide_table_of_contents: true
 
 import { Redirect } from '@docusaurus/router';
 
-<Redirect to="/getting-started/prisma-postgres/import-from-existing-database-postgresql" />
+<Redirect to="/docs/getting-started/prisma-postgres/import-from-existing-database-postgresql" />

--- a/content/250-postgres/50-getting-started/200-import-from-existing-database.mdx
+++ b/content/250-postgres/50-getting-started/200-import-from-existing-database.mdx
@@ -5,7 +5,3 @@ metaTitle: 'Import from existing Postgres database into Prisma Postgres'
 metaDescription: 'Learn how to import data from an existing PostgreSQL database into Prisma Postgres.'
 hide_table_of_contents: true
 ---
-
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="/docs/getting-started/prisma-postgres/import-from-existing-database-postgresql" />

--- a/static/_redirects
+++ b/static/_redirects
@@ -819,6 +819,12 @@
 /orm/getting-started/quickstart* /docs/getting-started/prisma-orm/quickstart/prisma-postgres
 /orm/getting-started/add-to-existing-project* /docs/getting-started/prisma-orm/add-to-existing-project/prisma-postgres
 
+/orm/getting-started/quickstart /docs/getting-started/prisma-orm/quickstart/prisma-postgres
+/orm/getting-started/add-to-existing-project /docs/getting-started/prisma-orm/add-to-existing-project/prisma-postgres
+
+/postgres/getting-started/quickstart /docs/getting-started/prisma-postgres/quickstart/prisma-orm
+/postgres/getting-started/import-from-existing-database /docs/getting-started/prisma-postgres/import-from-existing-database-postgresql
+
 /getting-started/prisma-postgres/upgrade-from-early-access* /docs/postgres/getting-started
 
 /postgres/introduction/import-from-existing-database* /docs/getting-started/prisma-postgres/import-from-existing-database-postgresql


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated several Getting Started guides to redirect to new /docs/* destinations instead of their previous locations.
  * Added site-level redirect entries mapping legacy ORM/Postgres Getting Started URLs to the new /docs/ paths.
  * Affected guides: Prisma ORM (quickstart, add-to-existing-project) and PostgreSQL (quickstart, import-from-existing-database).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->