### PR TITLE
DC-6378 Docker version warning added

### DIFF
--- a/content/200-orm/050-overview/500-databases/800-sql-server/030-sql-server-docker.mdx
+++ b/content/200-orm/050-overview/500-databases/800-sql-server/030-sql-server-docker.mdx
@@ -8,6 +8,16 @@ metaDescription: 'Download and use the Microsoft SQL Server Docker image.'
 This guide provides a quick overview on setting up and running Microsoft SQL Server in a Docker container, including pulling the image, starting the server, connecting, and creating a test database.
 :::
 
+:::warning
+
+Prisma 7.0.0 has updated minimum Node.js requirements:
+- Node.js 20: >= 20.19.0
+- Node.js 22: >= 22.12.0  
+- Node.js 24: >= 24.0.0+
+
+If you're using Prisma 7.0.0 or higher with Docker, ensure your application's Docker base image uses Node.js 22 or 24. Update your Dockerfile to use `node:22-alpine` or `node:24-alpine` instead of older Node.js 20 images.
+
+:::
 
 <TopBlock>
 

--- a/content/200-orm/200-prisma-client/450-testing/150-integration-testing.mdx
+++ b/content/200-orm/200-prisma-client/450-testing/150-integration-testing.mdx
@@ -19,6 +19,17 @@ One way to simulate a real world environment is to use [Docker](https://www.dock
 
 This guide assumes you have [Docker](https://docs.docker.com/get-started/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/) installed on your machine as well as `Jest` setup in your project.
 
+:::warning
+
+Prisma 7.0.0 has updated minimum Node.js requirements:
+- Node.js 20: >= 20.19.0
+- Node.js 22: >= 22.12.0  
+- Node.js 24: >= 24.0.0+
+
+If you're using Prisma 7.0.0 or higher with Docker, ensure your application's Docker base image uses Node.js 22 or 24. Update your Dockerfile to use `node:22-alpine` or `node:24-alpine` instead of older Node.js 20 images.
+
+:::
+
 The following ecommerce schema will be used throughout the guide. This varies from the traditional `User` and `Post` models used in other parts of the docs, mainly because it is unlikely you will be running integration tests against your blog.
 
 <details>

--- a/content/800-guides/130-docker.mdx
+++ b/content/800-guides/130-docker.mdx
@@ -28,6 +28,17 @@ This guide walks you through setting up a Prisma ORM application within a Docker
 - [Docker](https://docs.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed
 - Node.js version: A [compatible Node.js version](/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-6#minimum-supported-nodejs-versions), required for Prisma 6.  
 
+:::warning
+
+Prisma 7.0.0 has updated minimum Node.js requirements:
+- Node.js 20: >= 20.19.0
+- Node.js 22: >= 22.12.0  
+- Node.js 24: >= 24.0.0+
+
+If you're using Prisma 7.0.0 or higher with Docker, ensure your application's Docker base image uses Node.js 22 or 24. Update your Dockerfile to use `node:22-alpine` or `node:24-alpine` instead of older Node.js 20 images.
+
+:::
+
 Before starting, ensure that no PostgreSQL services are running locally, and that the following ports are free to avoid conflicts: `5432` (PostgreSQL), `3000` (application server) or `5555` (Prisma Studio server).
 
 To stop existing PostgreSQL services, use:


### PR DESCRIPTION
Added the following warning to various places relating to Docker

```
:::warning

Prisma 7.0.0 has updated minimum Node.js requirements:
- Node.js 20: >= 20.19.0
- Node.js 22: >= 22.12.0  
- Node.js 24: >= 24.0.0+

If you're using Prisma 7.0.0 or higher with Docker, ensure your application's Docker base image uses Node.js 22 or 24. Update your Dockerfile to use `node:22-alpine` or `node:24-alpine` instead of older Node.js 20 images.

:::
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum Node.js version requirements for Prisma 7.0.0+
  * Added Docker base image recommendations for Node.js 22 or 24
  * Enhanced guidance across Docker, integration testing, and database configuration documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->