### PR TITLE
Renamed Adminition back to Alert

### DIFF
--- a/apps/docs/src/mdx-components.tsx
+++ b/apps/docs/src/mdx-components.tsx
@@ -29,7 +29,7 @@ import {
   TableCell,
   TableCaption,
   Input,
-  Admonition,
+  Alert,
 } from "@prisma/eclipse";
 
 function withDocsBasePathForImageSrc(src: unknown): unknown {
@@ -81,7 +81,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     th: ({ ref: _ref, ...props }) => <TableHead {...props} />,
     td: ({ ref: _ref, ...props }) => <TableCell {...props} />,
     caption: ({ ref: _ref, ...props }) => <TableCaption {...props} />,
-    // Override Fumadocs Callout components with Eclipse Alert for admonitions (:::ppg, :::error, :::success, :::warning)
+    // Override Fumadocs Callout components with Eclipse Alert for alerts (:::ppg, :::error, :::success, :::warning)
     CalloutTitle: ({ children }: any) => <>{children}</>,
     CalloutDescription: ({ children }: any) => <>{children}</>,
     CalloutContainer: ({ type, children, icon, ...props }: any) => {
@@ -100,9 +100,9 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
       };
 
       return (
-        <Admonition variant={variantMap[type] || "ppg"} icon={icon} {...props}>
+        <Alert variant={variantMap[type] || "ppg"} icon={icon} {...props}>
           {children}
-        </Admonition>
+        </Alert>
       );
     },
   };

--- a/apps/eclipse/content/design-system/molecules/alert.mdx
+++ b/apps/eclipse/content/design-system/molecules/alert.mdx
@@ -9,7 +9,7 @@ import { Alert } from "@prisma/eclipse";
 
 **Basic Alert**
 
-The Alert component displays important information with a default info icon and the PPG variant.
+The Alert component displays important information with a default circle-exclamation icon and the PPG variant.
 
 ```tsx
 import { Alert } from "@prisma/eclipse";
@@ -254,7 +254,7 @@ export function ComplexAlerts() {
 ### Alert Props
 
 - `variant` - Visual style: `"ppg"`, `"error"`, `"success"`, or `"warning"` (optional, default: "ppg")
-- `icon` - Custom icon component or `null` to hide icon (ReactNode | null, optional, default: InfoIcon)
+- `icon` - Custom icon component or `null` to hide icon (ReactNode | null, optional, default: circle-exclamation icon)
 - `className` - Additional CSS classes (optional)
 - `children` - Alert content (any valid MDX/React content) (ReactNode, required)
 - Standard HTML div attributes
@@ -262,7 +262,7 @@ export function ComplexAlerts() {
 ### Features
 
 - ✅ Four semantic variants: ppg, error, success, warning
-- ✅ Default info icon with customization support
+- ✅ Default circle-exclamation icon with customization support
 - ✅ Accepts any MDX content (headings, paragraphs, lists, code, etc.)
 - ✅ Supports rich formatting and links
 - ✅ Accessible with proper ARIA roles

--- a/apps/eclipse/content/design-system/molecules/alert.mdx
+++ b/apps/eclipse/content/design-system/molecules/alert.mdx
@@ -1,24 +1,24 @@
 ---
-title: Admonition
-description: A versatile admonition component for displaying important messages and contextual information with support for different severity levels and custom icons.
+title: Alert
+description: A versatile alert component for displaying important messages and contextual information with support for different severity levels and custom icons.
 ---
 
-import { Admonition } from "@prisma/eclipse";
+import { Alert } from "@prisma/eclipse";
 
 ### Usage
 
-**Basic Admonition**
+**Basic Alert**
 
-The Admonition component displays important information with a default info icon and the PPG variant.
+The Alert component displays important information with a default info icon and the PPG variant.
 
 ```tsx
-import { Admonition } from "@prisma/eclipse";
+import { Alert } from "@prisma/eclipse";
 
