### PR TITLE
docs: Update seeding example to require adapter in Prisma ORM v7

### DIFF
--- a/apps/docs/content/docs/orm/prisma-migrate/workflows/seeding.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/workflows/seeding.mdx
@@ -68,9 +68,20 @@ model Post {
 
 Create some new users and posts in your `prisma/seed.ts` file:
 
+:::info[Prisma ORM v7 requirement]
+In Prisma ORM v7, `PrismaClient` must be initialized with a driver adapter. The example below uses `@prisma/adapter-pg` with a PostgreSQL connection pool.
+:::
+
 ```js title="seed.ts"
+import "dotenv/config";
+import { Pool } from "pg";
+import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "../prisma/generated/client";
-const prisma = new PrismaClient();
+
+const connectionString = `${process.env.DATABASE_URL}`;
+const pool = new Pool({ connectionString });
+const adapter = new PrismaPg(pool);
+const prisma = new PrismaClient({ adapter });
 async function main() {
   const alice = await prisma.user.upsert({
     where: { email: "alice@prisma.io" },
@@ -114,18 +125,20 @@ async function main() {
 main()
   .then(async () => {
     await prisma.$disconnect();
+    await pool.end();
   })
   .catch(async (e) => {
     console.error(e);
     await prisma.$disconnect();
+    await pool.end();
     process.exit(1);
   });
 ```
 
-- Add `typescript`, `tsx` and `@types/node` development dependencies:
+- Add `typescript`, `tsx`, `@types/node`, `@prisma/adapter-pg`, `pg`, `@types/pg` and `dotenv` development dependencies:
 
 ```npm
-npm install -D typescript tsx @types/node
+npm install -D typescript tsx @types/node @prisma/adapter-pg pg @types/pg dotenv
 ```
 
 - Add the `seed` field to your `prisma.config.ts` file:
@@ -176,10 +189,12 @@ main()
   .then(rawSql)
   .then(async () => {
     await prisma.$disconnect();
+    await pool.end();
   })
   .catch(async (e) => {
     console.error(e);
     await prisma.$disconnect();
+    await pool.end();
     process.exit(1);
   });
 ```


### PR DESCRIPTION
## Summary

This PR updates the seeding documentation to reflect that Prisma ORM v7 requires an `adapter` or `accelerateUrl` option when initializing PrismaClient.

## Changes

- Updated `seed.ts` example to include adapter initialization using `@prisma/adapter-pg`
- Added info callout explaining the v7 requirement
- Updated dependency installation command to include `@prisma/adapter-pg`, `pg`, and `dotenv`

## Background

In Prisma ORM v7, running `new PrismaClient()` without options throws:
```
PrismaClientInitializationError: PrismaClient needs to be constructed with a non-empty, valid PrismaClientOptions
```

This is a breaking change from v6 that is not currently documented in the seeding guide, causing confusion for developers migrating to v7.

## Related Issues

- Related to the v7 migration guide
- Addresses common `PrismaClientInitializationError` when running `prisma db seed`

## Testing

Tested with:
- Prisma ORM v7.3.0
- PostgreSQL 18
- `@prisma/adapter-pg` v7.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated seeding workflow to showcase Prisma v7 adapter-based seeding with connection pooling.
  * Added guidance for proper pool lifecycle/shutdown in both success and error paths.
  * Expanded examples for both JavaScript and TypeScript seeds and environment configuration.
  * Documented new public usage pattern and required development dependencies for adapter-enabled seeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->