### PR TITLE
Add DATABASE_PORT to PrismaMariaDb configuration

### DIFF
--- a/content/100-getting-started/02-prisma-orm/100-quickstart/400-mysql.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/400-mysql.mdx
@@ -203,6 +203,7 @@ import { PrismaClient } from '../generated/prisma/client';
 
 const adapter = new PrismaMariaDb({
   host: process.env.DATABASE_HOST,
+  port: process.env.DATABASE_PORT,
   user: process.env.DATABASE_USER,
   password: process.env.DATABASE_PASSWORD,
   database: process.env.DATABASE_NAME,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the MariaDB quickstart example to demonstrate port configuration in the adapter setup options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->