### PR TITLE
docs(better-auth): Change CLI command from @better-auth to auth 

### DIFF
--- a/apps/docs/content/docs/guides/authentication/better-auth/nextjs.mdx
+++ b/apps/docs/content/docs/guides/authentication/better-auth/nextjs.mdx
@@ -179,7 +179,7 @@ npm install better-auth
 Next, generate a secure secret that Better Auth will use to sign authentication tokens. This ensures your tokens cannot be messed with.
 
 ```npm
-npx @better-auth/cli@latest secret
+npx auth@latest secret
 ```
 
 Copy the generated secret and add it, along with your application's URL, to your `.env` file:
@@ -259,7 +259,7 @@ Better Auth provides a CLI command to automatically add the necessary authentica
 Run the following command:
 
 ```npm
-npx @better-auth/cli generate
+npx auth generate
 ```
 
 :::note


### PR DESCRIPTION
This pull request updates the Next.js authentication guide to use the new CLI command for Better Auth. The changes ensure that users follow the latest recommended setup instructions.

**Documentation updates:**

* Updated the command for generating a secure secret from `npx @better-auth/cli@latest secret` to `npx auth@latest secret` in the Next.js authentication guide (`apps/docs/content/docs/guides/authentication/better-auth/nextjs.mdx`).
* Updated the command for generating authentication configuration from `npx @better-auth/cli generate` to `npx auth generate` in the Next.js authentication guide (`apps/docs/content/docs/guides/authentication/better-auth/nextjs.mdx`).Updated command for generating secret and authentication tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated Next.js authentication setup documentation with refreshed CLI command examples for secret generation and schema/authorization configuration. The documentation now reflects the latest command interfaces and tooling updates while maintaining complete backward compatibility. All existing functionality, workflows, behavior, and authentication procedures remain entirely unchanged and unaffected by the updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->