### PR TITLE
docs: update prisma dev command documentation

### DIFF
--- a/content/200-orm/500-reference/200-prisma-cli-reference.mdx
+++ b/content/200-orm/500-reference/200-prisma-cli-reference.mdx
@@ -888,6 +888,14 @@ npx prisma dev --name="mydbname"
 
 This creates a named instance called `mydbname` that you can later start, stop, or manage using the instance management commands.
 
+**Run `prisma dev` in detached mode**
+
+```terminal
+npx prisma dev --detach
+```
+
+This runs the server in the background, freeing up your terminal for other commands. Use `prisma dev ls` to see running servers and `prisma dev stop` to stop them.
+
 ### `dev start`
 
 Starts existing [local Prisma Postgres](/postgres/database/local-development) instances in the background. 

--- a/content/200-orm/500-reference/200-prisma-cli-reference.mdx
+++ b/content/200-orm/500-reference/200-prisma-cli-reference.mdx
@@ -839,13 +839,14 @@ The `dev` command starts a [local Prisma Postgres](/postgres/database/local-deve
 
 ### Arguments
 
-| Argument              | Required | Description                                                                                                                                        | Default |
-| --------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `--name` (or `-n`)    | No       | Enables targeting a specific database instance. [Learn more](/postgres/database/local-development#using-different-local-prisma-postgres-instances). |         |
-| `--port` (or `-p`)    | No       | Main port number the local Prisma Postgres HTTP server will listen on.                                                                              | `51213` |
-| `--db-port` (or `-P`) | No       | Port number the local Prisma Postgres database server will listen on.                                                                               | `51214` |
-| `--shadow-db-port`    | No       | Port number the shadow database server will listen on.                                                                                              | `51215` |
-| `--debug`             | No       | Enable debug logging.                                                                                                                               | `false` |
+| Argument              | Required | Description                                                                                                                                        | Default   |
+| --------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| `--name` (or `-n`)    | No       | Enables targeting a specific database instance. [Learn more](/postgres/database/local-development#using-different-local-prisma-postgres-instances). | `default` |
+| `--port` (or `-p`)    | No       | Main port number the local Prisma Postgres HTTP server will listen on.                                                                              | `51213`   |
+| `--db-port` (or `-P`) | No       | Port number the local Prisma Postgres database server will listen on.                                                                               | `51214`   |
+| `--shadow-db-port`    | No       | Port number the shadow database server will listen on.                                                                                              | `51215`   |
+| `--detach` (or `-d`)  | No       | Run the server in the background.                                                                                                                   | `false`   |
+| `--debug`             | No       | Enable debug logging.                                                                                                                               | `false`   |
 
 ### Examples
 
@@ -970,6 +971,12 @@ To remove all databases that begin with `mydb` (e.g. `mydb-dev` and `mydb-prod`)
 ```terminal
 npx prisma dev rm mydb* # removes all DBs starting with `mydb`
 ```
+
+#### Arguments
+
+| Argument  | Required | Description                                                                                                          | Default |
+| --------- | -------- | -------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--force` | No       | Stops any running servers before removing them. Without this flag, the command will fail if any server is running. | `false` |
 
 :::note
 

--- a/content/250-postgres/300-database/550-local-development.mdx
+++ b/content/250-postgres/300-database/550-local-development.mdx
@@ -50,7 +50,15 @@ If you want to connect via Prisma ORM, hit <kbd>h</kbd> on your keyboard, copy t
 DATABASE_URL="prisma+postgres://localhost:51213/?api_key=__API_KEY__"
 ```
 
-Keep the local Prisma Postgres server running in the background while you work on your application. 
+Keep the local Prisma Postgres server running in the background while you work on your application.
+
+Alternatively, you can run the server in detached mode to free up your terminal:
+
+```terminal
+npx prisma dev --detach
+```
+
+This starts the server in the background. Use `prisma dev ls` to see running servers and `prisma dev stop` to stop them.
 
 ### 2. Applying migrations and seeding data
 
@@ -166,11 +174,19 @@ npx prisma dev rm <glob>
 npx prisma dev rm mydb # removes a DB called `mydb`
 ```
 
-To stop all databases that begin with `mydb` (e.g. `mydb-dev` and `mydb-prod`), you can use a glob:
+To remove all databases that begin with `mydb` (e.g. `mydb-dev` and `mydb-prod`), you can use a glob:
 
-```
+```terminal
 npx prisma dev rm mydb* # removes all DBs starting with `mydb`
 ```
+
+You can use the `--force` flag to stop any running servers before removing them:
+
+```terminal
+npx prisma dev rm mydb --force
+```
+
+Without `--force`, the command will fail if any server is still running.
 
 :::note
 


### PR DESCRIPTION
## Summary
- Add missing `--detach` (`-d`) option to `prisma dev` arguments table - allows running the server in the background
- Add default value `default` for `--name` option
- Add `--force` option documentation for `dev rm` command - stops running servers before removing them

## Test plan
- [ ] Verify the documentation renders correctly
- [ ] Confirm options match `npx prisma@latest dev --help` output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma CLI docs for `dev` and `rm`: set `--name` default to "default"; added `--detach` (aka `-d`) flag with default false and a detached-mode example; introduced `--force` for `rm` with default false; adjusted argument tables and section structure for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->