### PR TITLE
Fix file path in nextjs guide for posts detail page

### DIFF
--- a/apps/docs/content/docs/guides/frameworks/nextjs.mdx
+++ b/apps/docs/content/docs/guides/frameworks/nextjs.mdx
@@ -421,7 +421,7 @@ In the `posts` directory, create a new `[id]` directory and a new `page.tsx` fil
 mkdir -p "app/posts/[id]" && touch "app/posts/[id]/page.tsx"
 ```
 
-This page will display a single post's title, content, and author. Just like your other pages, add the following code to the `app/posts/new/page.tsx` file:
+This page will display a single post's title, content, and author. Just like your other pages, add the following code to the `app/posts/[id]/page.tsx` file:
 
 ```tsx title="app/posts/[id]/page.tsx"
 import prisma from "@/lib/prisma";


### PR DESCRIPTION
Correct the path in the part talking about what content to add to the posts detail page. It's currently mentioning the new page file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Next.js framework guide with corrected instructional examples for dynamic page routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->