### PR TITLE
fix: DR-6879 Fix 404 dub link

### DIFF
--- a/content/200-orm/100-prisma-schema/10-overview/04-location.mdx
+++ b/content/200-orm/100-prisma-schema/10-overview/04-location.mdx
@@ -139,4 +139,4 @@ We've found that a few patterns work well with this feature and will help you ge
 
 ### Examples
 
-Our fork of [`dub` by dub.co](https://github.com/prisma/dub) is a great example of a real world project adapted to use a multi-file Prisma Schema.
+Our fork of [`dub` by dub.co](https://github.com/dubinc/dub/tree/main/packages/prisma) is a great example of a real world project adapted to use a multi-file Prisma Schema.


### PR DESCRIPTION
Update /orm/prisma-schema/overview/location to update 404 dub link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a code example URL in the Prisma schema overview documentation to reflect the current repository structure for multi-file schema usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->