### PR TITLE
Add Postgres 18 to supported databases

### DIFF
--- a/content/200-orm/500-reference/375-supported-databases.mdx
+++ b/content/200-orm/500-reference/375-supported-databases.mdx
@@ -34,6 +34,7 @@ An asterisk (\*) indicates that the version number is not relevant; either all v
 | PostgreSQL           | 15      |
 | PostgreSQL           | 16      |
 | PostgreSQL           | 17      |
+| PostgreSQL           | 18      |
 | SQLite               | \*      |
 
 Note that a fixed version of SQLite is shipped with every Prisma ORM release.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated supported databases reference to include PostgreSQL 18 as a newly supported option for self-hosted environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->