### PR TITLE
fix(docs): fix broken links in getting started page

### DIFF
--- a/apps/docs/content/docs/(index)/index.mdx
+++ b/apps/docs/content/docs/(index)/index.mdx
@@ -20,11 +20,11 @@ npx create-db
 
 
 <Cards>
-  <Card href="/prisma-orm/quickstart/prisma-postgres" title="Use Prisma Postgres" icon={<div className="text-primary"><svg xmlns="http://www.w3.org/2000/svg" width="159" height="195" viewBox="0 0 640 640" fill="none"><path d="M355.2 85C348.2 72.1 334.7 64 320 64C305.3 64 291.8 72.1 284.8 85L209.7 224L430.2 224L355.1 85zM123.3 384L516.6 384L456.1 272L183.7 272L123.2 384zM97.4 432L68.8 485C62.1 497.4 62.4 512.4 69.6 524.5C76.8 536.6 89.9 544 104 544L536 544C550.1 544 563.1 536.6 570.4 524.5C577.7 512.4 577.9 497.4 571.2 485L542.6 432L97.4 432z" fill="currentColor"/></svg></div>
+  <Card href="/docs/prisma-orm/quickstart/prisma-postgres" title="Use Prisma Postgres" icon={<div className="text-primary"><svg xmlns="http://www.w3.org/2000/svg" width="159" height="195" viewBox="0 0 640 640" fill="none"><path d="M355.2 85C348.2 72.1 334.7 64 320 64C305.3 64 291.8 72.1 284.8 85L209.7 224L430.2 224L355.1 85zM123.3 384L516.6 384L456.1 272L183.7 272L123.2 384zM97.4 432L68.8 485C62.1 497.4 62.4 512.4 69.6 524.5C76.8 536.6 89.9 544 104 544L536 544C550.1 544 563.1 536.6 570.4 524.5C577.7 512.4 577.9 497.4 571.2 485L542.6 432L97.4 432z" fill="currentColor"/></svg></div>
 }>
     **Need a database?** Get started with your favorite framework and Prisma Postgres.
   </Card>
-  <Card href="/prisma-postgres/quickstart/prisma-orm" title="Bring your own database" icon={<Database className="text-primary" />}>
+  <Card href="/docs/prisma-postgres/quickstart/prisma-orm" title="Bring your own database" icon={<Database className="text-primary" />}>
     **Already have a database?** Use Prisma ORM for a type-safe developer experience and automated migrations.
   </Card>
 </Cards>


### PR DESCRIPTION
Issue: #7524

**Problem:**
In the [getting started page](https://www.prisma.io/docs) of docs, clicking the two buttons "Use Prisma Prostgres" and ""Bring your own database" at the end of the content, redirect in 404 page.

**Solution:**
I added the missing "docs/" directory in the path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to point to correct paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->