### PR TITLE
docs: document CLI flag changes for prisma db execute and migrate diff in v7

### DIFF
--- a/content/200-orm/300-prisma-migrate/300-workflows/60-generating-down-migrations.mdx
+++ b/content/200-orm/300-prisma-migrate/300-workflows/60-generating-down-migrations.mdx
@@ -105,22 +105,36 @@ You will need to create the down migration first, before creating the correspond
 
    There are two potential options for specifying the 'to' state:
 
-   - Using `--to-migrations`: this makes a comparison to the state of the migrations given in the migrations directory. This is the preferred option, as it is more robust, but it requires a [shadow database](/orm/prisma-migrate/understanding-prisma-migrate/shadow-database). To use this option, run:
+   - Using `--to-migrations`: this makes a comparison to the state of the migrations given in the migrations directory. This is the preferred option, as it is more robust. To use this option, run:
 
      ```terminal wrap
+     # Prisma 6
      npx prisma migrate diff \
       --from-schema prisma/schema.prisma \
       --to-migrations prisma/migrations \
       --shadow-database-url $SHADOW_DATABASE_URL \
       --script > down.sql
+
+     # Prisma 7
+     npx prisma migrate diff \
+      --from-schema prisma/schema.prisma \
+      --to-migrations prisma/migrations \
+      --script > down.sql
      ```
 
-   - Using `--to-schema-datasource`: this makes a comparison to the state of the database. This does not require a shadow database, but it does rely on the database having an up-to-date schema. To use this option, run:
+   - Using `--to-config-datasource` (Prisma 7) or `--to-schema-datasource` (Prisma 6): this makes a comparison to the state of the database. This does not require a shadow database, but it does rely on the database having an up-to-date schema. To use this option, run:
 
      ```terminal wrap
+     # Prisma 6
      npx prisma migrate diff \
       --from-schema prisma/schema.prisma \
       --to-schema-datasource prisma/schema.prisma \
+      --script > down.sql
+
+     # Prisma 7
+     npx prisma migrate diff \
+      --from-schema prisma/schema.prisma \
+      --to-config-datasource \
       --script > down.sql
      ```
 

--- a/content/200-orm/300-prisma-migrate/300-workflows/60-generating-down-migrations.mdx
+++ b/content/200-orm/300-prisma-migrate/300-workflows/60-generating-down-migrations.mdx
@@ -140,10 +140,10 @@ If your previous up migration failed, you can apply your down migration on your 
 
 To apply the down migration on your production database after a failed up migration:
 
-1. Use `db execute` to run your `down.sql` file on the database server:
+1. Use `db execute` to run your `down.sql` file on the database server (using the database URL configured in `prisma.config.ts`):
 
    ```terminal
-   npx prisma db execute --file ./down.sql --schema prisma/schema.prisma
+   npx prisma db execute --file ./down.sql
    ```
 
 2. Use `migrate resolve` to record that you rolled back the up migration named `add_profile`:

--- a/content/200-orm/300-prisma-migrate/300-workflows/70-patching-and-hotfixing.mdx
+++ b/content/200-orm/300-prisma-migrate/300-workflows/70-patching-and-hotfixing.mdx
@@ -193,15 +193,22 @@ In this case, you need to create a migration that takes your production database
   - Run the following `prisma migrate diff` command:
 
     ```terminal wrap
-     npx prisma migrate diff \
+    # Prisma 6
+    npx prisma migrate diff \
       --from-url "$DATABASE_URL_PROD" \
       --to-migrations ./prisma/migrations \
       --shadow-database-url $SHADOW_DATABASE_URL \
       --script > backward.sql
+
+    # Prisma 7 (with production config)
+    npx prisma migrate diff \
+      --from-config-datasource \
+      --to-migrations ./prisma/migrations \
+      --config prisma.config.prod.ts \
+      --script > backward.sql
     ```
 
     This will create a SQL script file containing all changes necessary to take your production environment from its current failed state to the target state defined by your migrations history.
-    Note that because we're using `--to-migrations`, the command requires a [shadow database](/orm/prisma-migrate/understanding-prisma-migrate/shadow-database).
 
   - Run the following `prisma db execute` command:
 
