### PR TITLE
feat(docs): add JSON-LD structured data for rich snippets

### DIFF
--- a/apps/docs/src/app/(docs)/(default)/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/(docs)/(default)/[[...slug]]/page.tsx
@@ -12,6 +12,7 @@ import {
   EditOnGitHub,
   PageLastUpdate,
 } from '@/components/layout/notebook/page';
+import { TechArticleSchema, BreadcrumbSchema } from '@/components/structured-data';
 
 interface PageParams {
   slug?: string[];
@@ -29,25 +30,28 @@ export default async function Page({
   const MDX = page.data.body;
 
   return (
-    <DocsPage
-      tableOfContent={{
-        style: 'normal',
-      }}
-      toc={page.data.toc}
-      full={page.data.full}
-    >
-      <div className="flex flex-col md:flex-row items-start gap-4 pt-2 pb-1 md:justify-between">
-        <DocsTitle>{page.data.title}</DocsTitle>
-        <div className="flex flex-row gap-2 items-center">
-          {!page.url.startsWith('/management-api/endpoints') && (
-            <LLMCopyButton pageUrl={page.url} />
-          )}
-          <ViewOptions
-            pageUrl={page.url}
-            githubUrl={`https://github.com/prisma/docs/blob/main/apps/docs/content/docs/${page.path}`}
-          />
+    <>
+      <TechArticleSchema page={page} />
+      <BreadcrumbSchema page={page} />
+      <DocsPage
+        tableOfContent={{
+          style: 'normal',
+        }}
+        toc={page.data.toc}
+        full={page.data.full}
+      >
+        <div className="flex flex-col md:flex-row items-start gap-4 pt-2 pb-1 md:justify-between">
+          <DocsTitle>{page.data.title}</DocsTitle>
+          <div className="flex flex-row gap-2 items-center">
+            {!page.url.startsWith('/management-api/endpoints') && (
+              <LLMCopyButton pageUrl={page.url} />
+            )}
+            <ViewOptions
+              pageUrl={page.url}
+              githubUrl={`https://github.com/prisma/docs/blob/main/apps/docs/content/docs/${page.path}`}
+            />
+          </div>
         </div>
-      </div>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>
         <MDX
@@ -67,6 +71,7 @@ export default async function Page({
         )}
       </div>
     </DocsPage>
+    </>
   );
 }
 

--- a/apps/docs/src/app/(docs)/v6/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/(docs)/v6/[[...slug]]/page.tsx
@@ -17,6 +17,7 @@ import {
   EditOnGitHub,
   PageLastUpdate,
 } from '@/components/layout/notebook/page';
+import { TechArticleSchema, BreadcrumbSchema } from '@/components/structured-data';
 
 interface PageParams {
   version: string;
@@ -36,13 +37,16 @@ export default async function Page({
   const MDX = page.data.body;
 
   return (
-    <DocsPage
-      tableOfContent={{ style: 'normal' }}
-      toc={page.data.toc}
-      full={page.data.full}
-    >
-      <div className="flex flex-row items-center gap-4 pt-2 pb-6 justify-between">
-        <DocsTitle>{page.data.title}</DocsTitle>
+    <>
+      <TechArticleSchema page={page} />
+      <BreadcrumbSchema page={page} />
+      <DocsPage
+        tableOfContent={{ style: 'normal' }}
+        toc={page.data.toc}
+        full={page.data.full}
+      >
+        <div className="flex flex-row items-center gap-4 pt-2 pb-6 justify-between">
+          <DocsTitle>{page.data.title}</DocsTitle>
         <div className="flex flex-row gap-2 items-center">
           <LLMCopyButton pageUrl={page.url} />
           <ViewOptions
@@ -73,6 +77,7 @@ export default async function Page({
         )}
       </div>
     </DocsPage>
+    </>
   );
 }
 

--- a/apps/docs/src/components/structured-data.tsx
+++ b/apps/docs/src/components/structured-data.tsx
@@ -40,7 +40,7 @@ export function TechArticleSchema({ page }: StructuredDataProps) {
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema).replace(/</g, '\\u003c') }}
     />
   );
 }

