### PR TITLE
DR-6807 Documented `{ schema }` object for Postgres adapters in v7

### DIFF
--- a/content/200-orm/050-overview/500-databases/300-postgresql.mdx
+++ b/content/200-orm/050-overview/500-databases/300-postgresql.mdx
@@ -81,22 +81,47 @@ Notice that this code requires the `DATABASE_URL` environment variable to be set
 
 ### Notes
 
-#### Specifying a PostgreSQL schema
+#### Configuring the schema for Prisma queries (most common case)
 
-You can specify a [PostgreSQL schema](https://www.postgresql.org/docs/current/ddl-schemas.html) by passing in the `schema` option when instantiating `PrismaPg`:
+In Prisma 7, you configure the schema that Prisma uses when generating queries by passing a `schema` option when creating the `PrismaPg` instance. This is the recommended approach for most users who previously used the `schema` URL parameter in Prisma 6.
 
 ```ts
 const adapter = new PrismaPg(
   { connectionString },
-  { schema: 'myPostgresSchema' }
+  { schema: 'myPostgresSchema' } // Optional: specify the default schema
 )
 ```
+
+:::note
+**For Prisma 6 users**: In Prisma 6, you may have used a `?schema=` parameter in your connection URL. In Prisma 7, you must use the `schema` option shown above instead. This change makes the schema configuration more explicit and consistent across database adapters.
+:::
+
+#### Configuring the search path for raw SQL queries (less common case)
+
+If you need to set the search path for raw SQL queries (where you refer to tables without schema qualification), use PostgreSQL's native `options` parameter in your connection string. This is only necessary if you're using raw queries that reference tables without their schema name.
+
+```
+postgresql://user:pass@host:5432/db?options=-c%20search_path%3Dmyschemaname
+```
+
+or with the alternative syntax:
+
+```
+postgresql://user:pass@host:5432/db?options=--search_path%3Dmyschemaname
+```
+
+Both syntaxes are supported by the underlying `pg` driver. This approach is only needed for raw SQL queries - for Prisma Client queries, use the `schema` option shown above.
 
 ## Connection details
 
 ### Connection URL
 
-Prisma ORM follows the connection URL format specified by [PostgreSQL's official guidelines](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING), but does not support all arguments and includes additional arguments such as `schema`. Here's an overview of the components needed for a PostgreSQL connection URL:
+Prisma ORM follows the connection URL format specified by [PostgreSQL's official guidelines](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING). Note that in Prisma 7, the custom `schema` URL parameter that was available in Prisma 6 is no longer supported. Instead:
+
+1. For configuring the schema used by Prisma's query builder, use the `schema` option when creating the `PrismaPg` instance
+2. For setting the search path for raw SQL queries, use PostgreSQL's native `options` parameter in the connection URL
+
+Here's an overview of the components needed for a PostgreSQL connection URL:
 
 ![Structure of the PostgreSQL connection URL](./postgresql-connection-string.png)
 

--- a/content/200-orm/050-overview/500-databases/400-mysql.mdx
+++ b/content/200-orm/050-overview/500-databases/400-mysql.mdx
@@ -62,11 +62,14 @@ import 'dotenv/config'
 import { PrismaMariaDb } from '@prisma/adapter-mariadb'
 import { PrismaClient } from '../generated/prisma/client'
 
-const adapter = new PrismaMariaDb({
-  host: "localhost",
-  port: 3306,
-  connectionLimit: 5
-})
+const adapter = new PrismaMariaDb(
+  {
+    host: "localhost",
+    port: 3306,
+    connectionLimit: 5
+  },
+  { schema: 'mySchemaName' } // Optional: specify the default schema/database
+)
 const prisma = new PrismaClient({ adapter })
 ```
 

--- a/content/200-orm/050-overview/500-databases/800-sql-server/index.mdx
+++ b/content/200-orm/050-overview/500-databases/800-sql-server/index.mdx
@@ -81,7 +81,10 @@ const config = {
   },
 }
 
-const adapter = new PrismaMssql(config)
+const adapter = new PrismaMssql(
+  config,
+  { schema: 'mySchemaName' } // Optional: specify the default schema
+)
 const prisma = new PrismaClient({ adapter })
 ```
 

--- a/content/200-orm/050-overview/500-databases/890-neon.mdx
+++ b/content/200-orm/050-overview/500-databases/890-neon.mdx
@@ -153,12 +153,33 @@ You can then use Prisma Client as you normally would with full type-safety. Pris
 
 ### Notes
 
-#### Specifying a PostgreSQL schema
+#### Configuring the schema for Prisma queries (most common case)
 
-You can specify a [PostgreSQL schema](https://www.postgresql.org/docs/current/ddl-schemas.html) by passing in the `schema` option when instantiating `PrismaNeon`:
+In Prisma 7, you configure the schema that Prisma uses when generating queries by passing a `schema` option when creating the `PrismaNeon` instance. This is the recommended approach for most users who previously used the `schema` URL parameter in Prisma 6.
 
 ```ts
 const adapter = new PrismaNeon(
   { connectionString },
-  { schema: 'myPostgresSchema' })
+  { schema: 'myPostgresSchema' }  // Optional: specify the default schema
+)
 ```
+
+:::note
+**For Prisma 6 users**: In Prisma 6, you may have used a `?schema=` parameter in your connection URL. In Prisma 7, you must use the `schema` option shown above instead. This change makes the schema configuration more explicit and consistent across database adapters.
+:::
+
+#### Configuring the search path for raw SQL queries (less common case)
+
+If you need to set the search path for raw SQL queries (where you refer to tables without schema qualification), use PostgreSQL's native `options` parameter in your connection string. This is only necessary if you're using raw queries that reference tables without their schema name.
+
+```
+postgresql://user:pass@host:5432/db?options=-c%20search_path%3Dmyschemaname
+```
+
+or with the alternative syntax:
+
+```
+postgresql://user:pass@host:5432/db?options=--search_path%3Dmyschemaname
+```
+
+Both syntaxes are supported by the underlying `pg` driver. This approach is only needed for raw SQL queries - for Prisma Client queries, use the `schema` option shown above.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated schema configuration guides for PostgreSQL, MySQL/MariaDB, SQL Server, and Neon adapters.
  * Added Prisma 6 to Prisma 7 migration guidance.
  * Documented separate configuration approaches for standard queries and raw SQL operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->