-export function BasicAdmonition() {
+export function BasicAlert() {
   return (
-    <Admonition>
-      This is a basic admonition message with regular content.
-    </Admonition>
+    <Alert>
+      This is a basic alert message with regular content.
+    </Alert>
   );
 }
 ```
@@ -27,35 +27,35 @@ export function BasicAdmonition() {
   <p className="text-sm font-semibold mb-4">Live Example:</p>
 </div>
 
-<Admonition>
-  This is a basic admonition message with regular content.
-</Admonition>
+<Alert>
+  This is a basic alert message with regular content.
+</Alert>
 
-**Admonition Variants**
+**Alert Variants**
 
-The Admonition component supports four variants: `ppg`, `error`, `success`, and `warning`.
+The Alert component supports four variants: `ppg`, `error`, `success`, and `warning`.
 
 ```tsx
-import { Admonition } from "@prisma/eclipse";
+import { Alert } from "@prisma/eclipse";
 
-export function AdmonitionVariants() {
+export function AlertVariants() {
   return (
     <>
-      <Admonition variant="ppg">
+      <Alert variant="ppg">
         PPG variant - for general information and tips.
-      </Admonition>
+      </Alert>
 
-      <Admonition variant="success">
+      <Alert variant="success">
         Success variant - for positive confirmations.
-      </Admonition>
+      </Alert>
 
-      <Admonition variant="warning">
+      <Alert variant="warning">
         Warning variant - for important notices.
-      </Admonition>
+      </Alert>
 
-      <Admonition variant="error">
+      <Alert variant="error">
         Error variant - for errors and critical information.
-      </Admonition>
+      </Alert>
     </>
   );
 }
@@ -64,21 +64,21 @@ export function AdmonitionVariants() {
 <div className="not-prose my-6 space-y-4">
   <p className="text-sm font-semibold mb-4">Live Examples:</p>
 
-  <Admonition variant="ppg">
+  <Alert variant="ppg">
     PPG variant - for general information and tips.
-  </Admonition>
+  </Alert>
 
-  <Admonition variant="success">
+  <Alert variant="success">
     Success variant - for positive confirmations.
-  </Admonition>
+  </Alert>
 
-  <Admonition variant="warning">
+  <Alert variant="warning">
     Warning variant - for important notices.
-  </Admonition>
+  </Alert>
 
-  <Admonition variant="error">
+  <Alert variant="error">
     Error variant - for errors and critical information.
-  </Admonition>
+  </Alert>
 </div>
 
 **Custom Icons**
@@ -86,30 +86,30 @@ export function AdmonitionVariants() {
 You can customize the icon by passing a custom icon component or pass `null` to hide the icon.
 
 ```tsx
-import { Admonition } from "@prisma/eclipse";
+import { Alert } from "@prisma/eclipse";
 
-export function CustomIconAdmonitions() {
+export function CustomIconAlerts() {
   return (
     <>
-      <Admonition variant="ppg" icon={<i className="fa-regular fa-terminal h-4 w-4 mt-0.5" />}>
-        Admonition with a custom terminal icon.
-      </Admonition>
+      <Alert variant="ppg" icon={<i className="fa-regular fa-terminal h-4 w-4 mt-0.5" />}>
+        Alert with a custom terminal icon.
+      </Alert>
 
-      <Admonition variant="error" icon={<i className="fa-regular fa-circle-exclamation h-4 w-4 mt-0.5" />}>
-        Admonition with a custom error icon.
-      </Admonition>
+      <Alert variant="error" icon={<i className="fa-regular fa-circle-exclamation h-4 w-4 mt-0.5" />}>
+        Alert with a custom error icon.
+      </Alert>
 
-      <Admonition variant="success" icon={<i className="fa-regular fa-check h-4 w-4 mt-0.5" />}>
-        Admonition with a custom success icon.
-      </Admonition>
+      <Alert variant="success" icon={<i className="fa-regular fa-check h-4 w-4 mt-0.5" />}>
+        Alert with a custom success icon.
+      </Alert>
 
-      <Admonition variant="warning" icon={<i className="fa-regular fa-triangle-exclamation h-4 w-4 mt-0.5" />}>
-        Admonition with a custom warning icon.
-      </Admonition>
+      <Alert variant="warning" icon={<i className="fa-regular fa-triangle-exclamation h-4 w-4 mt-0.5" />}>
+        Alert with a custom warning icon.
+      </Alert>
 
-      <Admonition variant="ppg" icon={null}>
-        Admonition without an icon.
-      </Admonition>
+      <Alert variant="ppg" icon={null}>
+        Alert without an icon.
+      </Alert>
     </>
   );
 }
@@ -117,47 +117,47 @@ export function CustomIconAdmonitions() {
 
 <div className="not-prose my-6 space-y-4">
   <p className="text-sm font-semibold mb-4">Live Examples:</p>
-    <Admonition variant="ppg" icon={<i className="fa-regular fa-terminal h-4 w-4 mt-0.5" />}>
-      Admonition with a custom terminal icon.
-    </Admonition>
+    <Alert variant="ppg" icon={<i className="fa-regular fa-terminal h-4 w-4 mt-0.5" />}>
+      Alert with a custom terminal icon.
+    </Alert>
 
-    <Admonition variant="error" icon={<i className="fa-regular fa-circle-exclamation h-4 w-4 mt-0.5" />}>
-      Admonition with a custom error icon.
-    </Admonition>
+    <Alert variant="error" icon={<i className="fa-regular fa-circle-exclamation h-4 w-4 mt-0.5" />}>
+      Alert with a custom error icon.
+    </Alert>
 
-    <Admonition variant="success" icon={<i className="fa-regular fa-check h-4 w-4 mt-0.5" />}>
-      Admonition with a custom success icon.
-    </Admonition>
+    <Alert variant="success" icon={<i className="fa-regular fa-check h-4 w-4 mt-0.5" />}>
+      Alert with a custom success icon.
+    </Alert>
 
-    <Admonition variant="warning" icon={<i className="fa-regular fa-triangle-exclamation h-4 w-4 mt-0.5" />}>
-      Admonition with a custom warning icon.
-    </Admonition>
+    <Alert variant="warning" icon={<i className="fa-regular fa-triangle-exclamation h-4 w-4 mt-0.5" />}>
+      Alert with a custom warning icon.
+    </Alert>
 
-    <Admonition variant="ppg" icon={null}>
-      Admonition without an icon.
-    </Admonition>
+    <Alert variant="ppg" icon={null}>
+      Alert without an icon.
+    </Alert>
 </div>
 
 **Rich MDX Content**
 
-The Admonition component accepts and renders any MDX content including headings, paragraphs, lists, links, and code.
+The Alert component accepts and renders any MDX content including headings, paragraphs, lists, links, and code.
 
 ```tsx
-import { Admonition } from "@prisma/eclipse";
+import { Alert } from "@prisma/eclipse";
 
-export function RichContentAdmonition() {
+export function RichContentAlert() {
   return (
-    <Admonition variant="ppg">
+    <Alert variant="ppg">
       **Getting Started**
-      
+
       Follow these steps to get started:
-      
+
       1. Install the package: `npm install @prisma/client`
       2. Initialize Prisma: `npx prisma init`
       3. Define your schema and run migrations
-      
+
       For more information, visit the [documentation](https://prisma.io/docs).
-    </Admonition>
+    </Alert>
   );
 }
 ```
@@ -177,37 +177,37 @@ For more information, visit the [documentation](https://prisma.io/docs).
 **Complex Content Examples**
 
 ```tsx
-import { Admonition } from "@prisma/eclipse";
+import { Alert } from "@prisma/eclipse";
 
-export function ComplexAdmonitions() {
+export function ComplexAlerts() {
   return (
     <>
-      <Admonition variant="warning">
+      <Alert variant="warning">
         ### Important Update
-        
+
         This feature will be deprecated in version 6.0. Please migrate to the new API:
-        
+
         - Old: `prisma.user.findMany()`
         - New: `prisma.user.findMany({ where: {} })`
-      </Admonition>
+      </Alert>
 
-      <Admonition variant="error">
+      <Alert variant="error">
         **Connection Error**
-        
+
         Unable to connect to the database. Please check:
-        
+
         - Database credentials in `.env`
         - Database server is running
         - Network connectivity
-      </Admonition>
+      </Alert>
 
-      <Admonition variant="success">
+      <Alert variant="success">
         Your migration was successful! The following changes were applied:
-        
+
         - Created table `User`
         - Added index on `email` column
         - Updated foreign key constraints
-      </Admonition>
+      </Alert>
     </>
   );
 }
@@ -216,7 +216,7 @@ export function ComplexAdmonitions() {
 <div className="not-prose my-6 space-y-4">
   <p className="text-sm font-semibold mb-4">Live Examples:</p>
 
-  <Admonition variant="warning">
+  <Alert variant="warning">
     <div>
       <h3 className="text-base font-semibold mb-2">Important Update</h3>
       <p className="mb-2">This feature will be deprecated in version 6.0. Please migrate to the new API:</p>
@@ -225,9 +225,9 @@ export function ComplexAdmonitions() {
         <li>New: <code>prisma.user.findMany({`{ where: {} }`})</code></li>
       </ul>
     </div>
-  </Admonition>
+  </Alert>
 
-  <Admonition variant="error">
+  <Alert variant="error">
     <div>
       <p className="font-bold mb-2">Connection Error</p>
       <p className="mb-2">Unable to connect to the database. Please check:</p>
@@ -237,9 +237,9 @@ export function ComplexAdmonitions() {
         <li>Network connectivity</li>
       </ul>
     </div>
-  </Admonition>
+  </Alert>
 
-  <Admonition variant="success">
+  <Alert variant="success">
     <div>
       <p className="mb-2">Your migration was successful! The following changes were applied:</p>
       <ul className="list-disc list-inside space-y-1">
@@ -248,15 +248,15 @@ export function ComplexAdmonitions() {
         <li>Updated foreign key constraints</li>
       </ul>
     </div>
-  </Admonition>
+  </Alert>
 </div>
 
-### Admonition Props
+### Alert Props
 
 - `variant` - Visual style: `"ppg"`, `"error"`, `"success"`, or `"warning"` (optional, default: "ppg")
 - `icon` - Custom icon component or `null` to hide icon (ReactNode | null, optional, default: InfoIcon)
 - `className` - Additional CSS classes (optional)
-- `children` - Admonition content (any valid MDX/React content) (ReactNode, required)
+- `children` - Alert content (any valid MDX/React content) (ReactNode, required)
 - Standard HTML div attributes
 
 ### Features
@@ -278,14 +278,14 @@ export function ComplexAdmonitions() {
 - Use `variant="error"` for errors, failures, and critical information
 - Choose icons that match the message type and variant
 - Pass `icon={null}` if the message is self-explanatory without an icon
-- Use headings (`##`, `###`) to structure complex admonition content
+- Use headings (`##`, `###`) to structure complex alert content
 - Include actionable information or next steps when appropriate
-- Keep admonitions concise but informative
-- Don't overuse admonitions - reserve them for important information
+- Keep alerts concise but informative
+- Don't overuse alerts - reserve them for important information
 
 ### Common Use Cases
 
-The Admonition component is perfect for:
+The Alert component is perfect for:
 
 - **Documentation callouts** - Highlight important information in docs
 - **Feature announcements** - Announce new or beta features
@@ -296,13 +296,13 @@ The Admonition component is perfect for:
 - **Warning messages** - Alert users to important considerations
 - **Tips and notes** - Provide helpful tips and additional context
 
-### MDX Admonition Syntax
+### MDX Alert Syntax
 
-This Admonition component is automatically used for MDX admonition blocks when configured in your MDX components. The following syntaxes are supported:
+This Alert component is automatically used for MDX alert blocks when configured in your MDX components. The following syntaxes are supported:
 
 ```mdx
 :::ppg
-This is a PPG admonition using MDX admonition syntax.
+This is a PPG alert using MDX alert syntax.
 
 ## You can use any MDX content
 
@@ -310,15 +310,15 @@ Including lists, code, and more!
 :::
 
 :::error
-This is an error admonition.
+This is an error alert.
 :::
 
 :::success
-This is a success admonition.
+This is a success alert.
 :::
 
 :::warning
-This is a warning admonition.
+This is a warning alert.
 :::
 
 :::info
@@ -346,7 +346,7 @@ Maps to error variant.
 
 :::ppg
 
-This demonstrates how the `:::ppg` syntax renders as an Admonition component.
+This demonstrates how the `:::ppg` syntax renders as an Alert component.
 
 You can include:
 
@@ -359,8 +359,8 @@ You can include:
 
 ### Accessibility
 
-- The Admonition component includes `role="alert"` for screen readers
+- The Alert component includes `role="alert"` for screen readers
 - Icons are decorative and don't convey meaning alone - always include descriptive text
-- Color is not the only indicator of admonition type (icons and context provide additional cues)
+- Color is not the only indicator of alert type (icons and context provide additional cues)
 - All variants maintain appropriate color contrast ratios
-- Admonition content is keyboard accessible and screen reader friendly
+- Alert content is keyboard accessible and screen reader friendly

--- a/apps/eclipse/content/design-system/molecules/meta.json
+++ b/apps/eclipse/content/design-system/molecules/meta.json
@@ -3,7 +3,6 @@
   "description": "Compound UI components in the Eclipse Design System",
   "icon": "Component",
   "pages": [
-    "admonition",
     "accordion",
     "alert",
     "banner",

--- a/packages/eclipse/src/components/alert.tsx
+++ b/packages/eclipse/src/components/alert.tsx
@@ -3,8 +3,8 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "../lib/cn";
 
-const admonitionVariants = cva(
-  "relative w-full rounded-md border p-4 gap-3 text-sm [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg]:w-5 [&>svg]:h-5 alert-admonition flex items-start [&>i]:mt-0.5",
+const alertVariants = cva(
+  "relative w-full rounded-md border p-4 gap-3 text-sm [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg]:w-5 [&>svg]:h-5 alert-alert flex items-start [&>i]:mt-0.5",
   {
     variants: {
       variant: {
@@ -23,12 +23,12 @@ const admonitionVariants = cva(
   },
 );
 
-type AdmonitionProps = React.HTMLAttributes<HTMLDivElement> &
-  VariantProps<typeof admonitionVariants> & {
+type AlertProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof alertVariants> & {
     icon?: React.ReactNode;
   };
 
-const Admonition = React.forwardRef<HTMLDivElement, AdmonitionProps>(
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
   ({ className, variant, icon, children, ...props }, ref) => {
     const IconComponent =
       icon !== undefined ? (
@@ -40,7 +40,7 @@ const Admonition = React.forwardRef<HTMLDivElement, AdmonitionProps>(
       <div
         ref={ref}
         role="alert"
-        className={cn(admonitionVariants({ variant }), className)}
+        className={cn(alertVariants({ variant }), className)}
         {...props}
       >
         {IconComponent}
@@ -51,6 +51,6 @@ const Admonition = React.forwardRef<HTMLDivElement, AdmonitionProps>(
     );
   },
 );
-Admonition.displayName = "Admonition";
+Alert.displayName = "Alert";
 
-export { Admonition };
+export { Alert };

--- a/packages/eclipse/src/components/index.ts
+++ b/packages/eclipse/src/components/index.ts
@@ -152,5 +152,5 @@ export {
   PaginationInput,
 } from "./pagination";
 
-export { Admonition } from "./admonition";
+export { Alert } from "./alert";
 export { Switch } from "./switch";


### PR DESCRIPTION
- Renames the Admonition component back to Alert across the Eclipse design system and docs app
- Updates the component file, MDX documentation, and all import references

Changed files

- packages/eclipse/src/components/admonition.tsx → alert.tsx
- packages/eclipse/src/components/index.ts — export renamed
- apps/docs/src/mdx-components.tsx — import and usage updated
- content/design-system/molecules/admonition.mdx → alert.mdx
- content/design-system/molecules/meta.json — sidebar entry updated

Test plan

- Verify docs site builds successfully (pnpm build)
- Confirm :::note, :::warning, :::error, :::success directives still render correctly
- Check the design system molecules page renders the Alert documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the Admonition component family to Alert across the codebase and public API.
  * Updated exported component names and variant identifiers to use Alert.

* **Documentation**
  * Replaced all Admonition documentation, examples, live demos, headings, and MDX syntax with Alert equivalents.
  * Updated wording and examples (including default icon description) to reference Alert.

* **Chores**
  * Removed legacy "admonition" page entry from site metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->