### PR TITLE
docs(): remove older package.json cli config

### DIFF
--- a/content/200-orm/500-reference/200-prisma-cli-reference.mdx
+++ b/content/200-orm/500-reference/200-prisma-cli-reference.mdx
@@ -1804,42 +1804,6 @@ prisma studio --config=./prisma.config.ts
 prisma studio --url="postgresql://user:password@localhost:5432/dbname"
 ```
 
-## `package.json` entry options
-
-### `schema`
-
-The path to the desired `schema.prisma` file can be specified with the `prisma.schema` entry in the `package.json` file. The path defines the file the Prisma CLI should use when you run any of the CLI commands. Both absolute and relative paths are supported.
-
-```json file="package.json"
-{
-  "name": "my-project",
-  "version": "1.0.0",
-  "prisma": {
-    "schema": "./custom-path-to-schema/schema.prisma"
-  }
-}
-```
-
-This is available from version 2.7.0 and later.
-
-### `seed`
-
-The command used to populate the datasource is specified in the `prisma.seed` entry in the `package.json` file. It is used when `prisma db seed` is invoked or triggered.
-
-See [Seeding your database](/orm/prisma-migrate/workflows/seeding)
-
-```json file="package.json"
-{
-  "name": "my-project",
-  "version": "1.0.0",
-  "prisma": {
-    "seed": "node ./prisma/seed.js"
-  }
-}
-```
-
-This is available from version 3.0.1 and later.
-
 ## Using a HTTP proxy for the CLI
 
 Prisma CLI supports [custom HTTP proxies](https://github.com/prisma/prisma/issues/506). This is particularly relevant when being behind a corporate firewall.


### PR DESCRIPTION
This removes the older `package.json` config settings that could be set by a users. These have been deprecated for some time and with v7 are no longer supported. Instead of adding a note for v7/v6 differences, we safely remove them as v6 also supports adding them via the `prisma.config`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed documentation sections describing package.json configuration options for schema and seed setup, including associated historical version notes. Reference material remains intact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->