### PR TITLE
docs: fix JSON fields FAQ - case-insensitive filtering is supported

### DIFF
--- a/content/200-orm/200-prisma-client/200-special-fields-and-types/100-working-with-json-fields.mdx
+++ b/content/200-orm/200-prisma-client/200-special-fields-and-types/100-working-with-json-fields.mdx
@@ -1054,7 +1054,7 @@ No - it is not yet possible to filter on the presence of a specific key.
 
 ### Is case insensitive filtering supported?
 
-No - [case insensitive filtering](https://github.com/prisma/prisma/issues/7390) is not yet supported.
+Yes - case-insensitive filtering for `Json` fields is supported since version 6.4.0. You can use the `mode: 'insensitive'` option with string filters like `string_contains`, `string_starts_with`, and `string_ends_with`. See [Filter on object property](#filter-on-object-property) for examples.
 
 ### Can you sort an object property within a JSON value?
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that case-insensitive filtering for JSON fields is supported since version 6.4.0, enabling case-insensitive string filtering operations on JSON data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->