### PR TITLE
chore(docs): add more links to tools

### DIFF
--- a/apps/docs/content/docs/postgres/integrations/meta.json
+++ b/apps/docs/content/docs/postgres/integrations/meta.json
@@ -1,4 +1,9 @@
 {
   "title": "Tools & Integrations",
-  "pages": ["raycast"]
+  "pages": [
+    "raycast",
+    "[MCP](/ai/tools/mcp-server)",
+    "[Studio](/studio)",
+    "[VSCode](/guides/postgres/vscode)"
+  ]
 }

--- a/apps/docs/content/docs/postgres/integrations/raycast.mdx
+++ b/apps/docs/content/docs/postgres/integrations/raycast.mdx
@@ -8,7 +8,7 @@ url: /postgres/integrations/raycast
 
 ## Overview
 
-[Raycast](https://www.raycast.com/) is a blazingly fast, extendable launcher for macOS that lets you control your tools with a few keystrokes. The [Prisma Postgres Raycast extension](https://www.raycast.com/amanvarshney01/prisma-postgres) brings database creation and management directly into your workflow.
+[Raycast](https://www.raycast.com/) is a fast and extendable launcher for macOS that lets you control your tools with a few keystrokes. The [Prisma Postgres Raycast extension](https://www.raycast.com/amanvarshney01/prisma-postgres) brings database creation and management directly into your workflow.
 
 With the Prisma Postgres extension, you can create production-ready Postgres databases in seconds without leaving Raycast, making it perfect for rapid prototyping and development.
 


### PR DESCRIPTION
Add additional links to tools for

- VsCode
- MCP Server
- Studio

We can reuse section of the docs that already exist without having to duplicate content. 

[DR-7435](https://linear.app/prisma-company/issue/DR-7435/expand-tools-and-integrations-docs-beyond-raycast)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Postgres integrations documentation navigation to include guides for MCP Server, Studio, and VSCode alongside Raycast.
  * Updated Raycast integration description text for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->