### PR TITLE
Replace deprecated schema file location argument

### DIFF
--- a/content/200-orm/300-prisma-migrate/300-workflows/30-baselining.mdx
+++ b/content/200-orm/300-prisma-migrate/300-workflows/30-baselining.mdx
@@ -72,7 +72,7 @@ To create a baseline migration:
    ```terminal no-lines
    npx prisma migrate diff \
    --from-empty \
-   --to-schema-datamodel prisma/schema.prisma \
+   --to-schema prisma/schema.prisma \
    --script > prisma/migrations/0_init/migration.sql
    ```
 


### PR DESCRIPTION
Fixes #7319 

As per issue, replaces the schema argument with `--to-schema`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated migration baselining documentation to reflect the current command syntax.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->