### PR TITLE
docs: highlight Prisma 7 driver adapter pool defaults and add v6 parity examples

### DIFF
--- a/content/200-orm/050-overview/500-databases/300-postgresql.mdx
+++ b/content/200-orm/050-overview/500-databases/300-postgresql.mdx
@@ -160,8 +160,15 @@ As an example, if you want to connect to a schema called `myschema`, set the con
 postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=myschema&connection_limit=5&socket_timeout=3
 ```
 
-:::tip[Prisma ORM v7 connection pooling]
-In Prisma ORM v7, [driver adapters](/orm/overview/databases/database-drivers) are the default for relational databases. Connection pooling is handled by the Node.js driver you provide (like `pg`), not by Prisma's connection URL parameters. See the [connection pool guide](/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool) for v7 defaults and configuration.
+:::warning[Prisma ORM v7: Connection pool defaults have changed]
+
+In Prisma ORM v7, [driver adapters](/orm/overview/databases/database-drivers) are the default for relational databases. Connection pooling is now handled by the `pg` driver, which has **different defaults** than Prisma ORM v6:
+
+- **Connection timeout**: `0` (no timeout) vs. v6's `5s`
+- **Idle timeout**: `10s` vs. v6's `300s`
+
+If you experience timeout issues after upgrading, you may need to configure your driver adapter to match v6 behavior. See the [connection pool guide](/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool#postgresql-using-the-pg-driver-adapter) for detailed configuration examples.
+
 :::
 
 ### Configuring an SSL connection

--- a/content/200-orm/050-overview/500-databases/400-mysql.mdx
+++ b/content/200-orm/050-overview/500-databases/400-mysql.mdx
@@ -130,8 +130,15 @@ As an example, if you want to set the connection pool size to `5` and configure 
 mysql://USER:PASSWORD@HOST:PORT/DATABASE?connection_limit=5&socket_timeout=3
 ```
 
