### PR TITLE
chore(docs): rename API keys to connection strings

### DIFF
--- a/apps/docs/content/docs/(index)/prisma-postgres/import-from-existing-database-mysql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-postgres/import-from-existing-database-mysql.mdx
@@ -44,9 +44,9 @@ Follow these steps to create a new Prisma Postgres database:
 Once your database is** **provisioned, find your direct Prisma Postgres connection string:
 
 1. Navigate to your active Prisma Postgres instance.
-1. Click the **API Keys** tab in the project's sidenav.
-1. Click the **Create API key** button.
-1. In the popup, provide a **Name** for the API key and click **Create**.
+1. Click the **Connection Strings** tab in the project's sidenav.
+1. Click the **Create connection string** button.
+1. In the popup, provide a **Name** for the connection string and click **Create**.
 1. Copy the connection string starting with `postgres://`, this is your direct connection string.
 
 Save the connection string, as you'll need it in step 3.

--- a/apps/docs/content/docs/(index)/prisma-postgres/import-from-existing-database-postgresql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-postgres/import-from-existing-database-postgresql.mdx
@@ -43,9 +43,9 @@ Follow these steps to create a new Prisma Postgres database:
 Once your database is provisioned, obtain your direct connection string:
 
 1. Navigate to your active Prisma Postgres instance.
-1. Click the **API Keys** tab in the project's sidenav.
-1. Click the **Create API key** button.
-1. In the popup, provide a **Name** for the API key and click **Create**.
+1. Click the **Connection Strings** tab in the project's sidenav.
+1. Click the **Create connection string** button.
+1. In the popup, provide a **Name** for the connection string and click **Create**.
 1. Copy the connection string starting with `postgres://`, this is your direct connection string.
 
 Save the connection string, as you'll need it in step 3.

--- a/apps/docs/content/docs/cli/console/apikey.mdx
+++ b/apps/docs/content/docs/cli/console/apikey.mdx
@@ -1,13 +1,13 @@
 ---
 title: apikey
-description: 'Create, list, and delete API keys for Prisma Console environments'
-metaTitle: prisma platform apikey | Manage Console API Keys
-metaDescription: 'Create, list, and delete API keys for Prisma Console environments. Use prisma platform apikey show, create, and delete with --early-access.'
+description: 'Create, list, and delete connection strings for Prisma Console environments'
+metaTitle: prisma platform apikey | Manage Console Connection Strings
+metaDescription: 'Create, list, and delete connection strings for Prisma Console environments. Use prisma platform apikey show, create, and delete with --early-access.'
 badge: early-access
 url: /cli/console/apikey
 ---
 
-The `prisma platform apikey` command manages API keys for Prisma Console environments.
+The `prisma platform apikey` command manages connection strings for Prisma Console environments.
 
 ## Usage
 
@@ -17,36 +17,36 @@ prisma platform apikey [action] [options] --early-access
 
 ## Actions
 
-| Action   | Description              |
-| -------- | ------------------------ |
-| `show`   | List all API keys        |
-| `create` | Create a new API key     |
-| `delete` | Delete an API key        |
+| Action   | Description                    |
+| -------- | ------------------------------ |
+| `show`   | List all connection strings    |
+| `create` | Create a new connection string |
+| `delete` | Delete a connection string     |
 
 ## Options
 
-| Option              | Description                                                      |
-| ------------------- | ---------------------------------------------------------------- |
-| `-h`, `--help`      | Display help message                                             |
-| `-e`, `--environment` | The environment ID (required for `show` and `create` commands)   |
-| `-a`, `--apikey`    | The API key ID (required for `delete` command)                   |
-| `-n`, `--name`      | Display name for the API key (optional for `create` command)     |
+| Option              | Description                                                              |
+| ------------------- | ------------------------------------------------------------------------ |
+| `-h`, `--help`      | Display help message                                                     |
+| `-e`, `--environment` | The environment ID (required for `show` and `create` commands)         |
+| `-a`, `--apikey`    | The connection string ID (required for `delete` command)                 |
+| `-n`, `--name`      | Display name for the connection string (optional for `create` command)   |
 
 ## Examples
 
-### List API keys
+### List connection strings
 
 ```npm
 npx prisma platform apikey show --environment $ENVIRONMENT_ID --early-access
 ```
 
-### Create an API key
+### Create a connection string
 
 ```npm
 npx prisma platform apikey create --environment $ENVIRONMENT_ID --name "production-key" --early-access
 ```
 
