### PR TITLE
fix(docs): DR-7592 fix logo separator spacing in navbar

### DIFF
--- a/apps/docs/src/lib/layout.shared.tsx
+++ b/apps/docs/src/lib/layout.shared.tsx
@@ -7,18 +7,8 @@ import Link from "next/link";
 
 export const logo = (
   <>
-    <Image
-      alt="Prisma"
-      src={logoDark}
-      aria-label="Prisma"
-      className="dark:hidden"
-    />
-    <Image
-      alt="Prisma"
-      src={logoWhite}
-      aria-label="Prisma"
-      className="hidden dark:block"
-    />
+    <Image alt="Prisma" src={logoDark} aria-label="Prisma" className="dark:hidden" />
+    <Image alt="Prisma" src={logoWhite} aria-label="Prisma" className="hidden dark:block" />
   </>
 );
 
@@ -81,17 +71,12 @@ export function baseOptions(): BaseLayoutProps {
     nav: {
       title: (
         <>
-          <Link
-            href="https://www.prisma.io"
-            className="mb-0 hover:mb-1 transition-[margin] -mr-3!"
-          >
+          <Link href="https://www.prisma.io" className="mb-0 hover:mb-1 transition-[margin]">
             {logo}
-          </Link>{" "}
-          /
+          </Link>
+          <span className="text-fd-muted-foreground">/</span>
           <Link href="/" className="group relative inline-block pl-3 -ml-3!">
-            <span className="font-mono text-lg mt-1 block group-hover:mt-0 transition-[margin]">
-              docs
-            </span>
+            <span className="font-mono text-lg block translate-y-px">docs</span>
           </Link>
         </>
       ),


### PR DESCRIPTION
## Summary
- Removed `-mr-3!` negative margin from the Prisma logo link that was pulling the `/` separator into the logo text
- Wrapped `/` separator in a `<span>` with `text-fd-muted-foreground` for proper flex spacing and visual hierarchy
- Removed `{" "}` space hack (parent `gap-2.5` handles spacing)
- Added `translate-y-px` to "docs" text for precise vertical alignment with the SVG logo

## Linear
https://linear.app/prisma-company/issue/DR-7592/docs-fix-broken-prisma-docs-logo-separator-in-sidebar

## Test plan
- [ ] Verify "Prisma / docs" logo has proper spacing in the navbar
- [ ] Check both light and dark modes
- [ ] Verify Prisma logo link and docs link are both clickable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined header navigation spacing and layout adjustments
  * Added a visual separator in the navigation
  * Optimized component formatting for cleaner code structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->