### PR TITLE
fix: Update react eclipse

### DIFF
--- a/packages/eclipse/package.json
+++ b/packages/eclipse/package.json
@@ -76,8 +76,8 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
     "tailwindcss": "^4.0.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,7 +33,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -625,10 +625,10 @@ importers:
         specifier: 'catalog:'
         version: 0.575.0(react@19.2.4)
       react:
-        specifier: ^19.0.0
+        specifier: ^19.2.0
         version: 19.2.4
       react-dom:
-        specifier: ^19.0.0
+        specifier: ^19.2.0
         version: 19.2.4(react@19.2.4)
       recharts:
         specifier: 'catalog:'
@@ -680,10 +680,10 @@ importers:
         specifier: 'catalog:'
         version: 0.575.0(react@19.2.4)
       react:
-        specifier: ^19.0.0
+        specifier: ^19.2.0
         version: 19.2.4
       react-dom:
-        specifier: ^19.0.0
+        specifier: ^19.2.0
         version: 19.2.4(react@19.2.4)
       tailwind-merge:
         specifier: 'catalog:'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated React and React-DOM peer dependency requirements from version 19.0.0 to 19.2.0 in the Eclipse and UI packages. If you are using these packages, verify that your project is compatible with the updated React version requirements for seamless integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->