### PR TITLE
fix: properly redirect

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -5,7 +5,7 @@ const withMDX = createMDX();
 
 /** @type {import('next').NextConfig} */
 const config = {
-  basePath: '/docs/', // if serving under /docs path
+  basePath: '/docs', // if serving under /docs path
   reactStrictMode: true,
   images: { unoptimized: true },
   transpilePackages: ['@prisma-docs/eclipse'],

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -1,5 +1,5 @@
-import { withSentryConfig } from "@sentry/nextjs";
-import { createMDX } from "fumadocs-mdx/next";
+import { withSentryConfig } from '@sentry/nextjs';
+import { createMDX } from 'fumadocs-mdx/next';
 
 const withMDX = createMDX();
 
@@ -7,7 +7,7 @@ const withMDX = createMDX();
 const config = {
   reactStrictMode: true,
   images: { unoptimized: true },
-  transpilePackages: ["@prisma-docs/eclipse"],
+  transpilePackages: ['@prisma-docs/eclipse'],
   experimental: {
     globalNotFound: true,
   },
@@ -15,15 +15,23 @@ const config = {
   // Only enable when this deployment is the subdomain proxy; leave unset when this app is used as DOCS_ORIGIN (e.g. *.vercel.app) to avoid a loop.
   // For local testing: ENABLE_DOCS_SUBDOMAIN_PROXY=1 and DOCS_PROXY_TARGET=http://localhost:<WEBSITE_PORT>/docs (website must be running on that port)
   async rewrites() {
-    if (process.env.ENABLE_DOCS_SUBDOMAIN_PROXY !== "1") {
+    if (process.env.ENABLE_DOCS_SUBDOMAIN_PROXY !== '1') {
       return [];
     }
-    const base =
-      process.env.DOCS_PROXY_TARGET ?? "https://prisma.io/docs";
+    const base = process.env.DOCS_PROXY_TARGET ?? 'https://prisma.io/docs';
     return [
       {
-        source: "/:path*",
-        destination: `${base.replace(/\/$/, "")}/:path*`,
+        source: '/:path*',
+        destination: `${base.replace(/\/$/, '')}/:path*`,
+      },
+    ];
+  },
+  async redirects() {
+    return [
+      {
+        source: '/:path*',
+        destination: 'https://prisma.io/docs/:path*',
+        permanent: true, // 308
       },
     ];
   },
@@ -33,13 +41,13 @@ export default withSentryConfig(withMDX(config), {
   // For all available options, see:
   // https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
-  org: "prisma-ch",
+  org: 'prisma-ch',
 
-  project: "javascript-nextjs",
+  project: 'javascript-nextjs',
 
   authToken: process.env.SENTRY_AUTH_TOKEN,
-  tunnelRoute: "/monitoring",
-  
+  tunnelRoute: '/monitoring',
+
   // Only print logs for uploading source maps in CI\
   silent: !process.env.CI,
 

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -5,7 +5,6 @@ const withMDX = createMDX();
 
 /** @type {import('next').NextConfig} */
 const config = {
-  assetPrefix: 'https://docs.prisma.io',
   basePath: '/docs', // if serving under /docs path
   reactStrictMode: true,
   images: { unoptimized: true },

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -5,7 +5,7 @@ const withMDX = createMDX();
 
 /** @type {import('next').NextConfig} */
 const config = {
-  basePath: '/docs', // if serving under /docs path
+  basePath: '/docs/', // if serving under /docs path
   reactStrictMode: true,
   images: { unoptimized: true },
   transpilePackages: ['@prisma-docs/eclipse'],

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -5,6 +5,8 @@ const withMDX = createMDX();
 
 /** @type {import('next').NextConfig} */
 const config = {
+  assetPrefix: 'https://docs.prisma.io',
+  basePath: '/docs', // if serving under /docs path
   reactStrictMode: true,
   images: { unoptimized: true },
   transpilePackages: ['@prisma-docs/eclipse'],

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -5,30 +5,16 @@ const withMDX = createMDX();
 
 /** @type {import('next').NextConfig} */
 const config = {
-  basePath: '/docs', // if serving under /docs path
+  basePath: process.env.NODE_ENV === 'production' ? '/docs' : '', // if serving under /docs path
   reactStrictMode: true,
   images: { unoptimized: true },
   transpilePackages: ['@prisma-docs/eclipse'],
   experimental: {
     globalNotFound: true,
   },
-  // docs.prisma.io: proxy all requests to prisma.io/docs/... (browser stays on docs.prisma.io).
-  // Only enable when this deployment is the subdomain proxy; leave unset when this app is used as DOCS_ORIGIN (e.g. *.vercel.app) to avoid a loop.
-  // For local testing: ENABLE_DOCS_SUBDOMAIN_PROXY=1 and DOCS_PROXY_TARGET=http://localhost:<WEBSITE_PORT>/docs (website must be running on that port)
-  async rewrites() {
-    if (process.env.ENABLE_DOCS_SUBDOMAIN_PROXY !== '1') {
-      return [];
-    }
-    const base = process.env.DOCS_PROXY_TARGET ?? 'https://prisma.io/docs';
-    return [
-      {
-        source: '/:path*',
-        destination: `${base.replace(/\/$/, '')}/:path*`,
-      },
-    ];
-  },
+  // docs.prisma.io: in production, redirect all requests to prisma.io/docs (browser navigates to prisma.io).
   async redirects() {
-    if (process.env.ENABLE_DOCS_SUBDOMAIN_PROXY === '1') {
+    if (process.env.NODE_ENV !== 'production') {
       return [];
     }
     return [

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -28,11 +28,14 @@ const config = {
     ];
   },
   async redirects() {
+    if (process.env.ENABLE_DOCS_SUBDOMAIN_PROXY === '1') {
+      return [];
+    }
     return [
       {
         source: '/:path*',
         destination: 'https://prisma.io/docs/:path*',
-        permanent: true, // 308
+        permanent: false, // use 307 until you've verified the behavior
       },
     ];
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation is served under a /docs base path in production.
  * Production now redirects all doc paths to the main docs site (non-permanent); in non-production, no redirects are added.

* **Chores**
  * Configuration and formatting normalization (quotes, spacing) and small Sentry config string updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->