### PR TITLE
Fix connection string parameter for pooling

### DIFF
--- a/apps/docs/content/docs/postgres/database/connection-pooling.mdx
+++ b/apps/docs/content/docs/postgres/database/connection-pooling.mdx
@@ -16,14 +16,14 @@ Prisma Postgres supports connection pooling through [TCP connections](#connectio
 TCP connection pooling is currently in [Early Access](/console/more/feature-maturity#early-access).
 :::
 
-To use a pooled connection, append `&pooled=true` to your Prisma Postgres TCP connection string:
+To use a pooled connection, append `&pool=true` to your Prisma Postgres TCP connection string:
 
 ```bash
 # Direct connection (no pooling)
 DATABASE_URL="postgres://USER:PASSWORD@db.prisma.io:5432/?sslmode=require"
 
 # Pooled connection
-DATABASE_URL="postgres://USER:PASSWORD@db.prisma.io:5432/?sslmode=require&pooled=true"
+DATABASE_URL="postgres://USER:PASSWORD@db.prisma.io:5432/?sslmode=require&pool=true"
 ```
 
 You can also enable connection pooling when generating your connection string in the [Prisma Console](https://console.prisma.io) by toggling on the **pooling** option.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected PostgreSQL connection pooling documentation examples to use the accurate parameter specification. Updated all code snippets and guidance text to reflect the correct parameter usage in connection strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->