### PR TITLE
feat(docs): DR-7571 Add floating Ask AI input

### DIFF
--- a/apps/docs/src/app/(docs)/(default)/layout.tsx
+++ b/apps/docs/src/app/(docs)/(default)/layout.tsx
@@ -9,12 +9,14 @@ import { StatusIndicator } from "@/components/status-indicator";
 import { SidebarBannerCarousel } from "@/components/sidebar-banner";
 import { fetchOgImage } from "@/lib/og-image";
 import { cn } from "@prisma-docs/ui/lib/cn";
+import { FloatingAsk } from "@/components/floating-ask";
 
 // Sidebar announcement slides — set to [] to hide the banner
 const SIDEBAR_SLIDES = [
   {
     title: "The Next Evolution of Prisma ORM",
-    description: "Prisma Next: a full TypeScript rewrite with a new query API, SQL builder, and extensible architecture.",
+    description:
+      "Prisma Next: a full TypeScript rewrite with a new query API, SQL builder, and extensible architecture.",
     href: "https://pris.ly/pn-anouncement",
     gradient: "orm" as const,
     badge: "New",
@@ -44,23 +46,26 @@ export default async function Layout({ children }: { children: React.ReactNode }
   );
 
   return (
-    <DocsLayout
-      {...base}
-      links={navbarLinks}
-      nav={{ ...nav }}
-      sidebar={{
-        collapsible: false,
-        footer: ({ className, ...props }: ComponentProps<"div">) => (
-          <div className={cn("flex flex-col p-4 pt-2 gap-3", className)} {...props}>
-            <SidebarBannerCarousel slides={slides} />
-            <StatusIndicator />
-            {props.children}
-          </div>
-        ),
-      }}
-      tree={source.pageTree}
-    >
-      {children}
-    </DocsLayout>
+    <>
+      <DocsLayout
+        {...base}
+        links={navbarLinks}
+        nav={{ ...nav }}
+        sidebar={{
+          collapsible: false,
+          footer: ({ className, ...props }: ComponentProps<"div">) => (
+            <div className={cn("flex flex-col p-4 pt-2 gap-3", className)} {...props}>
+              <SidebarBannerCarousel slides={slides} />
+              <StatusIndicator />
+              {props.children}
+            </div>
+          ),
+        }}
+        tree={source.pageTree}
+      >
+        {children}
+      </DocsLayout>
+      <FloatingAsk />
+    </>
   );
 }

--- a/apps/docs/src/components/ai-chat-sidebar.tsx
+++ b/apps/docs/src/components/ai-chat-sidebar.tsx
@@ -180,7 +180,6 @@ const ChatInner = ({
 
   const deepThinking = useDeepThinking();
 
-  // Auto-submit pending message from the floating input
   useEffect(() => {
     if (pendingMessage && !isGeneratingAnswer) {
       submitQuery(pendingMessage);

--- a/apps/docs/src/components/ai-chat-sidebar.tsx
+++ b/apps/docs/src/components/ai-chat-sidebar.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  useChat,
-  useDeepThinking,
-  type Reaction,
-  type Source,
-} from "@kapaai/react-sdk";
+import { useChat, useDeepThinking, type Reaction, type Source } from "@kapaai/react-sdk";
 import {
   AlertCircleIcon,
   ChevronRightIcon,
@@ -20,11 +15,7 @@ import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@prisma-docs/ui/lib/cn";
 import { buttonVariants } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@prisma-docs/ui/components/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@prisma-docs/ui/components/tooltip";
 import {
   Drawer,
   DrawerContent,
@@ -46,28 +37,17 @@ import {
   ConversationContent,
   ConversationScrollButton,
 } from "@/components/ai-elements/conversation";
-import {
-  Message,
-  MessageContent,
-  MessageResponseMarkdown,
-} from "@/components/ai-elements/message";
+import { Message, MessageContent, MessageResponseMarkdown } from "@/components/ai-elements/message";
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import { Spinner } from "@/components/ai-elements/spinner";
-import {
-  PromptInput,
-  PromptInputFooter,
-} from "@/components/ai-elements/prompt-input";
+import { PromptInput, PromptInputFooter } from "@/components/ai-elements/prompt-input";
 import { CopyChat } from "@/components/ai-elements/copy-chat";
 
 interface AIChatSidebarProps {
   exampleQuestions?: string[];
 }
 
-const SourcesDisplay = ({
-  sources,
-}: {
-  sources: (Source | StoredSource)[];
-}) => {
+const SourcesDisplay = ({ sources }: { sources: (Source | StoredSource)[] }) => {
   const [showAll, setShowAll] = useState(false);
   const displayedSources = showAll ? sources : sources.slice(0, 3);
   const hasMore = sources.length > 3;
@@ -132,14 +112,11 @@ const FeedbackButtons = ({
                 "h-7 w-7",
                 currentReaction === "upvote" &&
                   "text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-950",
-                disabled && "opacity-50 cursor-not-allowed"
+                disabled && "opacity-50 cursor-not-allowed",
               )}
             >
               <ThumbsUpIcon
-                className={cn(
-                  "size-3.5",
-                  currentReaction === "upvote" && "fill-current"
-                )}
+                className={cn("size-3.5", currentReaction === "upvote" && "fill-current")}
               />
             </button>
           )}
@@ -159,14 +136,11 @@ const FeedbackButtons = ({
                 "h-7 w-7",
                 currentReaction === "downvote" &&
                   "text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-950",
-                disabled && "opacity-50 cursor-not-allowed"
+                disabled && "opacity-50 cursor-not-allowed",
               )}
             >
               <ThumbsDownIcon
-                className={cn(
-                  "size-3.5",
-                  currentReaction === "downvote" && "fill-current"
-                )}
+                className={cn("size-3.5", currentReaction === "downvote" && "fill-current")}
               />
             </button>
           )}
@@ -185,6 +159,7 @@ const ChatInner = ({
   onClose: () => void;
 }) => {
   const [inputValue, setInputValue] = useState("");
+  const { pendingMessage, setPendingMessage } = useAIChatContext();
   const {
     initialMessages,
     isLoading: isPersistenceLoading,
@@ -204,6 +179,14 @@ const ChatInner = ({
   } = useChat();
 
   const deepThinking = useDeepThinking();
+
+  // Auto-submit pending message from the floating input
+  useEffect(() => {
+    if (pendingMessage && !isGeneratingAnswer) {
+      submitQuery(pendingMessage);
+      setPendingMessage("");
+    }
+  }, [pendingMessage, isGeneratingAnswer, submitQuery, setPendingMessage]);
 
   useEffect(() => {
     if (conversation.length === 0) return;
@@ -258,9 +241,7 @@ const ChatInner = ({
   };
 
   const messagesForCopy: ChatMessage[] = conversation.flatMap((qa) => {
-    const msgs: ChatMessage[] = [
-      { id: `${qa.id}-user`, role: "user", content: qa.question },
-    ];
+    const msgs: ChatMessage[] = [{ id: `${qa.id}-user`, role: "user", content: qa.question }];
     if (qa.answer) {
       msgs.push({
         id: `${qa.id}-assistant`,
@@ -273,30 +254,24 @@ const ChatInner = ({
 
   const hasActiveConversation = conversation.length > 0;
   const hasPersistedMessages = initialMessages.length > 0;
-  const showEmptyState =
-    !hasActiveConversation && !hasPersistedMessages && !isPersistenceLoading;
+  const showEmptyState = !hasActiveConversation && !hasPersistedMessages && !isPersistenceLoading;
 
   return (
     <div className="flex size-full w-full flex-col overflow-hidden bg-fd-background">
       <div className="flex items-center justify-between px-4 py-2.5 border-b shrink-0">
         <h2 className="font-semibold text-sm">Chat</h2>
         <div className="flex items-center gap-1">
-          <CopyChat
-            messages={hasActiveConversation ? messagesForCopy : initialMessages}
-          />
+          <CopyChat messages={hasActiveConversation ? messagesForCopy : initialMessages} />
           <Tooltip>
             <TooltipTrigger
               render={(props) => (
                 <button
                   {...props}
                   onClick={handleClearChat}
-                  disabled={
-                    (!hasActiveConversation && !hasPersistedMessages) ||
-                    isGeneratingAnswer
-                  }
+                  disabled={(!hasActiveConversation && !hasPersistedMessages) || isGeneratingAnswer}
                   className={cn(
                     buttonVariants({ variant: "ghost", size: "icon-sm" }),
-                    "disabled:opacity-50"
+                    "disabled:opacity-50",
                   )}
                 >
                   <Trash2 className="size-3.5" />
@@ -311,9 +286,7 @@ const ChatInner = ({
                 <button
                   {...props}
                   onClick={onClose}
-                  className={cn(
-                    buttonVariants({ variant: "ghost", size: "icon-sm" })
-                  )}
+                  className={cn(buttonVariants({ variant: "ghost", size: "icon-sm" }))}
                 >
                   <ChevronRightIcon className="size-3.5" />
                 </button>
@@ -333,9 +306,7 @@ const ChatInner = ({
                   <MessagesSquareIcon className="size-6 text-fd-primary" />
                 </div>
                 <div>
-                  <h3 className="font-semibold text-fd-foreground">
-                    How can I help?
-                  </h3>
+                  <h3 className="font-semibold text-fd-foreground">How can I help?</h3>
                   <p className="text-sm text-fd-muted-foreground mt-1">
                     Ask me anything about Prisma
                   </p>
@@ -373,8 +344,7 @@ const ChatInner = ({
             <>
               {conversation.map((qa, index) => {
                 const isLastItem = index === conversation.length - 1;
-                const isLoading =
-                  isLastItem && (isGeneratingAnswer || isPreparingAnswer);
+                const isLoading = isLastItem && (isGeneratingAnswer || isPreparingAnswer);
                 const hasAnswer = !!qa.answer;
                 const isComplete = qa.id && !isLoading;
 
@@ -387,9 +357,7 @@ const ChatInner = ({
                     <Message from="assistant">
                       <MessageContent>
                         {hasAnswer ? (
-                          <MessageResponseMarkdown>
-                            {qa.answer}
-                          </MessageResponseMarkdown>
+                          <MessageResponseMarkdown>{qa.answer}</MessageResponseMarkdown>
                         ) : isLoading ? (
                           <div className="flex items-center gap-2 overflow-hidden">
                             <Spinner />
@@ -443,18 +411,14 @@ const ChatInner = ({
                 <Message key={message.id} from={message.role}>
                   <MessageContent>
                     {message.role === "assistant" ? (
-                      <MessageResponseMarkdown>
-                        {message.content}
-                      </MessageResponseMarkdown>
+                      <MessageResponseMarkdown>{message.content}</MessageResponseMarkdown>
                     ) : (
                       message.content
                     )}
                   </MessageContent>
                   {message.role === "assistant" &&
                     message.sources &&
-                    message.sources.length > 0 && (
-                      <SourcesDisplay sources={message.sources} />
-                    )}
+                    message.sources.length > 0 && <SourcesDisplay sources={message.sources} />}
                 </Message>
               ))}
             </>
@@ -523,14 +487,18 @@ export const AIChatSidebar = ({
         onClick={() => setIsOpen(!isOpen)}
         className={cn(
           buttonVariants({ variant: "outline" }),
-          "hidden shrink-0 shadow-none md:inline-flex items-center gap-2 h-8 group cursor-pointer"
+          "hidden shrink-0 shadow-none md:inline-flex items-center gap-2 h-8 group cursor-pointer",
         )}
       >
         <MessagesSquareIcon className="size-4 text-fd-muted-foreground group-hover:text-fd-accent-foreground" />
         <span>Ask AI</span>
         <div className="ms-auto inline-flex gap-0.5">
-          <kbd className="rounded-md border bg-fd-background px-1.5 text-fd-muted-foreground group-hover:text-fd-accent-foreground">{isMac ? "⌘" : "Ctrl"}</kbd>
-          <kbd className="rounded-md border bg-fd-background px-1.5 text-fd-muted-foreground group-hover:text-fd-accent-foreground">I</kbd>
+          <kbd className="rounded-md border bg-fd-background px-1.5 text-fd-muted-foreground group-hover:text-fd-accent-foreground">
+            {isMac ? "⌘" : "Ctrl"}
+          </kbd>
+          <kbd className="rounded-md border bg-fd-background px-1.5 text-fd-muted-foreground group-hover:text-fd-accent-foreground">
+            I
+          </kbd>
         </div>
       </button>
 
@@ -542,28 +510,22 @@ export const AIChatSidebar = ({
               "inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-[500px]",
               "translate-x-full data-[state=open]:translate-x-0",
               "pointer-events-none data-[state=open]:pointer-events-auto",
-              "hidden md:flex"
+              "hidden md:flex",
             )}
             data-state={isOpen ? "open" : "closed"}
           >
-            <ChatInner
-              exampleQuestions={exampleQuestions}
-              onClose={() => setIsOpen(false)}
-            />
+            <ChatInner exampleQuestions={exampleQuestions} onClose={() => setIsOpen(false)} />
           </div>,
-          document.body
+          document.body,
         )}
 
       <div className="md:hidden">
-        <Drawer
-          open={isMobile ? isOpen : false}
-          onOpenChange={isMobile ? setIsOpen : undefined}
-        >
+        <Drawer open={isMobile ? isOpen : false} onOpenChange={isMobile ? setIsOpen : undefined}>
           <DrawerTrigger asChild>
             <button
               className={cn(
                 buttonVariants({ variant: "outline", size: "sm" }),
-                "shadow-none inline-flex items-center gap-1.5"
+                "shadow-none inline-flex items-center gap-1.5",
               )}
             >
               <MessagesSquareIcon className="size-3.5 text-fd-muted-foreground" />
@@ -575,10 +537,7 @@ export const AIChatSidebar = ({
               <DrawerTitle>AI Chat</DrawerTitle>
               <DrawerDescription>Ask questions about Prisma</DrawerDescription>
             </DrawerHeader>
-            <ChatInner
-              exampleQuestions={exampleQuestions}
-              onClose={() => setIsOpen(false)}
-            />
+            <ChatInner exampleQuestions={exampleQuestions} onClose={() => setIsOpen(false)} />
           </DrawerContent>
         </Drawer>
       </div>

--- a/apps/docs/src/components/ai-chat-sidebar.tsx
+++ b/apps/docs/src/components/ai-chat-sidebar.tsx
@@ -180,12 +180,14 @@ const ChatInner = ({
 
   const deepThinking = useDeepThinking();
 
+  const isBusy = isGeneratingAnswer || isPreparingAnswer;
+
   useEffect(() => {
-    if (pendingMessage && !isGeneratingAnswer) {
+    if (pendingMessage && !isBusy) {
       submitQuery(pendingMessage);
       setPendingMessage("");
     }
-  }, [pendingMessage, isGeneratingAnswer, submitQuery, setPendingMessage]);
+  }, [pendingMessage, isBusy, submitQuery, setPendingMessage]);
 
   useEffect(() => {
     if (conversation.length === 0) return;

--- a/apps/docs/src/components/floating-ask.tsx
+++ b/apps/docs/src/components/floating-ask.tsx
@@ -24,9 +24,9 @@ export function FloatingAsk() {
   }, [checkScroll]);
 
   const handleSubmit = () => {
-    if (inputValue.trim()) {
-      setPendingMessage(inputValue.trim());
-    }
+    const val = inputValue.trim();
+    if (!val) return;
+    setPendingMessage(val);
     setIsOpen(true);
     setInputValue("");
   };

--- a/apps/docs/src/components/floating-ask.tsx
+++ b/apps/docs/src/components/floating-ask.tsx
@@ -67,6 +67,7 @@ export function FloatingAsk() {
           <button
             type="button"
             onClick={handleSubmit}
+            aria-label="Submit question"
             className="flex size-7 shrink-0 items-center justify-center rounded-full bg-fd-primary text-fd-primary-foreground transition-colors hover:bg-fd-primary/90"
           >
             <ArrowUp className="size-4" />

--- a/apps/docs/src/components/floating-ask.tsx
+++ b/apps/docs/src/components/floating-ask.tsx
@@ -14,14 +14,13 @@ export function FloatingAsk() {
   const checkScroll = useCallback(() => {
     const scrollHeight = document.documentElement.scrollHeight;
     const viewportHeight = window.innerHeight;
-    const distanceFromBottom = scrollHeight - window.scrollY - viewportHeight;
-    const isShortPage = scrollHeight - viewportHeight < 200;
 
-    if (isShortPage) {
-      setVisible(distanceFromBottom > 10);
+    if (scrollHeight - viewportHeight < 200) {
+      setVisible(false);
       return;
     }
 
+    const distanceFromBottom = scrollHeight - window.scrollY - viewportHeight;
     setVisible(distanceFromBottom > 200);
   }, []);
 

--- a/apps/docs/src/components/floating-ask.tsx
+++ b/apps/docs/src/components/floating-ask.tsx
@@ -12,8 +12,16 @@ export function FloatingAsk() {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const checkScroll = useCallback(() => {
-    const distanceFromBottom =
-      document.documentElement.scrollHeight - window.scrollY - window.innerHeight;
+    const scrollHeight = document.documentElement.scrollHeight;
+    const viewportHeight = window.innerHeight;
+    const isShortPage = scrollHeight - viewportHeight < 200;
+
+    if (isShortPage) {
+      setVisible(true);
+      return;
+    }
+
+    const distanceFromBottom = scrollHeight - window.scrollY - viewportHeight;
     setVisible(distanceFromBottom > 200);
   }, []);
 

--- a/apps/docs/src/components/floating-ask.tsx
+++ b/apps/docs/src/components/floating-ask.tsx
@@ -14,14 +14,14 @@ export function FloatingAsk() {
   const checkScroll = useCallback(() => {
     const scrollHeight = document.documentElement.scrollHeight;
     const viewportHeight = window.innerHeight;
+    const distanceFromBottom = scrollHeight - window.scrollY - viewportHeight;
     const isShortPage = scrollHeight - viewportHeight < 200;
 
     if (isShortPage) {
-      setVisible(true);
+      setVisible(distanceFromBottom > 10);
       return;
     }
 
-    const distanceFromBottom = scrollHeight - window.scrollY - viewportHeight;
     setVisible(distanceFromBottom > 200);
   }, []);
 

--- a/apps/docs/src/components/floating-ask.tsx
+++ b/apps/docs/src/components/floating-ask.tsx
@@ -7,7 +7,7 @@ import { useAIChatContext } from "@/hooks/use-ai-chat";
 
 export function FloatingAsk() {
   const { isOpen, setIsOpen, setPendingMessage } = useAIChatContext();
-  const [visible, setVisible] = useState(true);
+  const [visible, setVisible] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 

--- a/apps/docs/src/components/floating-ask.tsx
+++ b/apps/docs/src/components/floating-ask.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useCallback, useState, useRef } from "react";
+import { ArrowUp } from "lucide-react";
+import { cn } from "@prisma-docs/ui/lib/cn";
+import { useAIChatContext } from "@/hooks/use-ai-chat";
+
+export function FloatingAsk() {
+  const { isOpen, setIsOpen, setPendingMessage } = useAIChatContext();
+  const [visible, setVisible] = useState(true);
+  const [inputValue, setInputValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const checkScroll = useCallback(() => {
+    const distanceFromBottom =
+      document.documentElement.scrollHeight - window.scrollY - window.innerHeight;
+    setVisible(distanceFromBottom > 200);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("scroll", checkScroll, { passive: true });
+    checkScroll();
+    return () => window.removeEventListener("scroll", checkScroll);
+  }, [checkScroll]);
+
+  const handleSubmit = () => {
+    if (inputValue.trim()) {
+      setPendingMessage(inputValue.trim());
+    }
+    setIsOpen(true);
+    setInputValue("");
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "fixed bottom-6 left-1/2 z-40 -translate-x-1/2 w-full max-w-lg px-4 transition-opacity duration-500 ease-in-out max-md:hidden",
+        visible && !isOpen ? "opacity-100" : "opacity-0 pointer-events-none",
+      )}
+    >
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+      <div
+        className={cn(
+          "group flex flex-col gap-2 rounded-2xl border border-fd-foreground/20 bg-fd-background/80 px-4 pt-3 pb-3 shadow-lg backdrop-blur-xl transition-[scale,border-color,box-shadow] duration-700 ease-in-out cursor-text hover:scale-x-[1.06] hover:scale-y-[1.02] hover:border-fd-primary/40 hover:shadow-[0_0_20px_rgba(99,102,241,0.15)]",
+          inputValue &&
+            "scale-x-[1.06] scale-y-[1.02] border-fd-primary/40 shadow-[0_0_20px_rgba(99,102,241,0.15)]",
+        )}
+        onClick={() => inputRef.current?.focus()}
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Ask a question..."
+          className="w-full bg-transparent text-sm text-fd-foreground placeholder:text-fd-muted-foreground focus:outline-none"
+        />
+        <div className="flex items-center justify-end">
+          <button
+            type="button"
+            onClick={handleSubmit}
+            className="flex size-7 shrink-0 items-center justify-center rounded-full bg-fd-primary text-fd-primary-foreground transition-colors hover:bg-fd-primary/90"
+          >
+            <ArrowUp className="size-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/src/hooks/use-ai-chat.ts
+++ b/apps/docs/src/hooks/use-ai-chat.ts
@@ -3,13 +3,13 @@
 import { atom, useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 
-// Atom for the current prompt/input text
+
 export const chatPromptAtom = atom<string>("");
 
-// Atom for sidebar open/closed state (persisted to localStorage)
+
 export const chatOpenAtom = atomWithStorage<boolean>("prisma-docs:chat-open", false);
 
-// Atom for a message queued from the floating input to be auto-submitted
+
 export const pendingMessageAtom = atom<string>("");
 
 export const useAIChatContext = () => {

--- a/apps/docs/src/hooks/use-ai-chat.ts
+++ b/apps/docs/src/hooks/use-ai-chat.ts
@@ -7,19 +7,22 @@ import { atomWithStorage } from "jotai/utils";
 export const chatPromptAtom = atom<string>("");
 
 // Atom for sidebar open/closed state (persisted to localStorage)
-export const chatOpenAtom = atomWithStorage<boolean>(
-  "prisma-docs:chat-open",
-  false
-);
+export const chatOpenAtom = atomWithStorage<boolean>("prisma-docs:chat-open", false);
+
+// Atom for a message queued from the floating input to be auto-submitted
+export const pendingMessageAtom = atom<string>("");
 
 export const useAIChatContext = () => {
   const [prompt, setPrompt] = useAtom(chatPromptAtom);
   const [isOpen, setIsOpen] = useAtom(chatOpenAtom);
+  const [pendingMessage, setPendingMessage] = useAtom(pendingMessageAtom);
 
   return {
     prompt,
     setPrompt,
     isOpen,
     setIsOpen,
+    pendingMessage,
+    setPendingMessage,
   };
 };


### PR DESCRIPTION
## Summary
- Add a floating "Ask a question" input bar at the bottom of docs pages (desktop only)
- On submit, opens the AI chat sidebar and auto-sends the message via Kapa AI
- Hides when the sidebar is open, when scrolled near the bottom of the page, or on short pages
- Smooth scale + border + shadow animation on hover, persists while text is typed

## Linear
https://linear.app/prisma-company/issue/DR-7571/docs-ask-ai-floating-input

https://github.com/user-attachments/assets/0a2532be-1733-4c74-a496-2556f5e66a0d

## Test plan
- [ ] Verify floating input appears on long docs pages (desktop only, hidden on mobile)
- [ ] Verify floating input does NOT appear on short pages (e.g. `/docs` homepage)
- [ ] Hover triggers smooth scale/border/shadow animation
- [ ] Typing a question and pressing Enter opens the sidebar and sends the message
- [ ] Clicking the send button does the same
- [ ] Empty input does not open the sidebar
- [ ] Floating input hides when sidebar is open
- [ ] Floating input fades out when scrolled near the bottom of the page
- [ ] Animation stays while text is in the input, reverts when empty