### PR TITLE
update mysql adapter to include connection string parameter

### DIFF
--- a/content/200-orm/050-overview/500-databases/400-mysql.mdx
+++ b/content/200-orm/050-overview/500-databases/400-mysql.mdx
@@ -70,6 +70,19 @@ const adapter = new PrismaMariaDb({
 const prisma = new PrismaClient({ adapter })
 ```
 
+Alternatively, you can instantiate the adapter using a connection string:
+
+```ts
+import 'dotenv/config'
+import { PrismaMariaDb } from '@prisma/adapter-mariadb'
+import { PrismaClient } from '../generated/prisma/client'
+
+const connectionString = `${process.env.DATABASE_URL}`
+
+const adapter = new PrismaMariaDb(connectionString)
+const prisma = new PrismaClient({ adapter })
+```
+
 ## Connection details
 
 ### Connection URL


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added alternative usage example for MySQL database adapter configuration, demonstrating how to instantiate the adapter with a connection string and environment variables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->