### PR TITLE
docs(docs): exclude PostgreSQL from "different database" note in NestJS guide

### DIFF
--- a/apps/docs/content/docs/guides/frameworks/nestjs.mdx
+++ b/apps/docs/content/docs/guides/frameworks/nestjs.mdx
@@ -65,7 +65,7 @@ npm install @prisma/client @prisma/adapter-pg pg
 
 :::info
 
-If you are using a different database provider (PostgreSQL, MySQL, SQL Server), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/core-concepts/supported-databases/database-drivers).
+If you are using a different database provider (MySQL, SQL Server), install the corresponding driver adapter package instead of `@prisma/adapter-pg`. For more information, see [Database drivers](/orm/core-concepts/supported-databases/database-drivers).
 
 :::
 


### PR DESCRIPTION
- **What:** Remove PostgreSQL from the “different database provider” list in the NestJS guide, since the default setup already uses `@prisma/adapter-pg` (PostgreSQL).
- **Why:** Listing PostgreSQL there suggested using a different adapter for PostgreSQL, which is incorrect.
- **How tested:** Docs reviewed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated database driver guidance in NestJS documentation to clarify adapter installation requirements for MySQL and SQL Server when not using the default PostgreSQL adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->