-:::tip[Prisma ORM v7 connection pooling]
-In Prisma ORM v7, [driver adapters](/orm/overview/databases/database-drivers) are the default for relational databases. Connection pooling is handled by the Node.js driver you provide (like `mariadb`), not by Prisma's connection URL parameters. See the [connection pool guide](/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool) for v7 defaults and configuration.
+:::warning[Prisma ORM v7: Connection pool defaults have changed]
+
+In Prisma ORM v7, [driver adapters](/orm/overview/databases/database-drivers) are the default for relational databases. Connection pooling is now handled by the `mariadb` driver, which has **different defaults** than Prisma ORM v6:
+
+- **Connection timeout**: `1s` vs. v6's `5s`
+- **Idle timeout**: `1800s` vs. v6's `300s`
+
+If you experience timeout issues after upgrading, you may need to configure your driver adapter to match v6 behavior. See the [connection pool guide](/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool#mysql-or-mariadb-using-the-mariadb-driver) for detailed configuration examples.
+
 :::
 
 ### Configuring an SSL connection

--- a/content/200-orm/050-overview/500-databases/800-sql-server/index.mdx
+++ b/content/200-orm/050-overview/500-databases/800-sql-server/index.mdx
@@ -131,8 +131,15 @@ sqlserver://HOST[:PORT];database=DATABASE;user={MyServer/MyUser};password={ThisI
 | `trustServerCertificate`                                                              | No                | `false`            | Configures whether to trust the server certificate.                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `trustServerCertificateCA`                                                            | No                |                    | A path to a certificate authority file to be used instead of the system certificates to authorize the server certificate. Must be either in `pem`, `crt` or `der` format. Cannot be used together with `trustServerCertificate` parameter.                                                                                                                                                                                                                 |
 
-:::tip[Prisma ORM v7 connection pooling]
-In Prisma ORM v7, [driver adapters](/orm/overview/databases/database-drivers) are the default for relational databases. Connection pooling is handled by the Node.js driver you provide (like `mssql`), not by Prisma's connection URL parameters. See the [connection pool guide](/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool) for v7 defaults and configuration.
+:::warning[Prisma ORM v7: Connection pool defaults have changed]
+
+In Prisma ORM v7, [driver adapters](/orm/overview/databases/database-drivers) are the default for relational databases. Connection pooling is now handled by the `mssql` driver, which has **different defaults** than Prisma ORM v6:
+
+- **Connection timeout**: `15s` vs. v6's `5s`
+- **Idle timeout**: `30s` vs. v6's `300s`
+
+If you experience timeout issues after upgrading, you may need to configure your driver adapter to match v6 behavior. See the [connection pool guide](/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool#sql-server-using-the-mssql-driver) for detailed configuration examples.
+
 :::
 
 ### Using [integrated security](https://learn.microsoft.com/en-us/previous-versions/dotnet/framework/data/adonet/sql/authentication-in-sql-server) (Windows only)

--- a/content/200-orm/200-prisma-client/000-setup-and-configuration/050-databases-connections/115-connection-pool.mdx
+++ b/content/200-orm/200-prisma-client/000-setup-and-configuration/050-databases-connections/115-connection-pool.mdx
@@ -56,6 +56,24 @@ Here are the default connection pool settings for the `pg` driver adapter:
 | Idle timeout | `max_idle_connection_lifetime` | `300s` | `idleTimeoutMillis` | `10s` |
 | Connection lifetime | `max_connection_lifetime` | `0` (no timeout) | `maxLifetimeSeconds` | `0` (no timeout) |
 
+<details>
+<summary>Example: Matching Prisma ORM v6 defaults with the `pg` driver adapter</summary>
+
+If you want to preserve the same timeout behavior you had in Prisma ORM v6, pass the following configuration when instantiating the driver adapter:
+
+```ts
+import { PrismaPg } from '@prisma/adapter-pg'
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL,
+  // Match Prisma ORM v6 defaults:
+  connectionTimeoutMillis: 5_000, // v6 connect_timeout was 5s
+  idleTimeoutMillis: 300_000,     // v6 max_idle_connection_lifetime was 300s
+})
+```
+
+</details>
+
 :::tip
 See the [node-postgres pool documentation](https://node-postgres.com/apis/pool) for details on every available option.
 :::
@@ -71,6 +89,28 @@ Here are the default connection pool settings for the `mariadb` driver adapter:
 | Connection timeout | `connect_timeout` | `5s` | `connectTimeout` | `1s` |
 | Idle timeout | `max_idle_connection_lifetime` | `300s` | `idleTimeout` | `1800s` |
 
+<details>
+<summary>Example: Matching Prisma ORM v6 defaults with the `mariadb` driver adapter</summary>
+
+If you want to preserve the same timeout behavior you had in Prisma ORM v6, pass the following configuration when instantiating the driver adapter:
+
+```ts
+import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+
+const adapter = new PrismaMariaDb({
+  host: 'localhost',
+  port: 3306,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  // Match Prisma ORM v6 defaults:
+  connectTimeout: 5_000, // v6 connect_timeout was 5s
+  idleTimeout: 300,      // v6 max_idle_connection_lifetime was 300s (note: in seconds, not ms)
+})
+```
+
+</details>
+
 :::tip
 Refer to the [MariaDB Connector/Node.js pool options](https://mariadb.com/docs/connectors/mariadb-connector-nodejs/connector-nodejs-promise-api#pool-options) for configuration and tuning guidance.
 :::
@@ -84,6 +124,30 @@ Here are the default connection pool settings for the `mssql` driver adapter:
 | Pool size | `connection_limit` | `num_cpus::get_physical() * 2 + 1` | `pool.max` | `10` |
 | Connection timeout | `connect_timeout` | `5s` | `connectionTimeout` | `15s` |
 | Idle timeout | `max_idle_connection_lifetime` | `300s` | `pool.idleTimeoutMillis` | `30s` |
+
+<details>
+<summary>Example: Matching Prisma ORM v6 defaults with the `mssql` driver adapter</summary>
+
+If you want to preserve the same timeout behavior you had in Prisma ORM v6, pass the following configuration when instantiating the driver adapter:
+
+```ts
+import { PrismaMssql } from '@prisma/adapter-mssql'
+
+const adapter = new PrismaMssql({
+  server: 'localhost',
+  port: 1433,
+  database: 'mydb',
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  // Match Prisma ORM v6 defaults:
+  connectionTimeout: 5_000, // v6 connect_timeout was 5s
+  pool: {
+    idleTimeoutMillis: 300_000, // v6 max_idle_connection_lifetime was 300s
+  },
+})
+```
+
+</details>
 
 :::tip
 See the [`node-mssql` pool docs](https://tediousjs.github.io/node-mssql/#general-same-for-all-drivers) for details on these fields.

--- a/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/400-upgrading-to-prisma-7.mdx
+++ b/content/200-orm/800-more/300-upgrade-guides/200-upgrading-versions/400-upgrading-to-prisma-7.mdx
@@ -175,6 +175,14 @@ This change aligns with the move to make the main Prisma Client as lean and open
 instance, if you are using Prisma Postgres, you now need the `@prisma/adapter-pg` adapter. This also
 means the signature for creating a new Prisma Client has changed slightly:
 
+:::warning[Connection pool defaults have changed]
+
+Driver adapters use the connection pool settings from the underlying Node.js database driver, which may differ significantly from Prisma ORM v6 defaults. For example, the `pg` driver has no connection timeout by default (`0`), while Prisma ORM v6 used a 5-second timeout.
+
+**If you experience timeout issues after upgrading**, configure your driver adapter to match v6 behavior. See the [connection pool guide](/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool#prisma-orm-v7-driver-adapter-defaults) for detailed configuration examples for each database.
+
+:::
+
 #### Before
 
 ```ts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated connection pooling documentation with clearer warnings about behavior changes in Prisma v7.
  * Added configuration examples for aligning v7 database driver settings with previous default values.
  * Clarified specific timeout value changes across PostgreSQL, MySQL, and SQL Server.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->