### PR TITLE
docs: Refactor userWithPosts and userPersonalData definitions

### DIFF
--- a/apps/docs/content/docs/orm/prisma-client/type-safety/operating-against-partial-structures-of-model-types.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/type-safety/operating-against-partial-structures-of-model-types.mdx
@@ -76,13 +76,9 @@ import { Prisma } from "@prisma/client";
 
 // 1: Define a type that includes the relation to `Post`
 const userWithPosts = { include: { posts: true } } satisfies Prisma.UserDefaultArgs;
-  include: { posts: true },
-});
 
 // 2: Define a type that only contains a subset of the scalar fields
 const userPersonalData = { select: { email: true, name: true } } satisfies Prisma.UserDefaultArgs;
-  select: { email: true, name: true },
-});
 
 // 3: This type will include a user and all their posts
 type UserWithPosts = Prisma.UserGetPayload<typeof userWithPosts>;


### PR DESCRIPTION
## Description.

Fix the documentation: [Problem: Using variations of the generated model type](https://www.prisma.io/docs/orm/prisma-client/type-safety/operating-against-partial-structures-of-model-types#problem-using-variations-of-the-generated-model-type)

## Changes.

Removed unnecessary object syntax from `userWithPosts` and `userPersonalData` definitions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified code examples in type-safety documentation by removing redundant lines from object literal closures. Examples now more clearly demonstrate type construction patterns while maintaining accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->