### PR TITLE
Update Yaak instructions to use OAuth 2.0

### DIFF
--- a/content/800-guides/450-management-api-api-clients.mdx
+++ b/content/800-guides/450-management-api-api-clients.mdx
@@ -161,34 +161,49 @@ Before you begin, make sure you have:
 - A [Prisma Console account](https://console.prisma.io)
 - [Yaak installed](https://yaak.app)
 
-### 1. Create a service token
+### 1. Create an OAuth2 Application
 
-First, you'll need to generate a service token from Prisma Console:
+First, you'll need to register an OAuth2 application in Prisma Console:
 
 1. Navigate to [Prisma Console](https://console.prisma.io) and log in
-2. Select your workspace
-3. Go to **Settings → Service Tokens**
-4. Click **New Service Token**
-5. **Important**: Copy the generated token immediately and store it securely
+2. Click the **🧩 Integrations** tab in the left sidebar
+3. Under the "Published Applications" section, click **New Application**
+4. Fill in your application details:
+   - **Name**: Yaak API Client
+   - **Description**: Brief description of your application *(Optional)*
+   - **Redirect URI**: `https://yaak.app/oauth`
+5. Click **Continue**
+6. **Important**: Copy your Client ID and Client Secret immediately and store them securely
 
-### 2. Configure authentication in Yaak
+:::note
+The redirect URI can be any valid URL. Yaak intercepts the OAuth callback regardless of the redirect URI, as long as it matches what's registered with the provider.
+:::
+
+### 2. Configure OAuth 2.0 in Yaak
 
 Now you'll set up authentication in Yaak:
 
 1. Open Yaak and create a new HTTP request
 2. Set the request method to **POST**
 3. Set the URL to `https://api.prisma.io/v1/projects`
-4. Navigate to the **Headers** tab
-5. Add the following headers:
+4. Navigate to the **Auth** tab
+5. Set the authentication type to **OAuth 2.0**
+6. Enter the following values:
 
-| Header Name | Value |
+| Parameter | Value |
 | --- | --- |
-| Authorization | `Bearer your-service-token` |
-| Content-Type | `application/json` |
+| Grant Type | Authorization Code |
+| Authorization URL | `https://auth.prisma.io/authorize` |
+| Token URL | `https://auth.prisma.io/token` |
+| Client ID | `your-client-id` |
+| Client Secret | `your-client-secret` |
+| Redirect URL | `https://yaak.app/oauth` |
+| Scope | `workspace:admin` |
 
-:::note
-Replace `your-service-token` with the service token you generated in step 1. You can use Yaak's secure variable feature by clicking the **secure** option when entering the token value.
-:::
+7. Click **Get Token**
+8. A browser window will open and have you complete the authorization flow
+9. Return to Yaak and verify that the access token has been retrieved
+10. The token will be automatically attached to your requests
 
 ### 3. Make your first request
 

--- a/content/800-guides/450-management-api-api-clients.mdx
+++ b/content/800-guides/450-management-api-api-clients.mdx
@@ -153,7 +153,7 @@ You should receive a successful response confirming your project creation.
 
 ## Yaak
 
-Yaak is a lightweight, native API client focused on speed and a minimal interface.
+Yaak is a lightweight, open-source, and offline API client that works with Git.
 
 ### Prerequisites
 

--- a/content/800-guides/450-management-api-api-clients.mdx
+++ b/content/800-guides/450-management-api-api-clients.mdx
@@ -171,7 +171,7 @@ First, you'll need to register an OAuth2 application in Prisma Console:
 4. Fill in your application details:
    - **Name**: Yaak API Client
    - **Description**: Brief description of your application *(Optional)*
-   - **Redirect URI**: `https://yaak.app/oauth`
+   - **Redirect URI**: `https://yaak.app/x/ok`
 5. Click **Continue**
 6. **Important**: Copy your Client ID and Client Secret immediately and store them securely
 
@@ -197,7 +197,7 @@ Now you'll set up authentication in Yaak:
 | Token URL | `https://auth.prisma.io/token` |
 | Client ID | `your-client-id` |
 | Client Secret | `your-client-secret` |
-| Redirect URL | `https://yaak.app/oauth` |
+| Redirect URL | `https://yaak.app/x/ok` |
 | Scope | `workspace:admin` |
 
 7. Click **Get Token**

--- a/content/800-guides/450-management-api-api-clients.mdx
+++ b/content/800-guides/450-management-api-api-clients.mdx
@@ -171,7 +171,7 @@ First, you'll need to register an OAuth2 application in Prisma Console:
 4. Fill in your application details:
    - **Name**: Yaak API Client
    - **Description**: Brief description of your application *(Optional)*
-   - **Redirect URI**: `https://yaak.app/x/ok`
+   - **Redirect URI**: `https://devnull.yaak.app/callback`
 5. Click **Continue**
 6. **Important**: Copy your Client ID and Client Secret immediately and store them securely
 
@@ -197,7 +197,7 @@ Now you'll set up authentication in Yaak:
 | Token URL | `https://auth.prisma.io/token` |
 | Client ID | `your-client-id` |
 | Client Secret | `your-client-secret` |
-| Redirect URL | `https://yaak.app/x/ok` |
+| Redirect URL | `https://devnull.yaak.app/callback` |
 | Scope | `workspace:admin` |
 
 7. Click **Get Token**


### PR DESCRIPTION
Hey! I just saw Prisma [post on X](https://x.com/prisma/status/2014277365820735577) about using [Yaak](https://yaak.app) with the Prisma Postgres Management API.

I noticed the Yaak instructions, however, used a Bearer token while the Postman and Insomnia instructions used OAuth 2.0.

Since Yaak also supports OAuth 2.0, I figured I'd update the docs to match, so here's the edit!

I also gave it a test to ensure everything worked:

<img width="2044" height="1266" alt="CleanShot 2026-01-22 at 13 47 11" src="https://github.com/user-attachments/assets/4ca19cf4-b1c3-4189-9288-7dc0aa3f321f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced service-token guidance with a full OAuth 2.0 application workflow and registration steps.
  * Added detailed OAuth configuration and UI steps (authorization/token URLs, grant type, client ID/secret, redirect handling, token retrieval).
  * Updated Yaak client description, usage notes, and example payloads/region names to reflect the OAuth-based flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->