### PR TITLE
fix: dr-7570 Apply security rules for fontawesome script

### DIFF
--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -36,7 +36,11 @@ export default function Layout({ children }: { children: ReactNode }) {
       suppressHydrationWarning
     >
       <head>
-        <Script src={EclipseFA} crossOrigin="anonymous" />
+        <Script
+          src={EclipseFA}
+          crossOrigin="anonymous"
+          data-auto-add-css="false"
+        />
       </head>
       <body className="flex flex-col min-h-screen">
         <Provider>{children}</Provider>

--- a/apps/eclipse/src/app/layout.tsx
+++ b/apps/eclipse/src/app/layout.tsx
@@ -23,7 +23,12 @@ export default function Layout({ children }: LayoutProps<"/">) {
       suppressHydrationWarning
     >
       <head>
-        <Script src={EclipseFA} crossOrigin="anonymous" async />
+        <Script
+          src={EclipseFA}
+          crossOrigin="anonymous"
+          async
+          data-auto-add-css="false"
+        />
         <Script
           src="https://widget.kapa.ai/kapa-widget.bundle.js"
           data-website-id="1b51bb03-43cc-4ef4-95f1-93288a91b560"

--- a/packages/ui/src/components/fontawesome-web.tsx
+++ b/packages/ui/src/components/fontawesome-web.tsx
@@ -6,6 +6,7 @@ export function FontAwesomeScript() {
       src="https://kit.fontawesome.com/ad485975d2.js"
       cross-origin="anonymous"
       async
+      data-auto-add-css="false"
     />
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic CSS injection in FontAwesome script loading across documentation, Eclipse, and UI components by updating script tag configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->