### PR TITLE
fix(docs): add missing frontmatter for deno guide

### DIFF
--- a/apps/docs/content/docs/guides/runtimes/deno.mdx
+++ b/apps/docs/content/docs/guides/runtimes/deno.mdx
@@ -2,6 +2,8 @@
 title: Deno
 description: Learn how to use Prisma ORM in a Deno application with Prisma Postgres
 url: /guides/runtimes/deno
+metaTitle: How to use Prisma ORM and Prisma Postgres with Deno
+metaDescription: Learn how to use Prisma ORM in a Deno application with Prisma Postgres
 ---
 
 ## Introduction


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added metaTitle and metaDescription front-matter to the Deno guide; updates improve metadata used for search, preview cards, and content indexing, enhancing discoverability and how the guide appears in external listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->