-### Delete an API key
+### Delete a connection string
 
 ```npm
 npx prisma platform apikey delete --apikey $API_KEY_ID --early-access

--- a/apps/docs/content/docs/cli/console/index.mdx
+++ b/apps/docs/content/docs/cli/console/index.mdx
@@ -1,13 +1,13 @@
 ---
 title: platform
-description: 'Manage Prisma Console workspaces, projects, environments, and API keys'
+description: 'Manage Prisma Console workspaces, projects, environments, and connection strings'
 badge: early-access
 url: /cli/console
 metaTitle: 'Platform CLI: About'
 metaDescription: Learn about the CLI for Prisma Console
 ---
 
-The `prisma platform` command group provides tools to manage Prisma Console workspaces, projects, environments, and API keys.
+The `prisma platform` command group provides tools to manage Prisma Console workspaces, projects, environments, and connection strings.
 
 :::warning[Legacy GraphQL API]
 
@@ -36,7 +36,7 @@ prisma platform [command] [options] --early-access
 | [`prisma platform workspace`](/cli/console/workspace)       | Manage workspaces                |
 | [`prisma platform project`](/cli/console/project)           | Manage projects                  |
 | [`prisma platform environment`](/cli/console/environment)   | Manage environments              |
-| [`prisma platform apikey`](/cli/console/apikey)             | Manage API keys                  |
+| [`prisma platform apikey`](/cli/console/apikey)             | Manage connection strings        |
 
 ## Examples
 
@@ -53,7 +53,7 @@ prisma platform project create --workspace $WORKSPACE_ID --name "My Project" --e
 # Create an environment
 prisma platform environment create --project $PROJECT_ID --name "production" --early-access
 
-# Create an API key
+# Create a connection string
 prisma platform apikey create --environment $ENVIRONMENT_ID --name "production-key" --early-access
 ```
 

--- a/apps/docs/content/docs/cli/console/platform.mdx
+++ b/apps/docs/content/docs/cli/console/platform.mdx
@@ -1,13 +1,13 @@
 ---
 title: platform
-description: 'Manage Prisma Console workspaces, projects, environments, and API keys'
+description: 'Manage Prisma Console workspaces, projects, environments, and connection strings'
 metaTitle: prisma platform | Console CLI Commands Reference
-metaDescription: 'Manage Prisma Console workspaces, projects, environments, and API keys from the CLI. Auth, workspace, project, environment, and apikey subcommands.'
+metaDescription: 'Manage Prisma Console workspaces, projects, environments, and connection strings from the CLI. Auth, workspace, project, environment, and apikey subcommands.'
 badge: early-access
 url: /cli/console/platform
 ---
 
-The `prisma platform` command provides access to Prisma Console functionality for managing workspaces, projects, environments, and API keys.
+The `prisma platform` command provides access to Prisma Console functionality for managing workspaces, projects, environments, and connection strings.
 
 ## Usage
 
@@ -23,7 +23,7 @@ prisma platform [subcommand] [options] --early-access
 | `workspace`   | Manage workspaces                |
 | `project`     | Manage projects                  |
 | `environment` | Manage environments              |
-| `apikey`      | Manage API keys                  |
+| `apikey`      | Manage connection strings        |
 
 ## Examples
 
@@ -95,21 +95,21 @@ Delete an environment:
 npx prisma platform environment delete --environment $ENVIRONMENT_ID --early-access
 ```
 
-### Manage API keys
+### Manage connection strings
 
-List all API keys for an environment:
+List all connection strings for an environment:
 
 ```npm
 npx prisma platform apikey show --environment $ENVIRONMENT_ID --early-access
 ```
 
-Create a new API key for an environment:
+Create a new connection string for an environment:
 
 ```npm
 npx prisma platform apikey create --environment $ENVIRONMENT_ID --name "production-key" --early-access
 ```
 
-Delete an API key:
+Delete a connection string:
 
 ```npm
 npx prisma platform apikey delete --apikey $API_KEY_ID --early-access
@@ -147,14 +147,14 @@ npx prisma platform apikey delete --apikey $API_KEY_ID --early-access
 | `-e`, `--environment` | The environment ID (required for `delete` command)                  |
 | `-n`, `--name`      | Display name for the environment (optional for `create` command)    |
 
-### API key commands
+### Connection string commands
 
