### PR TITLE
DR-6749 added `/docs` to multiple search results to counter 404 errors

### DIFF
--- a/content/200-orm/500-reference/300-errors/migrate-no-foreign-keys.mdx
+++ b/content/200-orm/500-reference/300-errors/migrate-no-foreign-keys.mdx
@@ -5,5 +5,5 @@ sidebar_class_name: hidden
 
 import {Redirect} from '@docusaurus/router';
 
-<Redirect to="/orm/overview/databases/planetscale#option-1-emulate-relations-in-prisma-client" />
+<Redirect to="/docs/orm/overview/databases/planetscale#option-1-emulate-relations-in-prisma-client" />
 

--- a/content/200-orm/500-reference/300-errors/migrate-provider-switch.mdx
+++ b/content/200-orm/500-reference/300-errors/migrate-provider-switch.mdx
@@ -5,5 +5,5 @@ sidebar_class_name: hidden
 
 import {Redirect} from '@docusaurus/router';
 
-<Redirect to="/orm/prisma-migrate/understanding-prisma-migrate/limitations-and-known-issues#you-cannot-automatically-switch-database-providers" />
+<Redirect to="/docs/orm/prisma-migrate/understanding-prisma-migrate/limitations-and-known-issues#you-cannot-automatically-switch-database-providers" />
 

--- a/content/200-orm/500-reference/300-errors/migrate-resolve.mdx
+++ b/content/200-orm/500-reference/300-errors/migrate-resolve.mdx
@@ -5,5 +5,5 @@ sidebar_class_name: hidden
 
 import {Redirect} from '@docusaurus/router';
 
-<Redirect to="/orm/prisma-migrate/workflows/patching-and-hotfixing#failed-migration" />
+<Redirect to="/docs/orm/prisma-migrate/workflows/patching-and-hotfixing#failed-migration" />
 

--- a/content/200-orm/500-reference/300-errors/migrate-shadow.mdx
+++ b/content/200-orm/500-reference/300-errors/migrate-shadow.mdx
@@ -5,5 +5,5 @@ sidebar_class_name: hidden
 
 import {Redirect} from '@docusaurus/router';
 
-<Redirect to="/orm/prisma-migrate/understanding-prisma-migrate/shadow-database" />
+<Redirect to="/docs/orm/prisma-migrate/understanding-prisma-migrate/shadow-database" />
 

--- a/content/200-orm/500-reference/300-errors/mongodb-replica-set.mdx
+++ b/content/200-orm/500-reference/300-errors/mongodb-replica-set.mdx
@@ -5,5 +5,5 @@ sidebar_class_name: hidden
 
 import {Redirect} from '@docusaurus/router';
 
-<Redirect to="/orm/overview/databases/mongodb#how-to-use-mongodb-replica-sets" />
+<Redirect to="/docs/orm/overview/databases/mongodb#how-to-use-mongodb-replica-sets" />
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated redirect links across error reference documentation pages to correct navigation paths. Changes affect five documentation pages covering Prisma migration errors (foreign keys, provider switching, conflict resolution, shadow database) and MongoDB replica set configuration, improving user navigation to relevant resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->