### PR TITLE
fix(): exclude custom subsections

### DIFF
--- a/content/200-orm/500-reference/300-errors/_category_.json
+++ b/content/200-orm/500-reference/300-errors/_category_.json
@@ -1,3 +1,5 @@
 {
-  "className": "hidden-sidebar"
+  "className": "hidden-sidebar",
+  
+  "customProps": { "hide_from_subsection": true }
 }

--- a/src/theme/DocCardList/index.tsx
+++ b/src/theme/DocCardList/index.tsx
@@ -19,7 +19,11 @@ export default function DocCardList(props: Props): JSX.Element {
   }
   const [filteredItems, setFilteredItems] = useState<any>(filterDocCardListItems(items));
   useEffect(() => {
-    setFilteredItems(filteredItems.filter((e: any) => e?.href?.slice(0, -1) !== location.pathname));
+    setFilteredItems(prevFilteredItems => 
+      prevFilteredItems
+        .filter((e: any) => e?.href?.slice(0, -1) !== location.pathname)
+        .filter((e: any) => !e?.customProps?.hide_from_subsection)
+    );
   }, [items]);
   return (
     <section className={clsx("row", className)}>


### PR DESCRIPTION
This adds a custom prop support to our Subsection component. With this we can exclude specific pages from being rendered in our sub-sections, but still use them if we need custom redirects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation sections can be configured to be hidden from subsection listings for cleaner navigation.
* **Bug Fixes / UX**
  * Related/section lists now omit the current page to avoid self-references, improving relevance of suggestions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->