@@ -235,9 +242,11 @@ In this case, you need to fix the non-unique data and then go ahead with the res
   - Run the following `prisma migrate diff` command:
 
     ```bash
-
+    # Prisma 6
     npx prisma migrate diff --from-url "$DATABASE_URL_PROD" --to-schema schema.prisma --script > forward.sql
 
+    # Prisma 7 (with production config)
+    npx prisma migrate diff --from-config-datasource --to-schema schema.prisma --config prisma.config.prod.ts --script > forward.sql
     ```
 
     This will create a SQL script file containing all changes necessary to take your production environment from its current failed state to the target state defined in your `schema.prisma` file.

--- a/content/200-orm/300-prisma-migrate/300-workflows/70-patching-and-hotfixing.mdx
+++ b/content/200-orm/300-prisma-migrate/300-workflows/70-patching-and-hotfixing.mdx
@@ -123,6 +123,12 @@ The following example demonstrates how to manually complete the steps of a migra
 
 ## Fixing failed migrations with `migrate diff` and `db execute`
 
+:::info
+
+**Prisma 7 note**: The `--url` flag has been removed from `prisma db execute`. To run these commands against a production database, you'll need to configure the production database URL in your `prisma.config.ts` file before running `db execute`. You can create a separate config file for production (e.g., `prisma.config.prod.ts`) and use `--config prisma.config.prod.ts` to specify it.
+
+:::
+
 To help with fixing a failed migration, Prisma ORM provides the following commands for creating and executing a migration file:
 
 - [`prisma migrate diff`](/orm/reference/prisma-cli-reference#migrate-diff) which diffs two database schema sources to create a migration taking one to the state of the second. You can output either a summary of the difference or a sql script. The script can be output into a file via `> file_name.sql` or be piped to the `db execute --stdin` command.
@@ -200,7 +206,11 @@ In this case, you need to create a migration that takes your production database
   - Run the following `prisma db execute` command:
 
     ```bash
-     npx prisma db execute --url "$DATABASE_URL_PROD" --file backward.sql
+    # Prisma 6
+    npx prisma db execute --url "$DATABASE_URL_PROD" --file backward.sql
+
+    # Prisma 7 (with production config)
+    npx prisma db execute --config prisma.config.prod.ts --file backward.sql
     ```
 
     This applies the changes in the SQL script against the target database without interacting with the migrations table.
@@ -235,7 +245,11 @@ In this case, you need to fix the non-unique data and then go ahead with the res
   - Run the following `prisma db execute` command:
 
     ```bash
+    # Prisma 6
     npx prisma db execute --url "$DATABASE_URL_PROD" --file forward.sql
+
+    # Prisma 7 (with production config)
+    npx prisma db execute --config prisma.config.prod.ts --file forward.sql
     ```
 
     This applies the changes in the SQL script against the target database without interacting with the migrations table.

--- a/content/200-orm/500-reference/200-prisma-cli-reference.mdx
+++ b/content/200-orm/500-reference/200-prisma-cli-reference.mdx
@@ -1648,7 +1648,7 @@ See also:
 
 #### Prerequisites
 
-Before using the `migrate diff` command, if you are using the `--from-schema-datasource` or `--to-schema-datasource` you must configure your database connection in your `prisma.config.ts` file.
+Before using the `migrate diff` command, if you are using `--from-config-datasource` or `--to-config-datasource`, you must configure your database connection in your `prisma.config.ts` file.
 
 For example:
 
@@ -1679,56 +1679,85 @@ export default defineConfig({
 
 #### Options
 
+:::info
+
+**Prisma 7 breaking change**: The `--from-url`, `--to-url`, `--from-schema-datasource`, `--to-schema-datasource`, and `--shadow-database-url` options have been removed. Use `--from-config-datasource` and `--to-config-datasource` instead, which read the database URL from `prisma.config.ts`.
+
+:::
+
 One of the following `--from-...` options is required:
 
 | Options                    | Description                                                                                              | Notes                                                                          |
 | :------------------------- | :------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
-| `--from-url`               | A data source URL                                                                                        |                                                                                |
-| `--from-migrations`        | Path to the Prisma Migrate migrations directory                                                          | Not supported in MongoDB                                                       |
+| `--from-empty`             | Assume that the data model you are migrating from is empty                                               |                                                                                |
 | `--from-schema`            | Path to a Prisma schema file, uses the data model for the diff                                           |                                                                                |
-| `--from-schema-datasource` | Path to a Prisma schema file, uses the URL in the `datasource` block for the diff                        |                                                                                |
-| `--from-empty`             | Assume that you the data model you are migrating from is empty                                           |                                                                                |
-| `--from-local-d1`          | Path to a local D1 instance ([learn more](/orm/overview/databases/cloudflare-d1#using-the-wrangler-cli-with-prisma-migrate-diff)) | Available since [5.12.0](https://github.com/prisma/prisma/releases/tag/5.12.0) |
+| `--from-migrations`        | Path to the Prisma Migrate migrations directory                                                          | Not supported in MongoDB                                                       |
+| `--from-config-datasource` | Use the datasource from the Prisma config file                                                           | Prisma 7+                                                                      |
 
 One of the following `--to-...` options is required:
 
 | Options                  | Description                                                                                              | Notes                                                                          |
 | :----------------------- | :------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------- |
-| `--to-url`               | A data source URL                                                                                        |                                                                                |
-| `--to-migrations`        | Path to the Prisma Migrate migrations directory                                                          | Not supported in MongoDB                                                       |
+| `--to-empty`             | Assume that the data model you are migrating to is empty                                                 |                                                                                |
 | `--to-schema`            | Path to a Prisma schema file, uses the data model for the diff                                           |                                                                                |
-| `--to-schema-datasource` | Path to a Prisma schema file, uses the URL in the `datasource` block for the diff                        |                                                                                |
-| `--to-empty`             | Assume that you the data model you are migrating to is empty                                             |                                                                                |
-| `--to-local-d1`          | Path to a local D1 instance ([learn more](/orm/overview/databases/cloudflare-d1#using-the-wrangler-cli-with-prisma-migrate-diff)) | Available since [5.12.0](https://github.com/prisma/prisma/releases/tag/5.12.0) |
+| `--to-migrations`        | Path to the Prisma Migrate migrations directory                                                          | Not supported in MongoDB                                                       |
+| `--to-config-datasource` | Use the datasource from the Prisma config file                                                           | Prisma 7+                                                                      |
 
 Other options:
 
-| Options                 | Required | Description                                                                                                                                       | Notes                                                                          |
-| :---------------------- | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------- |
-| `--shadow-database-url` | No       | URL for the shadow database                                                                                                                       | Only required if using `--to-migrations` or `--from-migrations`                |
-| `--script`              | No       | Outputs a SQL script instead of the default human-readable summary                                                                                | Not supported in MongoDB                                                       |
-| `-o`, `--output`        | No       | Writes to a file instead of stdout                                                                                                                | Available since [5.12.1](https://github.com/prisma/prisma/releases/tag/5.12.1) |
-| `--exit-code`           | No       | Change the exit code behavior to signal if the diff is empty or not (Empty: 0, Error: 1, Not empty: 2). Default behavior is Success: 0, Error: 1. |                                                                                |
-| `--help`                | No       | Displays the help message.                                                                                                                        |                                                                                |
+| Options       | Required | Description                                                                                                                                       | Notes                                                                          |
+| :------------ | :------- | :------------------------------------------------------------------------------------------------------------------------------------------------ | :----------------------------------------------------------------------------- |
+| `--script`    | No       | Outputs a SQL script instead of the default human-readable summary                                                                                | Not supported in MongoDB                                                       |
+| `-o`, `--output` | No    | Writes to a file instead of stdout                                                                                                                | Available since [5.12.1](https://github.com/prisma/prisma/releases/tag/5.12.1) |
+| `--exit-code` | No       | Change the exit code behavior to signal if the diff is empty or not (Empty: 0, Error: 1, Not empty: 2). Default behavior is Success: 0, Error: 1. |                                                                                |
+| `--config`    | No       | Custom path to your Prisma config file                                                                                                            |                                                                                |
+| `--help`      | No       | Displays the help message                                                                                                                         |                                                                                |
 
 #### Examples
 
-- Compare two databases specified by their data source URL, and output the default human-readable summary:
+- Compare the configured database to a Prisma schema (e.g., to roll forward after a migration failed):
 
   ```terminal
   prisma migrate diff \
-    --from-url "$DATABASE_URL" \
-    --to-url "postgresql://login:password@localhost:5432/db2"
+    --from-config-datasource \
+    --to-schema=next_datamodel.prisma \
+    --script
   ```
 
-- Compare the state of a database with a URL of `$DATABASE_URL` to the schema defined by the migrations in the `./prisma/migrations` directory, and output the differences to a script `script.sql`:
+- Compare a Prisma schema to the configured database:
 
   ```terminal
   prisma migrate diff \
-   --from-url "$DATABASE_URL" \
-   --to-migrations ./prisma/migrations \
-   --shadow-database-url $SHADOW_DATABASE_URL \
-   --script > script.sql
+    --from-schema=schema.prisma \
+    --to-config-datasource \
+    --script
+  ```
+
+- Compare the migrations directory to the configured database (e.g., to generate a migration for a hotfix already applied on production):
+
+  ```terminal
+  prisma migrate diff \
+    --from-migrations ./migrations \
+    --to-config-datasource \
+    --script
+  ```
+
+- Pipe the output to `prisma db execute`:
+
+  ```terminal
+  prisma migrate diff \
+    --from-config-datasource \
+    --to-schema=schema.prisma \
+    --script | prisma db execute --stdin
+  ```
+
+- Detect if both sources are in sync (exits with code 2 if changes are detected):
+
+  ```terminal
+  prisma migrate diff \
+    --exit-code \
+    --from-config-datasource \
+    --to-schema=schema.prisma
   ```
 
 ## Prisma Data Platform

--- a/content/200-orm/500-reference/200-prisma-cli-reference.mdx
+++ b/content/200-orm/500-reference/200-prisma-cli-reference.mdx
@@ -1266,10 +1266,7 @@ This command is currently not supported on [MongoDB](/orm/overview/databases/mon
 
 :::
 
-This command applies a SQL script to the database without interacting with the Prisma migrations table. The script takes two inputs:
-
-- the SQL script, which can be provided either on standard input or in a file
-- the data source, which can either be the URL of the data source or the path to your Prisma schema file
+This command applies a SQL script to the database without interacting with the Prisma migrations table. The datasource URL configuration is read from the Prisma config file (e.g., `prisma.config.ts`).
 
 The output of the command is connector-specific, and is not meant for returning data, but only to report success or failure.
 
@@ -1279,7 +1276,7 @@ See also:
 
 #### Prerequisites
 
-Before using the `db execute` command, if you do not use the `--url` option you must configure your database connection in your `prisma.config.ts` file.
+Before using the `db execute` command, you must configure your database connection in your `prisma.config.ts` file.
 
 For example:
 
@@ -1312,38 +1309,33 @@ export default defineConfig({
 
 #### Options
 
-One of the following data source inputs is required:
+| Options    | Required | Description                                                           |
+| :--------- | :------- | :-------------------------------------------------------------------- |
+| `--file`   | Yes*     | Path to a file. The content will be sent as the script to be executed |
+| `--stdin`  | No       | Use the terminal standard input as the script to be executed          |
+| `--config` | No       | Custom path to your Prisma config file                                |
+| `--help`   | No       | Displays the help message                                             |
 
-| Options    | Description                                                          |
-| :--------- | :------------------------------------------------------------------- |
-| `--url`    | URL of the data source to run the command on                         |
-| `--schema` | Path to a Prisma schema file, uses the URL in the `datasource` block |
+\* Either `--file` or `--stdin` is required to provide the script input.
 
-One of the following script inputs is required:
+:::info
 
-| Options   | Description                                                           |
-| :-------- | :-------------------------------------------------------------------- |
-| `--stdin` | Use the terminal standard input as the script to be executed          |
-| `--file`  | Path to a file. The content will be sent as the script to be executed |
+**Prisma 7 breaking change**: The `--schema` and `--url` options have been removed. Configure your database connection in `prisma.config.ts` instead.
 
-Other options:
-
-| Options  | Required | Description                |
-| :------- | :------- | :------------------------- |
-| `--help` | No       | Displays the help message. |
+:::
 
 #### Examples
 
-- Take the content of a SQL file located at `./script.sql` and execute it on the database specified by the URL in the `datasource` block of your `schema.prisma` file:
+- Execute the content of a SQL script file using the datasource configured in `prisma.config.ts`:
 
   ```terminal
-  prisma db execute --file ./script.sql --schema schema.prisma
+  prisma db execute --file ./script.sql
   ```
 
-- Take the SQL script from standard input and execute it on the database specified by the data source URL given in the `DATABASE_URL` environment variable:
+- Execute the SQL script from stdin using the configured datasource:
 
   ```terminal wrap
-  echo 'TRUNCATE TABLE dev;' | prisma db execute --stdin --url="$DATABASE_URL"
+  echo 'TRUNCATE TABLE dev;' | prisma db execute --stdin
   ```
 
 ## Prisma Migrate

--- a/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/400-upgrading-to-prisma-7.mdx
+++ b/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/400-upgrading-to-prisma-7.mdx
@@ -417,6 +417,38 @@ Then run the command without `--schema` or `--url`:
 prisma db execute --file ./script.sql
 ```
 
+### `prisma migrate diff` CLI options changed
+
+Several options have been removed from `prisma migrate diff` and replaced with new options that use `prisma.config.ts`:
+
+| Removed Option             | Replacement                  |
+|---------------------------|------------------------------|
+| `--from-url`              | `--from-config-datasource`   |
+| `--to-url`                | `--to-config-datasource`     |
+| `--from-schema-datasource`| `--from-config-datasource`   |
+| `--to-schema-datasource`  | `--to-config-datasource`     |
+| `--shadow-database-url`   | Configure in `prisma.config.ts` |
+
+#### Before (v6)
+
+```terminal
+prisma migrate diff \
+  --from-url "$DATABASE_URL" \
+  --to-schema schema.prisma \
+  --script
+```
+
+#### After (v7)
+
+Configure your database connection in `prisma.config.ts`, then use `--from-config-datasource` or `--to-config-datasource`:
+
+```terminal
+prisma migrate diff \
+  --from-config-datasource \
+  --to-schema schema.prisma \
+  --script
+```
+
 ### Various environment variables have been removed
 
 We've removed a small selection of Prisma-specific environment variables. 

--- a/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/400-upgrading-to-prisma-7.mdx
+++ b/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/400-upgrading-to-prisma-7.mdx
@@ -381,6 +381,42 @@ The `--skip-generate` flag was removed from `prisma migrate dev` and `prisma db 
 
 `migrate dev` and `db push` no longer run `prisma generate` automatically. You must run `prisma generate` explicitly to generate Prisma Client.
 
+### `--schema` and `--url` flags removed from `prisma db execute`
+
+The `--schema` and `--url` flags have been removed from the `prisma db execute` command. Previously, you could use `--schema` to specify the path to your Prisma schema file, or `--url` to specify the database URL directly. Now, the database connection must be configured in `prisma.config.ts`.
+
+#### Before (v6)
+
+```terminal
+# Using --schema
+prisma db execute --file ./script.sql --schema prisma/schema.prisma
+
+# Using --url
+prisma db execute --file ./script.sql --url "$DATABASE_URL"
+```
+
+#### After (v7)
+
+Configure your database connection in `prisma.config.ts` instead:
+
+```ts
+import 'dotenv/config'
+import { defineConfig, env } from 'prisma/config'
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  datasource: {
+    url: env('DATABASE_URL'),
+  },
+})
+```
+
+Then run the command without `--schema` or `--url`:
+
+```terminal
+prisma db execute --file ./script.sql
+```
+
 ### Various environment variables have been removed
 
 We've removed a small selection of Prisma-specific environment variables. 

--- a/content/900-ai/prompts/prisma-7.mdx
+++ b/content/900-ai/prompts/prisma-7.mdx
@@ -294,6 +294,35 @@ Your project will be migrated accordingly using the appropriate adapter.
 
 ---
 
+## 11) CLI Flag Changes
+
+### `--schema` and `--url` flags removed from `prisma db execute`
+
+The `--schema` and `--url` flags have been removed from `prisma db execute`. Configure your database connection in `prisma.config.ts` instead.
+
+**Before (v6):**
+```bash
+# Using --schema
+prisma db execute --file ./script.sql --schema prisma/schema.prisma
+
+# Using --url
+prisma db execute --file ./script.sql --url "$DATABASE_URL"
+```
+
+**After (v7):**
+```bash
+prisma db execute --file ./script.sql
+```
+
+The database URL is now read from `prisma.config.ts`.
+
+### Migration Action
+
+- Update any scripts or CI pipelines that use `prisma db execute --schema` or `prisma db execute --url`.
+- Configure your database connection in `prisma.config.ts` instead.
+
+---
+
 ## Safety Checks & Edge Cases
 - **MongoDB provider** detected → stop and recommend staying on Prisma 6 until v7 MongoDB support returns. 
 - **Multiple entrypoints** (workers, scripts, tests): apply the same client/adapter/dotenv pattern everywhere. 
@@ -312,5 +341,7 @@ Your project will be migrated accordingly using the appropriate adapter.
     - ESM/TS config updates
     - Seed script updates
     - No automatic removal of Accelerate
+    - Mapped enum breaking change warning (if applicable)
+    - CLI flag changes (`--schema` and `--url` removal from `db execute`)
 
 ````

--- a/content/900-ai/prompts/prisma-7.mdx
+++ b/content/900-ai/prompts/prisma-7.mdx
@@ -316,9 +316,38 @@ prisma db execute --file ./script.sql
 
 The database URL is now read from `prisma.config.ts`.
 
+### `prisma migrate diff` options changed
+
+Several options have been removed and replaced:
+
+| Removed Option             | Replacement                  |
+|---------------------------|------------------------------|
+| `--from-url`              | `--from-config-datasource`   |
+| `--to-url`                | `--to-config-datasource`     |
+| `--from-schema-datasource`| `--from-config-datasource`   |
+| `--to-schema-datasource`  | `--to-config-datasource`     |
+| `--shadow-database-url`   | Configure in `prisma.config.ts` |
+
+**Before (v6):**
+```bash
+prisma migrate diff \
+  --from-url "$DATABASE_URL" \
+  --to-schema schema.prisma \
+  --script
+```
+
+**After (v7):**
+```bash
+prisma migrate diff \
+  --from-config-datasource \
+  --to-schema schema.prisma \
+  --script
+```
+
 ### Migration Action
 
 - Update any scripts or CI pipelines that use `prisma db execute --schema` or `prisma db execute --url`.
+- Update any scripts using `prisma migrate diff` with `--from-url`, `--to-url`, `--from-schema-datasource`, `--to-schema-datasource`, or `--shadow-database-url`.
 - Configure your database connection in `prisma.config.ts` instead.
 
 ---
@@ -341,7 +370,6 @@ The database URL is now read from `prisma.config.ts`.
     - ESM/TS config updates
     - Seed script updates
     - No automatic removal of Accelerate
-    - Mapped enum breaking change warning (if applicable)
-    - CLI flag changes (`--schema` and `--url` removal from `db execute`)
+    - CLI flag changes (`--schema` and `--url` removal from `db execute`, `migrate diff` option changes)
 
 ````


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI docs: removed --schema/--url flags; DB connection is read from repository config (prisma.config).
  * Added explicit Prisma 6 vs Prisma 7 before/after examples and upgrade guidance.
  * Revised migrate/db-execute and migrate-diff examples to use config-based datasource flow, including production-config variants and expanded patching/migration scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->