### PR TITLE
Update database provider note in NestJS guide

### DIFF
--- a/content/800-guides/430-nestjs.mdx
+++ b/content/800-guides/430-nestjs.mdx
@@ -64,7 +64,7 @@ npm install @prisma/client @prisma/adapter-pg pg
 
 :::info
 
-If you are using a different database provider (PostgreSQL, MySQL, SQL Server), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/overview/databases/database-drivers).
+If you are using a different database provider (MySQL, SQL Server), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/overview/databases/database-drivers).
 
 :::
 


### PR DESCRIPTION
In the NestJS guide (section 2.1), the info block mentions PostgreSQL as an alternative database option. Since this specific guide is already built using PostgreSQL, listing it as an "alternative" is redundant and confusing for beginners. I have updated the text to clarify that other databases are supported, without listing the currently used database as an option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated NestJS guide to clarify the list of supported database driver adapters available for non-default providers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->