-| Option              | Description                                                      |
-| ------------------- | ---------------------------------------------------------------- |
-| `-h`, `--help`      | Display help message                                             |
-| `-e`, `--environment` | The environment ID (required for `show` and `create` commands)   |
-| `-a`, `--apikey`    | The API key ID (required for `delete` command)                   |
-| `-n`, `--name`      | Display name for the API key (optional for `create` command)     |
+| Option              | Description                                                              |
+| ------------------- | ------------------------------------------------------------------------ |
+| `-h`, `--help`      | Display help message                                                     |
+| `-e`, `--environment` | The environment ID (required for `show` and `create` commands)         |
+| `-a`, `--apikey`    | The connection string ID (required for `delete` command)                 |
+| `-n`, `--name`      | Display name for the connection string (optional for `create` command)   |
 
 ### Global options
 

--- a/apps/docs/content/docs/console/concepts.mdx
+++ b/apps/docs/content/docs/console/concepts.mdx
@@ -2,7 +2,7 @@
 title: Concepts
 description: 'Understand the core concepts of the Prisma Console: user accounts, workspaces, projects, and resources'
 metaTitle: Prisma Console Concepts | Workspaces, Projects & Resources
-metaDescription: 'Learn Prisma Console hierarchy: user accounts, workspaces (billing level), projects (apps), and resources (databases, environments). API keys scoped per resource.'
+metaDescription: 'Learn Prisma Console hierarchy: user accounts, workspaces (billing level), projects (apps), and resources (databases, environments). Connection strings scoped per resource.'
 url: /console/concepts
 ---
 
