### PR TITLE
docs(prisma-postgres): clarify local vs managed Prisma init commands

### DIFF
--- a/content/100-getting-started/02-prisma-orm/100-quickstart/100-prisma-postgres.mdx
+++ b/content/100-getting-started/02-prisma-orm/100-quickstart/100-prisma-postgres.mdx
@@ -74,7 +74,13 @@ You can now invoke the Prisma CLI by prefixing it with `npx`:
 npx prisma
 ```
 
-Next, set up your Prisma ORM project by creating your [Prisma Schema](/orm/prisma-schema) file with the following command:
+Initialize Prisma locally (you manage Postgres yourself):
+
+```terminal
+npx prisma init
+```
+
+If you want Prisma to provision a managed Prisma Postgres database (online login + database creation), use:
 
 ```terminal
 npx prisma init --db --output ../generated/prisma


### PR DESCRIPTION

### Summary
Clarifies Prisma ORM initialization in the Prisma Postgres quickstart by separating local vs managed setup.

### Context
`npx prisma init --db ...` provisions a managed Prisma Postgres database (online login + database creation), while local/self-managed Postgres setups should use `npx prisma init`.

### Changes
- Updated section title to reflect local vs managed setup
- Added `npx prisma init` for local/self-managed Postgres
- Kept `npx prisma init --db --output ../generated/prisma` for managed Prisma Postgres provisioning

### Related
Fixes #7435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Postgres setup instructions in the getting started guide by distinguishing between two initialization options: local Postgres management and managed Prisma Postgres database provisioning. Updated instructions now explicitly outline both setup paths with separate code examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->