### PR TITLE
docs: describe the sqlcommenter plugin infrastructure

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -155,6 +155,7 @@
     "Deepgram",
     "PGSSLMODE",
     "pgloader",
+    "sqlcommenter",
     "unikernel",
     "Mikro",
     "databaseto",

--- a/content/200-orm/200-prisma-client/600-observability-and-logging/250-opentelemetry-tracing.mdx
+++ b/content/200-orm/200-prisma-client/600-observability-and-logging/250-opentelemetry-tracing.mdx
@@ -13,6 +13,12 @@ Tracing gives you a highly detailed, operation-level insight into your Prisma OR
 
 :::
 
+:::tip Correlate database queries with traces
+
+You can add the `traceparent` header to your SQL queries as comments using the [`@prisma/sqlcommenter-trace-context`](/orm/prisma-client/observability-and-logging/sql-comments#trace-context) plugin. This enables correlation between distributed traces and database queries in your monitoring tools.
+
+:::
+
 
 ## About tracing
 

--- a/content/200-orm/200-prisma-client/600-observability-and-logging/260-sql-comments.mdx
+++ b/content/200-orm/200-prisma-client/600-observability-and-logging/260-sql-comments.mdx
@@ -1,0 +1,500 @@
+---
+title: 'SQL comments'
+metaTitle: 'SQL comments'
+metaDescription: 'Add metadata to your SQL queries as comments for improved observability, debugging, and tracing.'
+---
+
+SQL comments allow you to append metadata to your database queries, making it easier to correlate queries with application context. Prisma ORM supports the [sqlcommenter format](https://google.github.io/sqlcommenter/) developed by Google, which is widely supported by database monitoring tools.
+
+SQL comments are useful for:
+
+- **Observability**: Correlate database queries with application traces using `traceparent`
+- **Query insights**: Tag queries with metadata for analysis in database monitoring tools
+- **Debugging**: Add custom context to queries for easier troubleshooting
+
+## Installation
+
+Install one or more first-party plugins depending on your use case:
+
+```terminal
+npm install @prisma/sqlcommenter-query-tags
+npm install @prisma/sqlcommenter-trace-context
+```
+
+Install the core SQL commenter types package to create your own plugin:
+
+```terminal
+npm install @prisma/sqlcommenter
+```
+
+## Basic usage
+
+Pass an array of SQL commenter plugins to the `comments` option when creating a `PrismaClient` instance:
+
+```ts
+import { PrismaClient } from '../prisma/generated/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { queryTags } from '@prisma/sqlcommenter-query-tags'
+import { traceContext } from '@prisma/sqlcommenter-trace-context'
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL })
+
+const prisma = new PrismaClient({
+  adapter,
+  comments: [queryTags(), traceContext()],
+})
+```
+
+With this configuration, your SQL queries will include metadata as comments:
+
+```sql
+SELECT "id", "name" FROM "User" /*application='my-app',traceparent='00-abc123...-01'*/
+```
+
+## First-party plugins
+
+Prisma provides two official SQL commenter plugins:
+
+### Query tags
+
+The `@prisma/sqlcommenter-query-tags` package allows you to add arbitrary tags to queries within an async context using `AsyncLocalStorage`.
+
+```ts
+import { queryTags, withQueryTags } from '@prisma/sqlcommenter-query-tags'
+import { PrismaClient } from '../prisma/generated/client'
+
+const prisma = new PrismaClient({
+  adapter,
+  comments: [queryTags()],
+})
+
+// Wrap your queries to add tags
+const users = await withQueryTags(
+  { route: '/api/users', requestId: 'abc-123' },
+  () => prisma.user.findMany()
+)
+```
+
+The resulting SQL includes the tags as comments:
+
+```sql
+SELECT ... FROM "User" /*requestId='abc-123',route='/api/users'*/
+```
+
+#### Multiple queries in one scope
+
+All queries within the callback share the same tags:
+
+```ts
+const result = await withQueryTags({ traceId: 'trace-456' }, async () => {
+  const users = await prisma.user.findMany()
+  const posts = await prisma.post.findMany()
+  return { users, posts }
+})
+```
+
+#### Nested scopes with tag replacement
+
+By default, nested `withQueryTags` calls replace the outer tags entirely:
+
+```ts
+await withQueryTags({ requestId: 'req-123' }, async () => {
+  // Queries here have: requestId='req-123'
+
+  await withQueryTags({ userId: 'user-456' }, async () => {
+    // Queries here only have: userId='user-456'
+    // requestId is NOT included
+    await prisma.user.findMany()
+  })
+})
+```
+
+#### Nested scopes with tag merging
+
+Use `withMergedQueryTags` to merge tags with the outer scope:
+
+```ts
+import { withQueryTags, withMergedQueryTags } from '@prisma/sqlcommenter-query-tags'
+
+await withQueryTags({ requestId: 'req-123', source: 'api' }, async () => {
+  await withMergedQueryTags({ userId: 'user-456', source: 'handler' }, async () => {
+    // Queries here have: requestId='req-123', userId='user-456', source='handler'
+    await prisma.user.findMany()
+  })
+})
+```
+
+You can also remove tags in nested scopes by setting them to `undefined`:
+
+```ts
+await withQueryTags({ requestId: 'req-123', debug: 'true' }, async () => {
+  await withMergedQueryTags({ userId: 'user-456', debug: undefined }, async () => {
+    // Queries here have: requestId='req-123', userId='user-456'
+    // debug is removed
+    await prisma.user.findMany()
+  })
+})
+```
+
+### Trace context
+
+The `@prisma/sqlcommenter-trace-context` package adds W3C Trace Context (`traceparent`) headers to your queries, enabling correlation between distributed traces and database queries.
+
+```ts
+import { traceContext } from '@prisma/sqlcommenter-trace-context'
+import { PrismaClient } from '../prisma/generated/client'
+
+const prisma = new PrismaClient({
+  adapter,
+  comments: [traceContext()],
+})
+```
+
+When tracing is enabled and the current span is sampled, queries include the `traceparent`:
+
+```sql
+SELECT * FROM "User" /*traceparent='00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01'*/
+```
+
+:::info
+
+The trace context plugin requires [`@prisma/instrumentation`](/orm/prisma-client/observability-and-logging/opentelemetry-tracing) to be configured. The `traceparent` is only added when tracing is active and the span is sampled.
+
+:::
+
+The `traceparent` header follows the [W3C Trace Context](https://www.w3.org/TR/trace-context/) specification:
+
+```
+{version}-{trace-id}-{parent-id}-{trace-flags}
+```
+
+Where:
+
+- `version`: Always `00` for the current spec
+- `trace-id`: 32 hexadecimal characters representing the trace ID
+- `parent-id`: 16 hexadecimal characters representing the parent span ID
+- `trace-flags`: 2 hexadecimal characters; `01` indicates sampled
+
+## Creating custom plugins
+
+You can create your own SQL commenter plugins to add custom metadata to queries.
+
+### Plugin structure
+
+A SQL commenter plugin is a function that receives query context and returns key-value pairs:
+
+```ts
+import type { SqlCommenterPlugin, SqlCommenterContext } from '@prisma/sqlcommenter'
+
+const myPlugin: SqlCommenterPlugin = (context: SqlCommenterContext) => {
+  return {
+    application: 'my-app',
+    version: '1.0.0',
+  }
+}
+```
+
+### Using custom plugins
+
+Pass your custom plugins to the `comments` option:
+
+```ts
+const prisma = new PrismaClient({
+  adapter,
+  comments: [myPlugin],
+})
+```
+
+### Conditional keys
+
+Return `undefined` for keys you want to exclude from the comment. Keys with `undefined` values are automatically filtered out:
+
+```ts
+const conditionalPlugin: SqlCommenterPlugin = (context) => ({
+  model: context.query.modelName, // undefined for raw queries, automatically omitted
+  action: context.query.action,
+})
+```
+
+### Query context
+
+Plugins receive a `SqlCommenterContext` object containing information about the query:
+
+```ts
+interface SqlCommenterContext {
+  query: SqlCommenterQueryInfo
+  sql?: string
+}
+```
+
+The `query` property provides information about the Prisma operation:
+
+| Property    | Type                                  | Description                                                                      |
+| ----------- | ------------------------------------- | -------------------------------------------------------------------------------- |
+| `type`      | `'single'` \| `'compacted'`           | Whether this is a single query or a batched query                                |
+| `modelName` | `string` \| `undefined`               | The model being queried (e.g., `"User"`). Undefined for raw queries.             |
+| `action`    | `string`                              | The Prisma operation (e.g., `"findMany"`, `"createOne"`, `"queryRaw"`)           |
+| `query`     | `unknown` (single) or `queries: unknown[]` (compacted) | The full query object(s). Structure is not part of the public API.  |
+
+The `sql` property is the raw SQL query generated from this Prisma query. It is always available when `PrismaClient` connects to the database and renders SQL queries directly. When using Prisma Accelerate, SQL rendering happens on Accelerate side and the raw SQL strings are not available when SQL commenter plugins are executed on the `PrismaClient` side.
+
+#### Single vs. compacted queries
+
+- **Single queries** (`type: 'single'`): A single Prisma query is being executed
+- **Compacted queries** (`type: 'compacted'`): Multiple queries have been batched into a single SQL statement (e.g., automatic `findUnique` batching)
+
+### Example: Application metadata
+
+```ts
+import type { SqlCommenterPlugin } from '@prisma/sqlcommenter'
+
+const applicationTags: SqlCommenterPlugin = (context) => ({
+  application: 'my-service',
+  environment: process.env.NODE_ENV ?? 'development',
+  operation: context.query.action,
+  model: context.query.modelName,
+})
+```
+
+### Example: Async context propagation
+
+Use `AsyncLocalStorage` to propagate context through your application:
+
+```ts
+import { AsyncLocalStorage } from 'node:async_hooks'
+import type { SqlCommenterPlugin } from '@prisma/sqlcommenter'
+
+interface RequestContext {
+  route: string
+  userId?: string
+}
+
+const requestStorage = new AsyncLocalStorage<RequestContext>()
+
+const requestContextPlugin: SqlCommenterPlugin = () => {
+  const context = requestStorage.getStore()
+  return {
+    route: context?.route,
+    userId: context?.userId,
+  }
+}
+
+// Usage in a request handler
+requestStorage.run({ route: '/api/users', userId: 'user-123' }, async () => {
+  await prisma.user.findMany()
+})
+```
+
+### Combining multiple plugins
+
+Plugins are called in array order, and their outputs are merged. Later plugins can override keys from earlier plugins:
+
+```ts
+import type { SqlCommenterPlugin } from '@prisma/sqlcommenter'
+import { queryTags } from '@prisma/sqlcommenter-query-tags'
+import { traceContext } from '@prisma/sqlcommenter-trace-context'
+
+const appPlugin: SqlCommenterPlugin = () => ({
+  application: 'my-app',
+  version: '1.0.0',
+})
+
+const prisma = new PrismaClient({
+  adapter,
+  comments: [appPlugin, queryTags(), traceContext()],
+})
+```
+
+## Framework integration
+
+### Hono
+
+Hono's middleware properly awaits downstream handlers:
+
+```ts
+import { createMiddleware } from 'hono/factory'
+import { withQueryTags } from '@prisma/sqlcommenter-query-tags'
+
+app.use(
+  createMiddleware(async (c, next) => {
+    await withQueryTags(
+      {
+        route: c.req.path,
+        method: c.req.method,
+        requestId: c.req.header('x-request-id') ?? crypto.randomUUID(),
+      },
+      () => next(),
+    )
+  }),
+)
+```
+
+### Koa
+
+Koa's middleware properly awaits downstream handlers:
+
+```ts
+import { withQueryTags } from '@prisma/sqlcommenter-query-tags'
+
+app.use(async (ctx, next) => {
+  await withQueryTags(
+    {
+      route: ctx.path,
+      method: ctx.method,
+      requestId: ctx.get('x-request-id') || crypto.randomUUID(),
+    },
+    () => next(),
+  )
+})
+```
+
+### Fastify
+
+Wrap individual route handlers:
+
+```ts
+import { withQueryTags } from '@prisma/sqlcommenter-query-tags'
+
+fastify.get('/users', (request, reply) => {
+  return withQueryTags(
+    {
+      route: '/users',
+      method: 'GET',
+      requestId: request.id,
+    },
+    () => prisma.user.findMany(),
+  )
+})
+```
+
+### Express
+
+Express middleware uses callbacks, so wrap route handlers directly:
+
+```ts
+import { withQueryTags } from '@prisma/sqlcommenter-query-tags'
+
+app.get('/users', (req, res, next) => {
+  withQueryTags(
+    {
+      route: req.path,
+      method: req.method,
+      requestId: req.header('x-request-id') ?? crypto.randomUUID(),
+    },
+    () => prisma.user.findMany(),
+  )
+    .then((users) => res.json(users))
+    .catch(next)
+})
+```
+
+### NestJS
+
+Use an interceptor to wrap handler execution:
+
+```ts
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common'
+import { Observable, from, lastValueFrom } from 'rxjs'
+import { withQueryTags } from '@prisma/sqlcommenter-query-tags'
+
+@Injectable()
+export class QueryTagsInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest<Request>()
+    return from(
+      withQueryTags(
+        {
+          route: request.url,
+          method: request.method,
+          requestId: request.headers.get('x-request-id') ?? crypto.randomUUID(),
+        },
+        () => lastValueFrom(next.handle()),
+      ),
+    )
+  }
+}
+
+// Apply globally in main.ts
+app.useGlobalInterceptors(new QueryTagsInterceptor())
+```
+
+## Output format
+
+Plugin outputs are merged, sorted alphabetically by key, URL-encoded, and formatted according to the [sqlcommenter specification](https://google.github.io/sqlcommenter/spec/):
+
+```sql
+SELECT "id", "name" FROM "User" /*application='my-app',environment='production',model='User'*/
+```
+
+Key behaviors:
+
+- Plugins are called synchronously in array order
+- Later plugins override earlier ones if they return the same key
+- Keys with `undefined` values are filtered out (they do not remove keys set by earlier plugins)
+- Keys and values are URL-encoded per the sqlcommenter spec
+- Single quotes in values are escaped as `\'`
+- Comments are appended to the end of SQL queries
+
+## API reference
+
+### `SqlCommenterTags`
+
+```ts
+type SqlCommenterTags = { readonly [key: string]: string | undefined }
+```
+
+Key-value pairs to add as SQL comments. Keys with `undefined` values are automatically filtered out.
+
+### `SqlCommenterPlugin`
+
+```ts
+interface SqlCommenterPlugin {
+  (context: SqlCommenterContext): SqlCommenterTags
+}
+```
+
+A function that receives query context and returns key-value pairs. Return an empty object to add no comments for a particular query.
+
+### `SqlCommenterContext`
+
+```ts
+interface SqlCommenterContext {
+  query: SqlCommenterQueryInfo
+}
+```
+
+Context provided to plugins containing information about the query.
+
+### `SqlCommenterQueryInfo`
+
+```ts
+type SqlCommenterQueryInfo =
+  | ({ type: 'single' } & SqlCommenterSingleQueryInfo)
+  | ({ type: 'compacted' } & SqlCommenterCompactedQueryInfo)
+```
+
+Information about the query or queries being executed.
+
+### `SqlCommenterSingleQueryInfo`
+
+```ts
+interface SqlCommenterSingleQueryInfo {
+  modelName?: string
+  action: string
+  query: unknown
+}
+```
+
+Information about a single Prisma query.
+
+### `SqlCommenterCompactedQueryInfo`
+
+```ts
+interface SqlCommenterCompactedQueryInfo {
+  modelName?: string
+  action: string
+  queries: unknown[]
+}
+```
+
+Information about a compacted batch query.

--- a/content/200-orm/200-prisma-client/600-observability-and-logging/260-sql-comments.mdx
+++ b/content/200-orm/200-prisma-client/600-observability-and-logging/260-sql-comments.mdx
@@ -460,10 +460,15 @@ A function that receives query context and returns key-value pairs. Return an em
 ```ts
 interface SqlCommenterContext {
   query: SqlCommenterQueryInfo
+  sql?: string
 }
 ```
 
 Context provided to plugins containing information about the query.
+
+- **`query`**: Information about the Prisma query being executed. See [`SqlCommenterQueryInfo`](#sqlcommenterqueryinfo).
+- **`sql`**: The SQL query being executed. It is only available when using driver adapters but not when using Accelerate.
+
 
 ### `SqlCommenterQueryInfo`
 

--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -429,12 +429,6 @@ const prisma = new PrismaClient({ adapter });
 
 Defines an array of [SQL commenter plugins](/orm/prisma-client/observability-and-logging/sql-comments) that add metadata to your SQL queries as comments. This is useful for observability, debugging, and correlating queries with application traces.
 
-:::info
-
-This requires either a [driver adapter](/orm/overview/databases/database-drivers#driver-adapters) or a connection via [Prisma Accelerate](/accelerate).
-
-:::
-
 #### Options
 
 | Option                      | Description                                                                                                     |

--- a/content/200-orm/500-reference/050-prisma-client-reference.mdx
+++ b/content/200-orm/500-reference/050-prisma-client-reference.mdx
@@ -425,6 +425,77 @@ const adapter = new PrismaNeon({ connectionString });
 const prisma = new PrismaClient({ adapter });
 ```
 
+### `comments`
+
+Defines an array of [SQL commenter plugins](/orm/prisma-client/observability-and-logging/sql-comments) that add metadata to your SQL queries as comments. This is useful for observability, debugging, and correlating queries with application traces.
+
+:::info
+
+This requires either a [driver adapter](/orm/overview/databases/database-drivers#driver-adapters) or a connection via [Prisma Accelerate](/accelerate).
+
+:::
+
+#### Options
+
+| Option                      | Description                                                                                                     |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `SqlCommenterPlugin[]`      | An array of SQL commenter plugin functions. Each plugin receives query context and returns key-value pairs.     |
+
+#### First-party plugins
+
+| Package                                | Description                                                                 |
+| -------------------------------------- | --------------------------------------------------------------------------- |
+| `@prisma/sqlcommenter-query-tags`      | Adds arbitrary tags to queries within an async context using `AsyncLocalStorage` |
+| `@prisma/sqlcommenter-trace-context`   | Adds W3C Trace Context (`traceparent`) headers for distributed tracing      |
+
+#### Examples
+
+##### Using first-party plugins
+
+```ts
+import { PrismaClient } from '../prisma/generated/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import { queryTags } from '@prisma/sqlcommenter-query-tags';
+import { traceContext } from '@prisma/sqlcommenter-trace-context';
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+
+const prisma = new PrismaClient({
+  adapter,
+  comments: [queryTags(), traceContext()],
+});
+```
+
+##### Creating a custom plugin
+
+```ts
+import { PrismaClient } from '../prisma/generated/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import type { SqlCommenterPlugin } from '@prisma/sqlcommenter';
+
+const appPlugin: SqlCommenterPlugin = (context) => ({
+  application: 'my-app',
+  environment: process.env.NODE_ENV ?? 'development',
+  model: context.query.modelName,
+  action: context.query.action,
+});
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+
+const prisma = new PrismaClient({
+  adapter,
+  comments: [appPlugin],
+});
+```
+
+This produces SQL queries with comments like:
+
+```sql
+SELECT "id", "name" FROM "User" /*action='findMany',application='my-app',environment='production',model='User'*/
+```
+
+For more details, see [SQL comments](/orm/prisma-client/observability-and-logging/sql-comments).
+
 ### `rejectOnNotFound`
 
 :::info

--- a/package-lock.json
+++ b/package-lock.json
@@ -248,6 +248,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.40.0.tgz",
       "integrity": "sha512-nlr/MMgoLNUHcfWC5Ns2ENrzKx9x51orPc6wJ8Ignv1DsrUmKm0LUih+Tj3J+kxYofzqQIQRU495d4xn3ozMbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.40.0",
         "@algolia/requester-browser-xhr": "5.40.0",
@@ -373,6 +374,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2313,6 +2315,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2335,6 +2338,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2444,6 +2448,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2865,6 +2870,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3547,6 +3553,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.2.tgz",
       "integrity": "sha512-HbjwKeC+pHUFBfLMNzuSjqFE/58+rLVKmOU3lxQrpsxLBOGosYco/Q0GduBb0/jEMRiyEqjNT/01rRdOMWq5pw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/babel": "3.9.2",
         "@docusaurus/bundler": "3.9.2",
@@ -3623,6 +3630,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.9.2.tgz",
       "integrity": "sha512-DEVIwhbrZZ4ir31X+qQNEQqDWkgCJUV6kiPPAd2MGTY8n5/n0c4B8qA5k1ipF2izwH00JEf0h6Daaut71zzkyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/types": "3.9.2",
         "@rspack/core": "^1.5.0",
@@ -3751,6 +3759,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
       "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.2",
         "@docusaurus/logger": "3.9.2",
@@ -5531,6 +5540,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -6751,6 +6761,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6855,6 +6866,7 @@
       "integrity": "sha512-WezcBo8a0Dg2rnR82zhwoR6aRNxeTGfK5QCD6TQ+kg3xx/zNT02s/0o+81h/3zhvFSB24NtqEr8FTw88O5W/JQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.24"
@@ -7544,6 +7556,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -7903,6 +7916,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7988,6 +8002,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8033,6 +8048,7 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.40.0.tgz",
       "integrity": "sha512-a9aIL2E3Z7uYUPMCmjMFFd5MWhn+ccTubEvnMy7rOTZCB62dXBJtz0R5BZ/TPuX3R9ocBsgWuAbGWQ+Ph4Fmlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.6.0",
         "@algolia/client-abtesting": "5.40.0",
@@ -8544,6 +8560,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -9576,6 +9593,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11130,6 +11148,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -16303,6 +16322,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -16976,6 +16996,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -17879,6 +17900,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -18715,6 +18737,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18724,6 +18747,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -18779,6 +18803,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -18807,6 +18832,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -19604,6 +19630,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.2.tgz",
       "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -20916,7 +20943,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-fest": {
       "version": "2.19.0",
@@ -20979,6 +21007,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21008,6 +21037,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -21383,6 +21413,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -21604,6 +21635,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -22031,6 +22063,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -22297,6 +22330,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Add docs about the [sqlcommenter](https://google.github.io/sqlcommenter/) support in Prisma Client added in Prisma 7.1.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new comments option to Prisma Client to enable SQL comment plugins for attaching metadata to queries.
  * First‑party plugins available for query tags and trace context to aid trace correlation.

* **Documentation**
  * Added comprehensive docs and examples for SQL comments, plugin composition, integrations, and trace correlation.
  * Inserted an informational tip on correlating database queries with distributed traces.

* **Chores**
  * Updated spellcheck dictionary to ignore "sqlcommenter".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->