@@ -11,7 +11,7 @@ The Console workflows are based on four main concepts:
 - [**User account**](#user-account): In order to use Prisma products, you need to have a Console user account. A _user_ will typically create one user account to manage all their workspaces, projects and resources. The _user_ can also be invited to join other workspaces to collaborate on the projects in that workspace.
 - [**Workspaces**](#workspace): A user account can belong to multiple workspaces. A workspace typically represents a _team_ of individuals working together on one or more projects. **Billing is on a workspace level**, i.e. the invoice for a workspace at the end of the month captures all costs associated with the projects in that workspace.
 - [**Projects**](#project): A project belongs to a workspace. It typically represents the _application_ or _service_ a team is working on.
-- [**Resources**](#resources): Resources represent the actual services or databases within a project. For example, in Prisma Postgres, each project can contain multiple databases. For Accelerate, resources might correspond to different environments (like `Development`, `Staging`, or `Production`). **API keys are provisioned at the resource level**, and products are configured per resource as well (e.g., the database connection string used for Accelerate).
+- [**Resources**](#resources): Resources represent the actual services or databases within a project. For example, in Prisma Postgres, each project can contain multiple databases. For Accelerate, resources might correspond to different environments (like `Development`, `Staging`, or `Production`). **Connection strings are provisioned at the resource level**, and products are configured per resource as well (e.g., the database connection string used for Accelerate).
 
 Here is a visual illustration of how these concepts relate to each other:
 
@@ -83,7 +83,7 @@ Resources represent the actual services or databases within a project. The type 
 In each project, you can:
 
 - Create and manage multiple resources (databases or environments)
-- Generate API keys specific to each resource
+- Generate connection strings specific to each resource
 - Configure product-specific settings:
   - **For Prisma Postgres databases**:
     - View database metrics and performance

--- a/apps/docs/content/docs/console/getting-started.mdx
+++ b/apps/docs/content/docs/console/getting-started.mdx
@@ -2,7 +2,7 @@
 title: Getting Started
 description: Quick start guide for setting up and using the Prisma Console
 metaTitle: Prisma Console Getting Started | Setup in 6 Steps
-metaDescription: 'Set up Prisma Console: sign in with GitHub, create workspace and project, provision database or environment, generate API keys for Accelerate or Optimize.'
+metaDescription: 'Set up Prisma Console: sign in with GitHub, create workspace and project, provision database or environment, generate connection strings for Accelerate or Optimize.'
 url: /console/getting-started
 ---
 
@@ -84,17 +84,17 @@ Resources are the actual databases or environments within your project.
 npx prisma platform environment create --project $PROJECT_ID --name "production" --early-access
 ```
 
-## Step 5: Generate an API key
+## Step 5: Generate a connection string
 
-API keys authenticate your application's requests to Prisma products.
+Connection strings authenticate your application's requests to Prisma products.
 
 ### Using the Console web interface
 
 1. Navigate to your resource (database or environment)
-2. Click **API Keys** tab
-3. Click **Create API Key**
-4. Enter a name for the key
-5. Copy the API key and store it securely
+2. Click **Connection Strings** tab
+3. Click **Create Connection String**
+4. Enter a name for the connection string
+5. Copy the connection string and store it securely
 6. Click **Done**
 
 ### Using the CLI
@@ -103,9 +103,9 @@ API keys authenticate your application's requests to Prisma products.
 npx prisma platform apikey create --environment $ENVIRONMENT_ID --name "production-key" --early-access
 ```
 
-## Step 6: Use the API key in your application
+## Step 6: Use the connection string in your application
 
-Add the API key to your `.env` file:
+Add the connection string to your `.env` file:
 
 ```bash
 # For Accelerate

--- a/apps/docs/content/docs/console/index.mdx
+++ b/apps/docs/content/docs/console/index.mdx
@@ -21,7 +21,7 @@ To start using Prisma products, you'll need to:
 1. Create a Console account
 2. Set up a workspace for your team
 3. Create a project for your application
-4. Generate API keys for your resources
+4. Generate connection strings for your resources
 
 Learn more in the [Getting Started](/console/getting-started) guide.
 

--- a/apps/docs/content/docs/guides/postgres/viewing-data.mdx
+++ b/apps/docs/content/docs/guides/postgres/viewing-data.mdx
@@ -30,7 +30,7 @@ You can connect to your Prisma Postgres instance using third party database edit
 
 If you already have a `.env` file in your current directory with `DATABASE_URL` set, the tunnel CLI will automatically pick it up, no need to manually export it. However, if you haven't set up a `.env` file, you'll need to set the `DATABASE_URL` environment variable explicitly.
 
-In your terminal, to set the environment variable `DATABASE_URL` referring to your Prisma Postgres instance which you want to connect to (be sure to replace the `API_KEY` placeholder with the API key value of your Prisma Postgres instance):
+In your terminal, to set the environment variable `DATABASE_URL` referring to your Prisma Postgres instance which you want to connect to (be sure to replace the `API_KEY` placeholder with the connection string value for your Prisma Postgres instance):
 
 ```bash tab="macOS"
 export DATABASE_URL="prisma+postgres://accelerate.prisma-data.net/?api_key=API_KEY"

--- a/apps/docs/content/docs/guides/runtimes/bun.mdx
+++ b/apps/docs/content/docs/guides/runtimes/bun.mdx
@@ -85,9 +85,9 @@ This command creates:
 We're going to use a direct connection string for connecting to Prisma Postgres. To get your [direct connection string](/postgres/database/direct-connections#how-to-connect-to-prisma-postgres-via-direct-tcp):
 
 1. Navigate to your recently created Prisma Postgres project dashboard (e.g. "My Bun Project")
-2. Click the **API Keys** tab in the project's sidebar
-3. Click the **Create API key** button
-4. Provide a name for the API key and click **Create**
+2. Click the **Connection Strings** tab in the project's sidebar
+3. Click the **Create connection string** button
+4. Provide a name for the connection string and click **Create**
 5. Copy the connection string starting with `postgres://`
 
 Update your `.env` file to replace the `DATABASE_URL` with the new connection string:

--- a/apps/docs/content/docs/guides/runtimes/deno.mdx
+++ b/apps/docs/content/docs/guides/runtimes/deno.mdx
@@ -115,9 +115,9 @@ export default defineConfig({
 We're going to use a direct connection string for connecting to Prisma Postgres. To get your [direct connection string](/postgres/database/direct-connections#how-to-connect-to-prisma-postgres-via-direct-tcp):
 
 1. Navigate to your recently created Prisma Postgres project dashboard (e.g. "My Deno Project")
-2. Click the **API Keys** tab in the project's sidebar
-3. Click the **Create API key** button
-4. Provide a name for the API key and click **Create**
+2. Click the **Connection Strings** tab in the project's sidebar
+3. Click the **Create connection string** button
+4. Provide a name for the connection string and click **Create**
 5. Copy the connection string starting with `postgres://`
 
 Update your `.env` file to replace the `DATABASE_URL` with the new connection string:


### PR DESCRIPTION
Linear: DR-7581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect connection strings workflow instead of API keys.
  * Revised getting started guides and CLI references with updated terminology and UI steps.
  * Updated environment variable examples to use connection string configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->