### PR TITLE
feat(docs): add frontmatter to `llms.mdx`

### DIFF
--- a/apps/docs/src/app/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/src/app/llms.mdx/[[...slug]]/route.ts
@@ -4,6 +4,11 @@ import { notFound } from "next/navigation";
 
 export const revalidate = false;
 
+function escapeYaml(value: string): string {
+  // Wrap in double quotes and escape special characters
+  return '"' + value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r') + '"';
+}
+
 export async function GET(_req: Request, { params }: RouteContext<"/llms.mdx/[[...slug]]">) {
   const { slug } = await params;
   const page = source.getPage(slug) || sourceV6.getPage(slug);
@@ -11,9 +16,9 @@ export async function GET(_req: Request, { params }: RouteContext<"/llms.mdx/[[.
 
   const content = await getLLMText(page);
   const frontmatter = `---
-title: ${page.data.title}
-description: ${page.data.description || ''}
-url: ${page.url}
+title: ${escapeYaml(page.data.title)}
+description: ${escapeYaml(page.data.description || '')}
+url: ${escapeYaml(page.url)}
 ---
 
 `;

--- a/apps/docs/src/app/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/src/app/llms.mdx/[[...slug]]/route.ts
@@ -30,7 +30,15 @@ export function generateStaticParams() {
   // A slug is considered non-leaf if it is a prefix of any other slug.
   const v7Params = source.generateParams();
   const v6Params = sourceV6.generateParams();
-  const allParams = [...v7Params, ...v6Params];
+
+  // Deduplicate identical slugs from v7 and v6
+  const seen = new Set<string>();
+  const allParams = [...v7Params, ...v6Params].filter((p) => {
+    const key = JSON.stringify(p.slug ?? []);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 
   const allSlugs = allParams.map((p) => p.slug ?? []);
   const isPrefix = (a: string[], b: string[]) =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation pages now prepend generated frontmatter (title, description, URL) to content for more consistent rendering.

* **Improvements**
  * Docs build now merges content from multiple source versions with deduplication and leaf-page filtering, improving coverage and backward compatibility.
  * Static page parameter generation is now deterministic and returned synchronously, streamlining the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->