### PR TITLE
DC-6434 Clarify prisma db seed is only run explicitly in v7

### DIFF
--- a/content/200-orm/050-overview/100-introduction/300-data-modeling.mdx
+++ b/content/200-orm/050-overview/100-introduction/300-data-modeling.mdx
@@ -74,7 +74,7 @@ In MongoDB databases, models are represented by _collections_ and contain _docum
 }
 ```
 
-Prisma Client currently expects a consistent model and [normalized model design](https://www.mongodb.com/docs/manual/data-modeling/concepts/embedding-vs-references/#references). This means that:
+Prisma Client currently expects a consistent model and [normalized model design](https://www.mongodb.com/docs/manual/data-modeling/best-practices/#std-label-data-modeling-best-practices). This means that:
 
 - If a model or field is not present in the Prisma schema, it is ignored
 - If a field is mandatory but not present in the MongoDB dataset, you will get an error

--- a/content/200-orm/300-prisma-migrate/300-workflows/10-seeding.mdx
+++ b/content/200-orm/300-prisma-migrate/300-workflows/10-seeding.mdx
@@ -37,9 +37,16 @@ export default defineConfig({
 
 Database seeding happens when you run `prisma db seed`. With `prisma db seed`, _you_ decide when to invoke the seed command. It can be useful for a test setup or to prepare a new development environment, for example.
 
+:::info[Prisma ORM v7 changes]
 
-### Prisma 6 Only
-Prisma Migrate also integrates seamlessly with your seeds, assuming you follow the steps in the section below. Seeding is triggered automatically when Prisma Migrate resets the development database.
+In Prisma ORM v7, seeding is **only triggered explicitly** by running `npx prisma db seed`. Automatic seeding during `prisma migrate dev` or `prisma migrate reset` has been removed.
+
+:::
+
+<details>
+<summary>Prisma ORM v6 and earlier</summary>
+
+In Prisma ORM v6 and earlier, Prisma Migrate also integrates seamlessly with your seeds. Seeding is triggered automatically when Prisma Migrate resets the development database.
 
 Prisma Migrate resets the database and triggers seeding in the following scenarios:
 
@@ -48,6 +55,8 @@ Prisma Migrate resets the database and triggers seeding in the following scenari
 - The database is actually created by `prisma migrate dev`, because it did not exist before.
 
 When you want to use `prisma migrate dev` or `prisma migrate reset` without seeding, you can pass the `--skip-seed` flag.
+
+</details>
 
 ## Example seed scripts
 

--- a/content/200-orm/500-reference/325-prisma-config-reference.mdx
+++ b/content/200-orm/500-reference/325-prisma-config-reference.mdx
@@ -176,7 +176,13 @@ The path to the directory where Prisma should store migration files, and look fo
 
 ### `migrations.seed`
 
-This option allows you to define a script that Prisma runs to seed your database after running migrations or using the npx prisma db seed command. The string should be a command that can be executed in your terminal, such as with `node`, `ts-node`, or `tsx`.
+This option allows you to define a script that Prisma runs when you execute the `npx prisma db seed` command. The string should be a command that can be executed in your terminal, such as with `node`, `ts-node`, or `tsx`.
+
+:::info[Prisma ORM v7 changes]
+
+In Prisma ORM v7, seeding is only triggered explicitly via `npx prisma db seed`. In Prisma ORM v6 and earlier, the seed script also ran automatically after `prisma migrate dev` and `prisma migrate reset`.
+
+:::
 
 | Property          | Type     | Required | Default |
 | ----------------- | -------- | -------- | ------- |

--- a/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/400-upgrading-to-prisma-7.mdx
+++ b/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/400-upgrading-to-prisma-7.mdx
@@ -337,6 +337,16 @@ const prisma = new PrismaClient().$extends({
 })
 ```
 
+### Automatic seeding during migrations has been removed
+
+In Prisma ORM v6 and earlier, running `prisma migrate dev` or `prisma migrate reset` would automatically execute your seed script after applying migrations. This automatic seeding behavior has been removed in Prisma ORM v7.
+
+To seed your database in v7, you must explicitly run:
+
+```terminal
+npx prisma db seed
+```
+
 ### Various environment variables have been removed
 
 We've removed a small selection of Prisma-specific environment variables. 


### PR DESCRIPTION
Automatic seeding during migrate dev/reset was removed in v7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Clarified that seeding in Prisma v7 is explicit and now runs via the explicit seed command (no automatic seeding during migrations).
* Separated v7 and v6 seeding workflows and added highlighted notes explaining the behavioral differences.
* Updated reference text to state when the seed script runs and where to invoke it.
* Fixed a MongoDB modeling link to point to the recommended data-modeling best-practices page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->