### PR TITLE
fix(postgres): replaced pool url param with pooled hostname

### DIFF
--- a/apps/docs/content/docs/postgres/database/connection-pooling.mdx
+++ b/apps/docs/content/docs/postgres/database/connection-pooling.mdx
@@ -16,17 +16,17 @@ Prisma Postgres supports connection pooling through [TCP connections](#connectio
 TCP connection pooling is currently in [Early Access](/console/more/feature-maturity#early-access).
 :::
 
-To use a pooled connection, append `&pool=true` to your Prisma Postgres TCP connection string:
+To use a pooled connection, use the `pooled.db.prisma.io` hostname in your connection string:
 
 ```bash
 # Direct connection (no pooling)
 DATABASE_URL="postgres://USER:PASSWORD@db.prisma.io:5432/?sslmode=require"
 
 # Pooled connection
-DATABASE_URL="postgres://USER:PASSWORD@db.prisma.io:5432/?sslmode=require&pool=true"
+DATABASE_URL="postgres://USER:PASSWORD@pooled.db.prisma.io:5432/?sslmode=require"
 ```
 
-You can also enable connection pooling when generating your connection string in the [Prisma Console](https://console.prisma.io) by toggling on the **pooling** option.
+You can also enable connection pooling when generating your connection string in the [Prisma Console](https://console.prisma.io) by setting the **Enable connection pooling** option to true.
 
 This works with any PostgreSQL client, ORM, or database tool you already use.
 


### PR DESCRIPTION
This PR replaces the `pool=true` url param for connection pooling with the new pooled hostname.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated connection pooling configuration instructions to use the pooled hostname approach instead of query parameters.
  * Clarified Prisma Console guidance for enabling connection pooling options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->