### PR TITLE
Add documentation for map argument on Prisma indexes and constraints

### DIFF
--- a/content/200-orm/100-prisma-schema/20-data-model/30-indexes.mdx
+++ b/content/200-orm/100-prisma-schema/20-data-model/30-indexes.mdx
@@ -42,6 +42,10 @@ You can configure indexes, unique constraints, and primary key constraints with 
   - Available on the `@id`, `@@id`, `@unique`, `@@unique` and `@@index` attributes
   - SQL Server only
 
+- The [`map` argument](#configuring-the-name-of-indexes-with-map) allows you to specify a custom name for the index or constraint in the underlying database
+  - Available on the `@id`, `@@id`, `@unique`, `@@unique` and `@@index` attributes
+  - Supported in all databases
+
 See the linked sections for details of which version each feature was first introduced in.
 
 ### Configuring the length of indexes with `length` (MySQL)
@@ -457,6 +461,54 @@ The default value of `clustered` for each attribute is as follows:
 | `@@index`  | `false` |
 
 A table can have at most one clustered index.
+
+### Configuring the name of indexes with `map`
+
+The `map` argument allows you to specify a custom name for the index or constraint in the underlying database. This is useful when you want to use a specific naming convention or when the auto-generated name doesn't meet your requirements.
+
+The `map` argument is available on the `@id`, `@@id`, `@unique`, `@@unique` and `@@index` attributes.
+
+As an example, the following model configures a custom name for the index on the `title` field:
+
+```prisma file=schema.prisma showLineNumbers
+model Post {
+  id    Int    @id
+  title String
+
+  @@index([title], map: "my_custom_index_name")
+}
+```
+
+This translates to the following SQL command (PostgreSQL example):
+
+```sql
+CREATE INDEX "my_custom_index_name" ON "Post" ("title");
+```
+
+Without the `map` argument, Prisma would generate a default name like `Post_title_idx`.
+
+The `map` argument can also be used on unique constraints:
+
+```prisma file=schema.prisma showLineNumbers
+model User {
+  id    Int    @id
+  email String @unique(map: "unique_user_email")
+}
+```
+
+And on composite indexes and constraints:
+
+```prisma file=schema.prisma showLineNumbers
+model Post {
+  id        Int    @id
+  title     String
+  author    String
+  createdAt DateTime
+
+  @@index([author, createdAt], map: "posts_author_date_idx")
+  @@unique([title, author], map: "posts_title_author_unique")
+}
+```
 
 ### Upgrading from previous versions
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation on the `map` argument for indexes and constraints to specify custom database names
  * Includes practical Prisma schema examples with corresponding SQL translations
  * Clarifies `map` availability across @id, @@id, @unique, @@unique, and @@index directives for all supported databases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->