### PR TITLE
Remove DATABASE_URL from MongoDB datasource

### DIFF
--- a/content/200-orm/100-prisma-schema/20-data-model/10-models.mdx
+++ b/content/200-orm/100-prisma-schema/20-data-model/10-models.mdx
@@ -74,7 +74,6 @@ enum Role {
 ```prisma highlight=10-45;normal 
 datasource db {
   provider = "mongodb"
-  url      = env("DATABASE_URL")
 }
 
 generator client {


### PR DESCRIPTION
The datasource property `url` is no longer supported in schema files. Move connection URLs for Migrate to `prisma.config.ts` and pass either `adapter` for a direct database connection or `accelerateUrl` for Accelerate to the `PrismaClient` constructor. See https://pris.ly/d/config-datasource and https://pris.ly/d/prisma7-client-config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma schema example to reflect simplified MongoDB datasource configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->