### PR TITLE
fix: `wrangler d1 execute` argument name

### DIFF
--- a/apps/docs/content/docs/guides/deployment/cloudflare-d1.mdx
+++ b/apps/docs/content/docs/guides/deployment/cloudflare-d1.mdx
@@ -191,10 +191,10 @@ Now apply the migration to both your local and remote D1 databases using Wrangle
 
 ```bash
 # Apply to local database
-npx wrangler d1 execute __YOUR_D1_DATABASE_NAME__ --local --title="./prisma/migrations/0001_init.sql"
+npx wrangler d1 execute __YOUR_D1_DATABASE_NAME__ --local --file="./prisma/migrations/0001_init.sql"
 
 # Apply to remote database
-npx wrangler d1 execute __YOUR_D1_DATABASE_NAME__ --remote --title="./prisma/migrations/0001_init.sql"
+npx wrangler d1 execute __YOUR_D1_DATABASE_NAME__ --remote --file="./prisma/migrations/0001_init.sql"
 ```
 
 :::note


### PR DESCRIPTION
`--title` does NOT exist in `wrangler` version `4.67.0`, while `--file` does exist.

P.S. I hope this one is LLMs hallucinating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Cloudflare D1 deployment guide documentation with accurate migration command syntax and practical examples for developers. The guide now properly demonstrates and explains how to use the --file parameter to correctly specify SQL migration script file paths when running database migrations in both local development and production deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->