### PR TITLE
Fix typo in databases-connections#pgbouncer

### DIFF
--- a/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/databases-connections/index.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/databases-connections/index.mdx
@@ -225,7 +225,7 @@ export const prisma = new PrismaClient({ adapter });
 
 PostgreSQL only supports a certain amount of concurrent connections, and this limit can be reached quite fast when the service usage goes up – especially in [serverless environments](#serverless-environments-faas).
 
-[PgBouncer](https://www.pgbouncer.org/) holds a connection pool to the database and proxies incoming client connections by sitting between Prisma Client and the database. This reduces the number of processes a database has to handle at any given time. PgBouncer passes on a limited number of connections to the database and queues additional connections for delivery when connections becomes available. To use PgBouncer, see [Configure Prisma Client with PgBouncer](/orm/prisma-client/setup-and-configuration/databases-connections/pgbouncer).
+[PgBouncer](https://www.pgbouncer.org/) holds a connection pool to the database and proxies incoming client connections by sitting between Prisma Client and the database. This reduces the number of processes a database has to handle at any given time. PgBouncer passes on a limited number of connections to the database and queues additional connections for delivery when connections become available. To use PgBouncer, see [Configure Prisma Client with PgBouncer](/orm/prisma-client/setup-and-configuration/databases-connections/pgbouncer).
 
 ### AWS RDS Proxy
 


### PR DESCRIPTION
Minor grammar correction: change “when connections becomes available” to “when connections become available” in the PgBouncer section of "Database Connections"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected grammar in the database connections documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->