### PR TITLE
docs: fix duplicate "the the" typos across documentation

### DIFF
--- a/apps/docs/content/docs.v6/guides/shopify.mdx
+++ b/apps/docs/content/docs.v6/guides/shopify.mdx
@@ -279,7 +279,7 @@ Before those functions are able to be called, our route needs a layout to sit in
 
 ### 4.1. Create the ProductNotesLayout component
 
-Start by creating the folder `routes/app.product-notes.jsx` and adding the `ProductNotesLayout` component inside of it:
+Start by creating the file `routes/app.product-notes.jsx` and adding the `ProductNotesLayout` component inside it:
 
 ```jsx title="app/routes/app.product-notes.jsx"
 import { Page, Layout } from "@shopify/polaris"; // [!code ++]

--- a/apps/docs/content/docs.v6/guides/shopify.mdx
+++ b/apps/docs/content/docs.v6/guides/shopify.mdx
@@ -279,7 +279,7 @@ Before those functions are able to be called, our route needs a layout to sit in
 
 ### 4.1. Create the ProductNotesLayout component
 
-Start by creating the the folder `routes/app.product-notes.jsx` and adding the `ProductNotesLayout` component inside of it:
+Start by creating the folder `routes/app.product-notes.jsx` and adding the `ProductNotesLayout` component inside of it:
 
 ```jsx title="app/routes/app.product-notes.jsx"
 import { Page, Layout } from "@shopify/polaris"; // [!code ++]

--- a/apps/docs/content/docs.v6/orm/prisma-client/setup-and-configuration/databases-connections/index.mdx
+++ b/apps/docs/content/docs.v6/orm/prisma-client/setup-and-configuration/databases-connections/index.mdx
@@ -32,7 +32,7 @@ The recommended connection pool size (`connection_limit`) to [start with](#optim
 
 :::info
 
-`num_physical_cpus` refers to the the number of CPUs of the machine your application is running on.
+`num_physical_cpus` refers to the number of CPUs of the machine your application is running on.
 
 :::
 

--- a/apps/docs/content/docs.v6/orm/prisma-schema/overview/location.mdx
+++ b/apps/docs/content/docs.v6/orm/prisma-schema/overview/location.mdx
@@ -69,7 +69,7 @@ When using a multi-file Prisma schema, you must always explicitly specify the lo
 
 You can do this in either of three ways:
 
-- pass the the `--schema` option to your Prisma CLI command (e.g. `prisma migrate dev --schema ./prisma`)
+- pass the `--schema` option to your Prisma CLI command (e.g. `prisma migrate dev --schema ./prisma`)
 - set the `prisma.schema` field in `package.json`:
   ```jsonc
   // package.json

--- a/apps/docs/content/docs.v6/orm/reference/prisma-client-reference.mdx
+++ b/apps/docs/content/docs.v6/orm/reference/prisma-client-reference.mdx
@@ -4995,7 +4995,7 @@ const getUsers = await prisma.user.findMany({
 
 ### `mode`
 
-Specify whether the the string filtering should be case sensitive (default) or case insensitive.
+Specify whether the string filtering should be case sensitive (default) or case insensitive.
 
 The following query returns all users where the nested `favorites` > `catBreed` key value contains `"Van"` or `"van"`:
 

--- a/apps/docs/content/docs.v6/platform/about.mdx
+++ b/apps/docs/content/docs.v6/platform/about.mdx
@@ -36,7 +36,7 @@ If you need to delete your user account, go [here](/v6/platform/support#deleting
 
 ### Workspace
 
-You can create several workspaces. A workspace is an isolated space to host projects. A workspace can have multiple user accounts associated with it so that multiple users can collaborate on the the projects in the workspace.
+You can create several workspaces. A workspace is an isolated space to host projects. A workspace can have multiple user accounts associated with it so that multiple users can collaborate on the projects in the workspace.
 
 In each workspace, you can:
 


### PR DESCRIPTION
Fixed 5 instances of duplicate "the the" → "the" found across the documentation:

| File | Line |
|------|------|
| `platform/about.mdx` | "collaborate on the ~~the~~ projects" |
| `guides/shopify.mdx` | "creating the ~~the~~ folder" |
| `orm/reference/prisma-client-reference.mdx` | "whether the ~~the~~ string filtering" |
| `orm/prisma-client/.../databases-connections/index.mdx` | "refers to the ~~the~~ number" |
| `orm/prisma-schema/overview/location.mdx` | "pass the ~~the~~ `--schema` option" |

Small cleanup, no functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed minor typos and wording issues across multiple docs (guides, ORM/schema reference, client reference, and platform/about) to improve clarity and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->