### PR TITLE
DC-6383 UTM params persistence fixed for nav bar

### DIFF
--- a/src/theme/Layout/index.tsx
+++ b/src/theme/Layout/index.tsx
@@ -29,7 +29,24 @@ export default function Layout(props: Props): ReactNode {
 
   useKeyboardNavigation();
   useUTMPersistenceDocs();
-  
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const utms = sessionStorage.getItem('utm_params');
+      if (!utms) return;
+
+      document.querySelectorAll('a[href*="console.prisma.io"]').forEach((a) => {
+        const href = a.getAttribute('href');
+        if (!href) return;
+        const [base, query] = href.split('?');
+        const params = new URLSearchParams(query);
+        new URLSearchParams(utms).forEach((v, k) => params.set(k, v));
+        a.setAttribute('href', `${base}?${params}`);
+      });
+    }, 100);
+    return () => clearInterval(interval);
+  }, []);
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       const isKapaModalOpen = document.querySelector('#__docusaurus[aria-hidden="true"]');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-based UTM parameters are now automatically appended to Prisma Console navigation links and kept in sync for the duration of the session, including links added after the page initially loads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->