### PR TITLE
Replace mcp-remote config with direct url for remote MCP server

### DIFF
--- a/content/250-postgres/350-integrations/400-mcp-server.mdx
+++ b/content/250-postgres/350-integrations/400-mcp-server.mdx
@@ -49,8 +49,7 @@ The remote Prisma MCP server follows the standard JSON-based configuration for M
 {
   "mcpServers": {
     "Prisma-Remote": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.prisma.io/mcp"]
+      "url": "https://mcp.prisma.io/mcp"
     }
   }
 }
@@ -154,8 +153,7 @@ If your browser blocks the link, [you can set it up manually](https://code.visua
       "args": ["-y", "prisma", "mcp"]
     },
     "Prisma-Remote": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.prisma.io/mcp"]
+      "url": "https://mcp.prisma.io/mcp"
     }
   }
 }
@@ -210,8 +208,7 @@ Adding it via the  **Cursor Settings** settings will modify the global `~/.curso
       "args": ["-y", "prisma", "mcp"]
     },
     "Prisma-Remote": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.prisma.io/mcp"]
+      "url": "https://mcp.prisma.io/mcp"
     },
     // other MCP servers
   }
@@ -230,8 +227,7 @@ If you want the Prisma MCP server to be available only in specific Cursor projec
       "args": ["-y", "prisma", "mcp"]
     },
     "Prisma-Remote": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.prisma.io/mcp"]
+      "url": "https://mcp.prisma.io/mcp"
     }
     // other MCP servers
   }
@@ -279,8 +275,7 @@ Adding it via the  **Windsurf Settings** will modify the global `~/.codeium/wind
       "args": ["-y", "prisma", "mcp"]
     },
     "Prisma-Remote": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.prisma.io/mcp"]
+      "url": "https://mcp.prisma.io/mcp"
     },
     // other MCP servers
   }
@@ -344,8 +339,7 @@ Then add the JSON snippet to that configuration file:
       "args": ["-y", "prisma", "mcp"]
     },
     "Prisma-Remote": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.prisma.io/mcp"]
+      "url": "https://mcp.prisma.io/mcp"
     },
     // other MCP servers
   }

--- a/content/250-postgres/350-integrations/500-vscode.mdx
+++ b/content/250-postgres/350-integrations/500-vscode.mdx
@@ -92,8 +92,7 @@ If your browser blocks the link, [you can set it up manually](https://code.visua
       "args": ["-y", "prisma", "mcp"]
     },
     "Prisma-Remote": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.prisma.io/mcp"]
+      "url": "https://mcp.prisma.io/mcp"
     }
   }
 }

--- a/content/900-ai/index.mdx
+++ b/content/900-ai/index.mdx
@@ -69,8 +69,7 @@ With Prisma’s MCP server, your AI tool can take database actions on your behal
 {
   "mcpServers": {
     "Prisma-Remote": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://mcp.prisma.io/mcp"]
+      "url": "https://mcp.prisma.io/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary

Modern IDEs (Cursor, VS Code, etc.) now support direct remote MCP connections without `mcp-remote`. This PR updates the documentation to use the simpler URL-based configuration.

## Changes

Replaced the `mcp-remote` command-based configuration:

```json
"Prisma-Remote": {
  "command": "npx",
  "args": ["-y", "mcp-remote", "https://mcp.prisma.io/mcp"]
}
```

With the simpler direct URL config:

```json
"Prisma-Remote": {
  "url": "https://mcp.prisma.io/mcp"
}
```

## Files Changed

- `content/250-postgres/350-integrations/400-mcp-server.mdx`
- `content/250-postgres/350-integrations/500-vscode.mdx`
- `content/900-ai/index.mdx`

## Related

Fixes: [PTL-690](https://linear.app/prisma-company/issue/PTL-690/mcp-server-incompatible-with-mcp-remote0132-due-to-incorrect)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma MCP server configuration examples across documentation to use simplified URL-based format, replacing the previous command-line invocation approach for easier configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->