### PR TITLE
Fix Claude Code MCP setup command typos and missing flags

### DIFF
--- a/apps/docs/content/docs.v6/postgres/integrations/mcp-server.mdx
+++ b/apps/docs/content/docs.v6/postgres/integrations/mcp-server.mdx
@@ -10,7 +10,7 @@ metaDescription: Manage Prisma Postgres databases using LLMs with the Prisma Mod
 
 The [Model-Context-Protocol](https://modelcontextprotocol.io/introduction) (MCP) gives LLMs a way to call APIs and thus access external systems in a well-defined manner.
 
-Prisma's provides two MCP servers: a _local_ and a _remote_ one. See below for specific information on each.
+Prisma provides two MCP servers: a _local_ and a _remote_ one. See below for specific information on each.
 
 If you're a developer working on a local machine and want your AI agent to help with your database workflows, use the local MCP server.
 
@@ -317,10 +317,10 @@ To learn more about Warp's MCP integration, visit the [Warp MCP docs](https://do
 
 ### Claude Code
 
-Claude Code is a terminal-based AI tool where you can add MCP server using the `claud mcp add` command for the local MCP server:
+Claude Code is a terminal-based AI tool where you can add MCP servers using the `claude mcp add` command for the local MCP server:
 
 ```bash
-claude mcp add prisma-local npx prisma mcp
+claude mcp add prisma-local -- npx -y prisma mcp
 ```
 
 or for the remote MCP server:

--- a/apps/docs/content/docs/ai/tools/mcp-server.mdx
+++ b/apps/docs/content/docs/ai/tools/mcp-server.mdx
@@ -11,7 +11,7 @@ metaDescription: 'Manage Prisma Postgres databases using LLMs with the Prisma Mo
 
 The [Model-Context-Protocol](https://modelcontextprotocol.io/introduction) (MCP) gives LLMs a way to call APIs and thus access external systems in a well-defined manner.
 
-Prisma's provides two MCP servers: a _local_ and a _remote_ one. See below for specific information on each.
+Prisma provides two MCP servers: a _local_ and a _remote_ one. See below for specific information on each.
 
 If you're a developer working on a local machine and want your AI agent to help with your database workflows, use the local MCP server.
 
@@ -318,10 +318,10 @@ To learn more about Warp's MCP integration, visit the [Warp MCP docs](https://do
 
 ### Claude Code
 
-Claude Code is a terminal-based AI tool where you can add MCP server using the `claud mcp add` command for the local MCP server:
+Claude Code is a terminal-based AI tool where you can add MCP servers using the `claude mcp add` command for the local MCP server:
 
 ```bash
-claude mcp add prisma-local npx prisma mcp
+claude mcp add prisma-local -- npx -y prisma mcp
 ```
 
 or for the remote MCP server:


### PR DESCRIPTION
## Summary

Fixes documentation issues in the MCP server guide that could cause connection/auth errors when setting up Prisma MCP in Claude Code:

- **Typo fix**: `claud mcp add` → `claude mcp add`
- **Missing `-y` flag**: Added `-y` to the `npx` command to auto-confirm package installation (prevents stdio hanging)
- **Added `--` separator**: Ensures args are correctly passed to the npx command
- **Grammar fix**: `Prisma's provides` → `Prisma provides`

Applied to both v7 (`content/docs/`) and v6 (`content/docs.v6/`) versions of the MCP server guide.

Closes DR-7474

## Test plan

- [ ] Verify the corrected command `claude mcp add prisma-local -- npx -y prisma mcp` works in Claude Code
- [ ] Check docs render correctly on both v7 and v6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected grammar and syntax in MCP server integration guides.
  * Updated command examples for local and remote MCP server configuration in Claude Code.
  * Clarified instructions with corrected command flags and separators for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->