### PR TITLE
Docs Issue 7455: add 'export' keyword to code snippet

### DIFF
--- a/apps/docs/content/docs/guides/upgrade-prisma-orm/v7.mdx
+++ b/apps/docs/content/docs/guides/upgrade-prisma-orm/v7.mdx
@@ -168,7 +168,7 @@ import { PrismaPg } from "@prisma/adapter-pg";
 const adapter = new PrismaPg({
   connectionString: process.env.DATABASE_URL,
 });
-const prisma = new PrismaClient({ adapter });
+export const prisma = new PrismaClient({ adapter });
 ```
 
 If you are using SQLite, you can use the `@prisma/adapter-better-sqlite3`:


### PR DESCRIPTION
Resolves https://github.com/prisma/docs/issues/7455

In this code snippet https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-7#after-1, the last line is missing the export keyword.

Currently:

```
import { PrismaClient } from './generated/prisma/client'; import { PrismaPg } from '@prisma/adapter-pg';

const adapter = new PrismaPg({ 
  connectionString: process.env.DATABASE_URL 
});
const prisma = new PrismaClient({ adapter });
```

Proposed change:

```
import { PrismaClient } from './generated/prisma/client'; import { PrismaPg } from '@prisma/adapter-pg';

const adapter = new PrismaPg({ 
  connectionString: process.env.DATABASE_URL 
});
export const prisma = new PrismaClient({ adapter });
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma 7 upgrade guide with corrected code examples demonstrating the recommended approach for client instantiation and configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->