### PR TITLE
docs: add MongoDB support warning in migration guide

### DIFF
--- a/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/400-upgrading-to-prisma-7.mdx
+++ b/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/400-upgrading-to-prisma-7.mdx
@@ -20,6 +20,13 @@ Prisma ORM v7 introduces **breaking changes** when you upgrade from an earlier P
 For developers using AI Agents, we have a [migration prompt](/ai/prompts/prisma-7) that you can
 add to your project for automatic migrations. 
 
+
+:::info
+
+If you are using MongoDB, please note that Prisma ORM v7 does not yet support MongoDB. You should continue using Prisma ORM v6 for now. Support for MongoDB is coming soon in v7.
+
+:::
+
 ## Upgrade the `prisma` and `@prisma/client` packages to v7
 
 To upgrade to Prisma ORM v7 from an earlier version, you need to update both the `prisma` and `@prisma/client` packages:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma ORM v7 upgrade guide with clarification that MongoDB is not yet supported. Users working with MongoDB should continue using v6 until support becomes available in a future v7 release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->