### PR TITLE
DR-6767 SQLite 3.51.1 bug warning

### DIFF
--- a/content/200-orm/050-overview/500-databases/500-sqlite.mdx
+++ b/content/200-orm/050-overview/500-databases/500-sqlite.mdx
@@ -42,21 +42,17 @@ As of [`v5.4.0`](https://github.com/prisma/prisma/releases/tag/5.4.0), you can u
 
 For SQLite, [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3) is one of the most popular drivers in the JavaScript ecosystem.
 
-:::warning Known issue: Nested EXISTS queries in SQLite 3.51.0+
+:::warning SQLite 3.51.0+ nested EXISTS bug
 
-A [bug in SQLite versions 3.51.0 and later](https://sqlite.org/forum/forumpost/7992838ba28e0da9e505087bebd5d67f1fc2f2f6601c5f1fb97056f782c413f8) causes nested EXISTS queries to fail. This affects users of `better-sqlite3` versions newer than 12.4.1. This bug is not present in libsql.
+A bug report surfaced with `@prisma/adapter-better-sqlite3`. This is a [known bug in SQLite 3.51.0+](https://sqlite.org/forum/forumpost/7992838ba28e0da9e505087bebd5d67f1fc2f2f6601c5f1fb97056f782c413f8) that breaks nested `EXISTS` queries.
 
-**Workarounds:**
-- Use `better-sqlite3` 12.4.1 (recommended temporary fix)
-- Switch to libsql with `@prisma/adapter-libsql`
-- Wait for SQLite patch release
-  - The SQLite team has fixed this bug but has not yet released a patched version.
+**Update to v7.3.0 or later of `@prisma/adapter-better-sqlite3`** which pins to an unaffected SQLite version.
 
-:::note
-This is an upstream bug in SQLite itself, not specific to Prisma ORM. We will update this notice once a patched version of SQLite is available.
+`@prisma/adapter-libsql` is not affected by this bug.
+
+The SQLite team has a fix but has not yet released a patched version.
+
 :::
-
-::: 
 
 This section explains how you can use it with Prisma ORM and the `@prisma/adapter-better-sqlite3` driver adapter.
 

--- a/content/200-orm/050-overview/500-databases/500-sqlite.mdx
+++ b/content/200-orm/050-overview/500-databases/500-sqlite.mdx
@@ -40,7 +40,23 @@ The connection URL always starts with the prefix `file:` and then contains a fil
 
 As of [`v5.4.0`](https://github.com/prisma/prisma/releases/tag/5.4.0), you can use Prisma ORM with database drivers from the JavaScript ecosystem (instead of using Prisma ORM's built-in drivers). You can do this by using a [driver adapter](/orm/overview/databases/database-drivers).
 
-For SQLite, [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3) is one of the most popular drivers in the JavaScript ecosystem. 
+For SQLite, [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3) is one of the most popular drivers in the JavaScript ecosystem.
+
+:::warning Known issue: Nested EXISTS queries in SQLite 3.51.0+
+
+A [bug in SQLite versions 3.51.0 and later](https://sqlite.org/forum/forumpost/7992838ba28e0da9e505087bebd5d67f1fc2f2f6601c5f1fb97056f782c413f8) causes nested EXISTS queries to fail. This affects users of `better-sqlite3` versions newer than 12.4.1. This bug is not present in libsql.
+
+**Workarounds:**
+- Use `better-sqlite3` 12.4.1 (recommended temporary fix)
+- Switch to libsql with `@prisma/adapter-libsql`
+- Wait for SQLite patch release
+  - The SQLite team has fixed this bug but has not yet released a patched version.
+
+:::note
+This is an upstream bug in SQLite itself, not specific to Prisma ORM. We will update this notice once a patched version of SQLite is available.
+:::
+
+::: 
 
 This section explains how you can use it with Prisma ORM and the `@prisma/adapter-better-sqlite3` driver adapter.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a warning about a known SQLite 3.51.0+ nested EXISTS bug affecting certain driver/adapters; recommends upgrading to adapter v7.3.0+ (which pins an unaffected SQLite), notes an alternative adapter is not impacted, and clarifies the issue is upstream with a fix pending.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->