### PR TITLE
fix: add /docs prefix to ViewOptions markdownUrl

### DIFF
--- a/apps/docs/src/app/(docs)/(default)/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/(docs)/(default)/[[...slug]]/page.tsx
@@ -53,7 +53,7 @@ export default async function Page({ params }: { params: Promise<PageParams> }) 
             )}
 
             <ViewOptions
-              markdownUrl={`${page.url}.mdx`}
+              markdownUrl={`${withDocsBasePath(page.url)}.mdx`}
               githubUrl={`https://github.com/prisma/docs/blob/main/apps/docs/content/docs/${page.path}`}
             />
           </div>

--- a/apps/docs/src/app/(docs)/v6/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/(docs)/v6/[[...slug]]/page.tsx
@@ -52,7 +52,7 @@ export default async function Page({
           <div className="flex flex-row gap-2 items-center">
             <LLMCopyButton markdownUrl={`${withDocsBasePath(page.url)}.mdx`} />
             <ViewOptions
-              markdownUrl={page.url}
+              markdownUrl={`${withDocsBasePath(page.url)}.mdx`}
               githubUrl={`https://github.com/prisma/docs/blob/main/apps/docs/content/docs.v6/${page.path}`}
             />
           </div>


### PR DESCRIPTION
## Summary
- The "Open in ChatGPT/Claude/T3 Chat" buttons in the `ViewOptions` dropdown were generating incorrect URLs missing the `/docs/` base path (e.g. `https://www.prisma.io/prisma-orm/quickstart/prisma-postgres.mdx` instead of `https://www.prisma.io/docs/prisma-orm/quickstart/prisma-postgres.mdx`)
- Wrapped `page.url` with `withDocsBasePath()` in both the v7 and v6 page components, matching what `LLMCopyButton` already does


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed markdown URL resolution in documentation pages to correctly include the docs base path and file extension, ensuring consistent URL handling across the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->