### PR TITLE
Fix duplicate host property in PrismaMariaDb config

### DIFF
--- a/content/100-getting-started/02-prisma-orm/100-quickstart/400-mysql.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/400-mysql.mdx
@@ -204,6 +204,7 @@ import { PrismaClient } from '../generated/prisma/client';
 const adapter = new PrismaMariaDb({
   host: process.env.DATABASE_HOST,
   user: process.env.DATABASE_USER,
+  host: process.env.DATABASE_PORT,
   password: process.env.DATABASE_PASSWORD,
   database: process.env.DATABASE_NAME,
   connectionLimit: 5


### PR DESCRIPTION
Update code sample from [Doc](https://www.prisma.io/docs/getting-started/prisma-orm/quickstart/mysql#7-instantiate-prisma-client)

```ts
import "dotenv/config";
import { PrismaMariaDb } from '@prisma/adapter-mariadb';
import { PrismaClient } from '../generated/prisma/client';

const adapter = new PrismaMariaDb({
  host: process.env.DATABASE_HOST,
  port: process.env.DATABASE_PORT, // 👌HERE
  user: process.env.DATABASE_USER,
  password: process.env.DATABASE_PASSWORD,
  database: process.env.DATABASE_NAME,
  connectionLimit: 5
});
const prisma = new PrismaClient({ adapter });

export { prisma }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma MariaDB adapter configuration example in the getting started guide to correct the database connection settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->