### PR TITLE
fix(docs): align open markdown links with llms routing

### DIFF
--- a/apps/docs/src/app/docs/(default)/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/(default)/[[...slug]]/page.tsx
@@ -43,9 +43,7 @@ export default async function Page({
         <div className="flex flex-col md:flex-row items-start gap-4 pt-2 pb-1 md:justify-between">
           <DocsTitle>{page.data.title}</DocsTitle>
           <div className="flex flex-row gap-2 items-center">
-            {/* {!page.url.startsWith('/management-api/endpoints') && ( */}
-            {/*   <LLMCopyButton markdownUrl={`${page.url}.mdx`} /> */}
-            {/* )} */}
+            <LLMCopyButton markdownUrl={`${page.url}.mdx`} />
             <ViewOptions
               markdownUrl={`${page.url}.mdx`}
               githubUrl={`https://github.com/prisma/docs/blob/main/apps/docs/content/docs/${page.path}`}

--- a/apps/docs/src/app/docs/(default)/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/(default)/[[...slug]]/page.tsx
@@ -47,7 +47,7 @@ export default async function Page({
             {/*   <LLMCopyButton markdownUrl={`${page.url}.mdx`} /> */}
             {/* )} */}
             <ViewOptions
-              pageUrl={page.url}
+              markdownUrl={`${page.url}.mdx`}
               githubUrl={`https://github.com/prisma/docs/blob/main/apps/docs/content/docs/${page.path}`}
             />
           </div>

--- a/apps/docs/src/app/docs/v6/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/v6/[[...slug]]/page.tsx
@@ -49,7 +49,7 @@ export default async function Page({
         <div className="flex flex-row items-center gap-4 pt-2 pb-6 justify-between">
           <DocsTitle>{page.data.title}</DocsTitle>
         <div className="flex flex-row gap-2 items-center">
-          {/* <LLMCopyButton markdownUrl={`${page.url}.mdx`} /> */}
+          <LLMCopyButton markdownUrl={`${page.url}.mdx`} />
           <ViewOptions
             markdownUrl={`${page.url}.mdx`}
             githubUrl={`https://github.com/prisma/docs/blob/main/content/docs/${page.path}`}

--- a/apps/docs/src/app/docs/v6/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/docs/v6/[[...slug]]/page.tsx
@@ -51,7 +51,7 @@ export default async function Page({
         <div className="flex flex-row gap-2 items-center">
           {/* <LLMCopyButton markdownUrl={`${page.url}.mdx`} /> */}
           <ViewOptions
-            pageUrl={page.url}
+            markdownUrl={`${page.url}.mdx`}
             githubUrl={`https://github.com/prisma/docs/blob/main/content/docs/${page.path}`}
           />
         </div>

--- a/apps/docs/src/components/page-actions.tsx
+++ b/apps/docs/src/components/page-actions.tsx
@@ -104,13 +104,13 @@ const optionVariants = cva(
 );
 
 export function ViewOptions({
-  pageUrl,
+  markdownUrl,
   githubUrl,
 }: {
   /**
-   * The page URL path (e.g., /guides/getting-started)
+   * A URL to the raw Markdown/MDX content of page
    */
-  pageUrl: string;
+  markdownUrl: string;
 
   /**
    * Source file URL on GitHub
@@ -118,7 +118,6 @@ export function ViewOptions({
   githubUrl: string;
 }) {
   const items = useMemo(() => {
-    const markdownUrl = `/mdx${pageUrl}`;
     const fullMarkdownUrl =
       typeof window !== 'undefined'
         ? new URL(markdownUrl, window.location.origin)
@@ -179,7 +178,7 @@ export function ViewOptions({
         icon: <MessageCircleIcon />,
       },
     ];
-  }, [githubUrl, pageUrl]);
+  }, [githubUrl, markdownUrl]);
 
   return (
     <Popover>


### PR DESCRIPTION
## Summary
- switch Open menu to use explicit markdown URLs (page.url + .mdx), matching Fumadocs scaffold behavior
- update v7 and v6 docs pages to pass markdownUrl into ViewOptions
- make /llms.mdx/[[...slug]] resolve v6-prefixed slugs and generate v6 static params with v6 prefix

## Why
- fixes mismatch between Open-menu markdown links and app routing
- ensures v6 markdown URLs can be resolved via llms route behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The copy-to-clipboard button for page markdown is now always available.

* **Bug Fixes**
  * Markdown view options now consistently use the correct markdown link so copy/view actions work reliably.

* **Refactor**
  * Improved page resolution and routing generation for v6 content to ensure consistent access and pre-rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->