### PR TITLE
fix(docs): Fix frontpage card links

### DIFF
--- a/apps/docs/content/docs/(index)/index.mdx
+++ b/apps/docs/content/docs/(index)/index.mdx
@@ -20,11 +20,11 @@ npx create-db
 
 
 <Cards>
-  <Card href="/prisma-orm/quickstart/prisma-postgres" title="Use Prisma Postgres" icon={<div className="text-primary"><svg xmlns="http://www.w3.org/2000/svg" width="159" height="195" viewBox="0 0 640 640" fill="none"><path d="M355.2 85C348.2 72.1 334.7 64 320 64C305.3 64 291.8 72.1 284.8 85L209.7 224L430.2 224L355.1 85zM123.3 384L516.6 384L456.1 272L183.7 272L123.2 384zM97.4 432L68.8 485C62.1 497.4 62.4 512.4 69.6 524.5C76.8 536.6 89.9 544 104 544L536 544C550.1 544 563.1 536.6 570.4 524.5C577.7 512.4 577.9 497.4 571.2 485L542.6 432L97.4 432z" fill="currentColor"/></svg></div>
+  <Card href="/docs/prisma-orm/quickstart/prisma-postgres" title="Use Prisma Postgres" icon={<div className="text-primary"><svg xmlns="http://www.w3.org/2000/svg" width="159" height="195" viewBox="0 0 640 640" fill="none"><path d="M355.2 85C348.2 72.1 334.7 64 320 64C305.3 64 291.8 72.1 284.8 85L209.7 224L430.2 224L355.1 85zM123.3 384L516.6 384L456.1 272L183.7 272L123.2 384zM97.4 432L68.8 485C62.1 497.4 62.4 512.4 69.6 524.5C76.8 536.6 89.9 544 104 544L536 544C550.1 544 563.1 536.6 570.4 524.5C577.7 512.4 577.9 497.4 571.2 485L542.6 432L97.4 432z" fill="currentColor"/></svg></div>
 }>
     **Need a database?** Get started with your favorite framework and Prisma Postgres.
   </Card>
-  <Card href="/prisma-postgres/quickstart/prisma-orm" title="Bring your own database" icon={<Database className="text-primary" />}>
+  <Card href="/docs/prisma-postgres/quickstart/prisma-orm" title="Bring your own database" icon={<Database className="text-primary" />}>
     **Already have a database?** Use Prisma ORM for a type-safe developer experience and automated migrations.
   </Card>
 </Cards>


### PR DESCRIPTION
* Card links on frontpage were missing "`/docs`" prefix and would 404
* This PR adds that prefix so that the correct pages are linked


## How to test 

* Run locally: `pnpm dev`
* Open docs front page: http://localhost:3000/docs
* Verify that the clicking the card links "*Use Prisma Postgres*" and "*Bring your own database*" works


## Screenshots 

<details><summary>Click to expand screenshots</summary>
<p>

Card links: 

<img width="1028" height="1027" alt="image" src="https://github.com/user-attachments/assets/0794365b-a526-4d34-8a05-2f5d435181a3" />


Prisma postgres link 404s on prod:

<img width="1072" height="1071" alt="image" src="https://github.com/user-attachments/assets/f988701f-1026-4f03-9171-42750b5bef7d" />
 

</p>
</details> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed broken documentation navigation links to resolve routing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->