### PR TITLE
feat: Add prisma/generated to .gitignore in migration instructions

### DIFF
--- a/content/900-ai/prompts/prisma-7.mdx
+++ b/content/900-ai/prompts/prisma-7.mdx
@@ -299,6 +299,7 @@ Your project will be migrated accordingly using the appropriate adapter.
 - **Multiple entrypoints** (workers, scripts, tests): apply the same client/adapter/dotenv pattern everywhere. 
 - **Typed SQL** or custom extensions: keep as-is; ensure they compile after client re-generation. 
 - Preserve existing output path if the project uses custom locations.
+- Add `prisma/generated` to .gitignore if .gitignore exists
 
 ---
 


### PR DESCRIPTION
Update .gitignore to include prisma/generated since it should not be tracked by git. I had to do this step manually after running my AI agent with the provided instructions. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guidance on handling .gitignore configurations for generated files, including recommendations for edge cases and best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->