--- a/apps/docs/src/components/structured-data.tsx
+++ b/apps/docs/src/components/structured-data.tsx
@@ -1,0 +1,84 @@
+import { getBaseUrl } from '@/lib/urls';
+import type { InferPageType } from 'fumadocs-core/source';
+import type { source } from '@/lib/source';
+
+interface StructuredDataProps {
+  page: InferPageType<typeof source>;
+}
+
+export function TechArticleSchema({ page }: StructuredDataProps) {
+  const baseUrl = getBaseUrl();
+  const lastModified = (page.data as { lastModified?: Date }).lastModified;
+
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: page.data.metaTitle,
+    description: page.data.metaDescription,
+    url: `${baseUrl}${page.url}`,
+    dateModified: lastModified?.toISOString(),
+    author: {
+      '@type': 'Organization',
+      name: 'Prisma Data, Inc.',
+      url: 'https://www.prisma.io',
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Prisma',
+      url: 'https://www.prisma.io',
+      logo: {
+        '@type': 'ImageObject',
+        url: `${baseUrl}/logo.png`,
+      },
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `${baseUrl}${page.url}`,
+    },
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}
+
+export function BreadcrumbSchema({ page }: StructuredDataProps) {
+  const baseUrl = getBaseUrl();
+
+  // Build breadcrumb items from URL slugs
+  const breadcrumbItems = [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Home',
+      item: baseUrl,
+    },
+  ];
+
+  let currentPath = '';
+  page.slugs.forEach((slug, index) => {
+    currentPath += `/${slug}`;
+    breadcrumbItems.push({
+      '@type': 'ListItem',
+      position: index + 2,
+      name: slug.charAt(0).toUpperCase() + slug.slice(1).replace(/-/g, ' '),
+      item: `${baseUrl}${currentPath}`,
+    });
+  });
+
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: breadcrumbItems,
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}

--- a/apps/docs/src/components/structured-data.tsx
+++ b/apps/docs/src/components/structured-data.tsx
@@ -78,7 +78,7 @@ export function BreadcrumbSchema({ page }: StructuredDataProps) {
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema).replace(/</g, '\\u003c') }}
     />
   );
 }

--- a/apps/docs/src/components/structured-data.tsx
+++ b/apps/docs/src/components/structured-data.tsx
@@ -1,9 +1,9 @@
 import { getBaseUrl } from '@/lib/urls';
 import type { InferPageType } from 'fumadocs-core/source';
-import type { source } from '@/lib/source';
+import type { source, sourceV6 } from '@/lib/source';
 
 interface StructuredDataProps {
-  page: InferPageType<typeof source>;
+  page: InferPageType<typeof source> | InferPageType<typeof sourceV6>;
 }
 
 export function TechArticleSchema({ page }: StructuredDataProps) {
@@ -13,8 +13,8 @@ export function TechArticleSchema({ page }: StructuredDataProps) {
   const schema = {
     '@context': 'https://schema.org',
     '@type': 'TechArticle',
-    headline: page.data.metaTitle,
-    description: page.data.metaDescription,
+    headline: (page.data as any).metaTitle ?? page.data.title,
+    description: (page.data as any).metaDescription ?? page.data.description,
     url: `${baseUrl}${page.url}`,
     dateModified: lastModified?.toISOString(),
     author: {


### PR DESCRIPTION
Added TechArticle and BreadcrumbList JSON-LD schemas to all documentation pages for Google rich snippet eligibility.

**Changes:**
- Created `structured-data.tsx` component
- Added schemas to v7 and v6 page templates
- Enables rich snippets with article metadata and breadcrumb trails in search results

**Test:**
```bash
pnpm dev
# Visit http://localhost:3000/orm
# View source → search "application/ld+json"
# Should see 2 script tags with structured data
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured-data (JSON-LD) to docs pages: article metadata (title, description, author, publish/updated dates).
  * Added breadcrumb structured-data to represent hierarchical page navigation for richer search previews and improved indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->