### PR TITLE
fix(): duplicate `/` and `/showcase` in sitemap

### DIFF
--- a/apps/docs/src/app/(docs)/sitemap.ts
+++ b/apps/docs/src/app/(docs)/sitemap.ts
@@ -33,16 +33,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   });
 
   return [
-    {
-      url: url("/"),
-      changeFrequency: "monthly",
-      priority: 1,
-    },
-    {
-      url: url("/showcase"),
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
     ...items.filter((v) => v !== undefined),
     ...v6Items.filter((v) => v !== undefined),
   ];

--- a/apps/eclipse/src/app/(design-system)/sitemap.ts
+++ b/apps/eclipse/src/app/(design-system)/sitemap.ts
@@ -22,11 +22,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   });
 
   return [
-    {
-      url: url('/'),
-      changeFrequency: 'monthly',
-      priority: 1,
-    },
     ...items.filter((v) => v !== undefined),
   ];
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified sitemap generation by removing hard-coded root page entries. Sitemaps now rely entirely on dynamically generated page listings, reducing redundancy and improving maintainability across documentation and design system areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->