### PR TITLE
Add missing sizes to Input, Textarea and Badge

### DIFF
--- a/apps/eclipse/content/design-system/atoms/badge.mdx
+++ b/apps/eclipse/content/design-system/atoms/badge.mdx
@@ -3,7 +3,7 @@ title: Badge
 description: A label component that displays text with a colored background to highlight status, categories, or metadata.
 ---
 
-import { Badge } from "@prisma/eclipse";
+import { Badge, badgeVariants } from "@prisma/eclipse";
 
 ### Usage
 
@@ -110,9 +110,32 @@ export function ArticleCategories() {
   <Badge color="success" label="Best Practice" />
 </div>
 
+**Badge Sizes**
+
+```tsx
+import { Badge } from "@prisma/eclipse";
+
+export function BadgeSizes() {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Badge size="md" color="neutral" label="Medium (default)" />
+      <Badge size="lg" color="neutral" label="Large" />
+    </div>
+  );
+}
+```
+
+**Live Example:**
+
+<div className="flex flex-wrap items-center gap-2 my-4">
+  <Badge size="md" color="neutral" label="Medium (default)" />
+  <Badge size="lg" color="neutral" label="Large" />
+</div>
+
 ### Badge Props
 
-- `color` - The color variant: `"neutral"`, `"ppg"`, `"orm"`, `"error"`, `"success"`, `"warning"` (required)
+- `color` - The color variant: `"neutral"`, `"ppg"`, `"orm"`, `"error"`, `"success"`, `"warning"` (default: "neutral")
+- `size` - The size variant: `"md"`, `"lg"` (default: "md")
 - `label` - The text to display inside the badge (required)
 - `className` - Additional CSS classes (optional)
 
@@ -163,6 +186,7 @@ Indicates warnings, beta features, or items requiring attention.
 ### Features
 
 - ✅ Six semantic color variants
+- ✅ Size variants via CVA (md, lg)
 - ✅ Eclipse design system color tokens
 - ✅ Consistent typography and spacing
 - ✅ Flexible sizing that adapts to content

--- a/apps/eclipse/content/design-system/atoms/input.mdx
+++ b/apps/eclipse/content/design-system/atoms/input.mdx
@@ -3,7 +3,7 @@ title: Input
 description: A text input component for forms with multiple sizes and built-in validation styles.
 ---
 
-import { Input, Button, Field, FieldLabel, FieldDescription, FieldError } from "@prisma/eclipse";
+import { Input, inputVariants, Button, Field, FieldLabel, FieldDescription, FieldError } from "@prisma/eclipse";
 
 ### Usage
 
@@ -94,8 +94,8 @@ export function InputWithField() {
   return (
     <Field>
       <FieldLabel htmlFor="username">Username</FieldLabel>
-      <FieldDescription>Choose a unique username for your account.</FieldDescription>
       <Input id="username" placeholder="Enter your username" />
+      <FieldDescription>Choose a unique username for your account.</FieldDescription>
     </Field>
   );
 }
@@ -106,37 +106,9 @@ export function InputWithField() {
 <div className="max-w-md my-4">
   <Field>
     <FieldLabel htmlFor="username-field">Username</FieldLabel>
-    <FieldDescription>Choose a unique username for your account.</FieldDescription>
     <Input id="username-field" placeholder="Enter your username" />
+    <FieldDescription>Choose a unique username for your account.</FieldDescription>
   </Field>
-</div>
-
-**With Basic Labels**
-
-You can also use plain labels without the Field component:
-
-```tsx
-import { Input } from "@prisma/eclipse";
-
-export function InputWithLabel() {
-  return (
-    <div className="space-y-2 max-w-md">
-      <label htmlFor="username" className="text-sm font-medium">
-        Username
-      </label>
-      <Input id="username" placeholder="Enter your username" />
-    </div>
-  );
-}
-```
-
-**Live Example:**
-
-<div className="space-y-2 max-w-md my-4">
-  <label htmlFor="username" className="text-sm font-medium">
-    Username
-  </label>
-  <Input id="username" placeholder="Enter your username" />
 </div>
 
 **Disabled State**
@@ -172,13 +144,13 @@ export function InvalidInputWithField() {
   return (
     <Field>
       <FieldLabel htmlFor="email-invalid">Email</FieldLabel>
-      <FieldDescription>We'll send updates to this address.</FieldDescription>
       <Input
         id="email-invalid"
         type="email"
         defaultValue="invalid-email"
         aria-invalid="true"
       />
+      <FieldDescription>We'll send updates to this address.</FieldDescription>
       <FieldError>Please enter a valid email address</FieldError>
     </Field>
   );
@@ -190,13 +162,13 @@ export function InvalidInputWithField() {
 <div className="max-w-md my-4">
   <Field>
     <FieldLabel htmlFor="email-invalid-field">Email</FieldLabel>
-    <FieldDescription>We'll send updates to this address.</FieldDescription>
     <Input
       id="email-invalid-field"
       type="email"
       defaultValue="invalid-email"
       aria-invalid="true"
     />
+    <FieldDescription>We'll send updates to this address.</FieldDescription>
     <FieldError>Please enter a valid email address</FieldError>
   </Field>
 </div>
@@ -363,7 +335,7 @@ export function FileInput() {
 
 **Input**
 
-The Input component extends all native HTML input attributes and adds custom props:
+The Input component uses [class-variance-authority](https://cva.style) for size variants. It extends all native HTML input attributes and adds:
 
 - `type` - Input type (text, email, password, number, etc.) (string, default: "text")
 - `size` - Size variant ("lg" | "xl" | "2xl", default: "lg")
@@ -380,7 +352,7 @@ The Input component extends all native HTML input attributes and adds custom pro
 
 ### Features
 
-- ✅ Multiple size variants (lg, xl, 2xl)
+- ✅ Size variants via CVA (lg, xl, 2xl)
 - ✅ All native input types supported
 - ✅ Focus state with shadow and border highlight
 - ✅ Disabled state with reduced opacity

--- a/apps/eclipse/content/design-system/atoms/textarea.mdx
+++ b/apps/eclipse/content/design-system/atoms/textarea.mdx
@@ -405,16 +405,6 @@ export function TextareaRows() {
   <Textarea placeholder="Large (10 rows)" rows={10} />
 </div>
 
-### `textareaVariants`
-
-The `textareaVariants` function is also exported for use cases where you need to apply textarea styles without rendering the `Textarea` component:
-
-```tsx
-import { textareaVariants } from "@prisma/eclipse";
-
-const className = textareaVariants({ size: "xl" });
-```
-
 ### Component Props
 
 **Textarea**

--- a/apps/eclipse/content/design-system/atoms/textarea.mdx
+++ b/apps/eclipse/content/design-system/atoms/textarea.mdx
@@ -3,7 +3,7 @@ title: Textarea
 description: A multi-line text input component for forms with optional character count and validation styles.
 ---
 
-import { Textarea, Button, Field, FieldLabel, FieldDescription, FieldError } from "@prisma/eclipse";
+import { Textarea, textareaVariants, Button, Field, FieldLabel, FieldDescription, FieldError } from "@prisma/eclipse";
 
 ### Usage
 
@@ -32,8 +32,8 @@ import { Textarea } from "@prisma/eclipse";
 
 export function TextareaWithCount() {
   return (
-    <Textarea 
-      placeholder="Enter up to 200 characters..." 
+    <Textarea
+      placeholder="Enter up to 200 characters..."
       maxLength={200}
       showCharCount
     />
@@ -44,8 +44,8 @@ export function TextareaWithCount() {
 **Live Example:**
 
 <div className="max-w-md my-4">
-  <Textarea 
-    placeholder="Enter up to 200 characters..." 
+  <Textarea
+    placeholder="Enter up to 200 characters..."
     maxLength={200}
     showCharCount
   />
@@ -61,18 +61,18 @@ import { Textarea } from "@prisma/eclipse";
 export function TextareaLimits() {
   return (
     <div className="space-y-4 max-w-md">
-      <Textarea 
-        placeholder="Short text (50 chars)" 
+      <Textarea
+        placeholder="Short text (50 chars)"
         maxLength={50}
         showCharCount
       />
-      <Textarea 
-        placeholder="Medium text (150 chars)" 
+      <Textarea
+        placeholder="Medium text (150 chars)"
         maxLength={150}
         showCharCount
       />
-      <Textarea 
-        placeholder="Long text (500 chars)" 
+      <Textarea
+        placeholder="Long text (500 chars)"
         maxLength={500}
         showCharCount
       />
@@ -84,21 +84,45 @@ export function TextareaLimits() {
 **Live Example:**
 
 <div className="space-y-4 max-w-md my-4">
-  <Textarea 
-    placeholder="Short text (50 chars)" 
+  <Textarea
+    placeholder="Short text (50 chars)"
     maxLength={50}
     showCharCount
   />
-  <Textarea 
-    placeholder="Medium text (150 chars)" 
+  <Textarea
+    placeholder="Medium text (150 chars)"
     maxLength={150}
     showCharCount
   />
-  <Textarea 
-    placeholder="Long text (500 chars)" 
+  <Textarea
+    placeholder="Long text (500 chars)"
     maxLength={500}
     showCharCount
   />
+</div>
+
+**Textarea Sizes**
+
+```tsx
+import { Textarea } from "@prisma/eclipse";
+
+export function TextareaSizes() {
+  return (
+    <div className="space-y-4 max-w-md">
+      <Textarea size="lg" placeholder="Large (default)" maxLength={150} showCharCount />
+      <Textarea size="xl" placeholder="Extra Large" maxLength={150} showCharCount />
+      <Textarea size="2xl" placeholder="2X Large" maxLength={150} showCharCount />
+    </div>
+  );
+}
+```
+
+**Live Example:**
+
+<div className="space-y-4 max-w-md my-4">
+  <Textarea size="lg" placeholder="Large (default)" maxLength={150} showCharCount />
+  <Textarea size="xl" placeholder="Extra Large" maxLength={150} showCharCount />
+  <Textarea size="2xl" placeholder="2X Large" maxLength={150} showCharCount />
 </div>
 
 **With Field Component**
@@ -124,8 +148,8 @@ export function TextareaWithField() {
 <div className="max-w-md my-4">
   <Field>
     <FieldLabel htmlFor="bio-field">Bio</FieldLabel>
-    <FieldDescription>Tell us a little bit about yourself.</FieldDescription>
     <Textarea id="bio-field" placeholder="Enter your bio..." />
+    <FieldDescription>Tell us a little bit about yourself.</FieldDescription>
   </Field>
 </div>
 
@@ -140,13 +164,13 @@ export function TextareaFieldWithCount() {
   return (
     <Field>
       <FieldLabel htmlFor="description">Description</FieldLabel>
-      <FieldDescription>Provide a brief description (max 300 characters).</FieldDescription>
-      <Textarea 
-        id="description" 
-        placeholder="Enter description..." 
+      <Textarea
+        id="description"
+        placeholder="Enter description..."
         maxLength={300}
         showCharCount
       />
+      <FieldDescription>Provide a brief description (max 300 characters).</FieldDescription>
     </Field>
   );
 }
@@ -157,42 +181,14 @@ export function TextareaFieldWithCount() {
 <div className="max-w-md my-4">
   <Field>
     <FieldLabel htmlFor="description-field">Description</FieldLabel>
-    <FieldDescription>Provide a brief description (max 300 characters).</FieldDescription>
-    <Textarea 
-      id="description-field" 
-      placeholder="Enter description..." 
+    <Textarea
+      id="description-field"
+      placeholder="Enter description..."
       maxLength={300}
       showCharCount
     />
+    <FieldDescription>Provide a brief description (max 300 characters).</FieldDescription>
   </Field>
-</div>
-
-**With Basic Labels**
-
-You can also use plain labels without the Field component:
-
-```tsx
-import { Textarea } from "@prisma/eclipse";
-
-export function TextareaWithLabel() {
-  return (
-    <div className="space-y-2 max-w-md">
-      <label htmlFor="comments" className="text-sm font-medium">
-        Comments
-      </label>
-      <Textarea id="comments" placeholder="Enter your comments..." />
-    </div>
-  );
-}
-```
-
-**Live Example:**
-
-<div className="space-y-2 max-w-md my-4">
-  <label htmlFor="comments" className="text-sm font-medium">
-    Comments
-  </label>
-  <Textarea id="comments" placeholder="Enter your comments..." />
 </div>
 
 **Disabled State**
@@ -335,18 +331,18 @@ export function FormExample() {
     <form className="space-y-4 max-w-md">
       <Field>
         <FieldLabel htmlFor="title">Title</FieldLabel>
-        <input 
-          id="title" 
-          className="border rounded px-3 py-2 w-full" 
-          placeholder="Enter title" 
-          required 
+        <input
+          id="title"
+          className="border rounded px-3 py-2 w-full"
+          placeholder="Enter title"
+          required
         />
       </Field>
       <Field>
         <FieldLabel htmlFor="message">Message</FieldLabel>
-        <Textarea 
-          id="message" 
-          placeholder="Enter your message..." 
+        <Textarea
+          id="message"
+          placeholder="Enter your message..."
           required
           maxLength={500}
           showCharCount
@@ -363,18 +359,18 @@ export function FormExample() {
 <form className="space-y-4 max-w-md my-4">
   <Field>
     <FieldLabel htmlFor="title">Title</FieldLabel>
-    <input 
-      id="title" 
-      className="border rounded px-3 py-2 w-full" 
-      placeholder="Enter title" 
-      required 
+    <input
+      id="title"
+      className="border rounded px-3 py-2 w-full"
+      placeholder="Enter title"
+      required
     />
   </Field>
   <Field>
     <FieldLabel htmlFor="message">Message</FieldLabel>
-    <Textarea 
-      id="message" 
-      placeholder="Enter your message..." 
+    <Textarea
+      id="message"
+      placeholder="Enter your message..."
       required
       maxLength={500}
       showCharCount
@@ -409,12 +405,23 @@ export function TextareaRows() {
   <Textarea placeholder="Large (10 rows)" rows={10} />
 </div>
 
+### `textareaVariants`
+
+The `textareaVariants` function is also exported for use cases where you need to apply textarea styles without rendering the `Textarea` component:
+
+```tsx
+import { textareaVariants } from "@prisma/eclipse";
+
+const className = textareaVariants({ size: "xl" });
+```
+
 ### Component Props
 
 **Textarea**
 
-The Textarea component extends all native HTML textarea attributes and adds custom props:
+The Textarea component uses [class-variance-authority](https://cva.style) for size variants. It extends all native HTML textarea attributes and adds:
 
+- `size` - Size variant ("lg" | "xl" | "2xl", default: "lg")
 - `showCharCount` - Display character counter (boolean, default: false)
 - `maxLength` - Maximum number of characters allowed (number, optional)
 - `className` - Additional CSS classes (string, optional)
@@ -434,6 +441,7 @@ The Textarea component extends all native HTML textarea attributes and adds cust
 ### Features
 
 - ✅ Multi-line text input
+- ✅ Size variants via CVA (lg, xl, 2xl)
 - ✅ Optional character counter with color indicators
 - ✅ Character limit enforcement with maxLength
 - ✅ Visual feedback when approaching character limit (>90% = warning color)
@@ -539,7 +547,7 @@ export function FormWithValidation() {
   return (
     <form>
       <Textarea
-        {...register("description", { 
+        {...register("description", {
           required: "Description is required",
           minLength: { value: 10, message: "Too short" }
         })}

--- a/packages/eclipse/src/components/badge.tsx
+++ b/packages/eclipse/src/components/badge.tsx
@@ -6,7 +6,7 @@ import { cn } from "../lib/cn";
  * Define badge variants using CVA based on Figma design
  */
 const badgeVariants = cva(
-  "inline-flex flex-row justify-center items-center px-2 h-element-lg min-w-[24px] rounded-square text-xs font-medium",
+  "inline-flex flex-row justify-center items-center rounded-square text-xs font-medium",
   {
     variants: {
       color: {
@@ -17,9 +17,14 @@ const badgeVariants = cva(
         success: "bg-background-success text-foreground-success",
         warning: "bg-background-warning text-foreground-warning",
       },
+      size: {
+        md: "px-2 h-element-md min-w-element-md",
+        lg: "px-2 h-element-lg min-w-element-lg",
+      },
     },
     defaultVariants: {
       color: "neutral",
+      size: "md",
     },
   },
 );
@@ -35,6 +40,10 @@ export interface BadgeProps
    * The color variant of the badge
    */
   color?: "neutral" | "ppg" | "orm" | "error" | "success" | "warning";
+  /**
+   * The size variant of the badge
+   */
+  size?: "md" | "lg";
   /**
    * The label text to display inside the badge
    */
@@ -55,11 +64,11 @@ export interface BadgeProps
  * ```
  */
 const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
-  ({ className, color, label, ...props }, ref) => {
+  ({ className, color, size, label, ...props }, ref) => {
     return (
       <span
         ref={ref}
-        className={cn(badgeVariants({ color, className }))}
+        className={cn(badgeVariants({ color, size, className }))}
         {...props}
       >
         <span className="flex-grow-1">{label}</span>

--- a/packages/eclipse/src/components/index.ts
+++ b/packages/eclipse/src/components/index.ts
@@ -1,6 +1,6 @@
 export { default as Statistic } from "./statistic";
 
-export { Textarea } from "./textarea";
+export { Textarea, textareaVariants } from "./textarea";
 
 export {
   ChartContainer,

--- a/packages/eclipse/src/components/index.ts
+++ b/packages/eclipse/src/components/index.ts
@@ -103,7 +103,7 @@ export {
   TableCell,
   TableCaption,
 } from "./table";
-export { Input } from "./input";
+export { Input, inputVariants } from "./input";
 
 export { Label } from "./label";
 

--- a/packages/eclipse/src/components/input.tsx
+++ b/packages/eclipse/src/components/input.tsx
@@ -1,30 +1,33 @@
 import * as React from "react";
-
+import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../lib/cn";
 
-export interface InputProps extends Omit<
-  React.ComponentProps<"input">,
-  "size"
-> {
-  size?: "lg" | "xl" | "2xl";
-}
+const inputVariants = cva(
+  "flex w-full rounded-square border border-stroke-neutral bg-background-default text-foreground-neutral transition-colors placeholder:text-foreground-neutral-weak focus-visible:outline-none focus-visible:shadow-box-low focus-visible:ring-ring focus-visible:border-stroke-neutral-strong disabled:cursor-not-allowed disabled:text-foreground-neutral-weaker disabled:placeholder:text-foreground-neutral-weaker disabled:border-stroke-neutral-weak disabled:bg-background-neutral-weak aria-invalid:border-stroke-error aria-invalid:text-foreground-error aria-invalid:focus-visible:border-stroke-error text-sm",
+  {
+    variants: {
+      size: {
+        lg: "px-2 h-element-lg file:py-1 file:px-2",
+        xl: "px-3 h-element-xl file:py-1.5 file:px-3",
+        "2xl": "px-3 h-element-2xl file:py-2 file:px-3",
+      },
+    },
+    defaultVariants: {
+      size: "lg",
+    },
+  },
+);
+
+export interface InputProps
+  extends Omit<React.ComponentProps<"input">, "size">,
+    VariantProps<typeof inputVariants> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, size, ...props }, ref) => {
-    const sizes = {
-      lg: " px-2 h-element-lg file:py-1 file:px-2",
-      xl: "px-3 h-element-xl file:py-1.5 file:px-3",
-      "2xl": "px-3 h-element-2xl file:py-2 file:px-3",
-    };
-
     return (
       <input
         type={type}
-        className={cn(
-          "flex w-full rounded-square border border-stroke-neutral bg-background-default px-3 py-1 text-foreground-neutral transition-colors placeholder:text-foreground-neutral-weak focus-visible:outline-none focus-visible:shadow-box-low focus-visible:ring-ring focus-visible:border-stroke-neutral-strong disabled:cursor-not-allowed disabled:text-foreground-neutral-weaker disabled:placeholder:text-foreground-neutral-weaker disabled:border-stroke-neutral-weak disabled:bg-background-neutral-weak aria-invalid:border-stroke-error aria-invalid:text-foreground-error aria-invalid:focus-visible:border-stroke-error text-sm",
-          sizes[size ?? "lg"],
-          className,
-        )}
+        className={cn(inputVariants({ size, className }))}
         ref={ref}
         {...props}
       />
@@ -33,4 +36,4 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 );
 Input.displayName = "Input";
 
-export { Input };
+export { Input, inputVariants };

--- a/packages/eclipse/src/components/textarea.tsx
+++ b/packages/eclipse/src/components/textarea.tsx
@@ -46,9 +46,9 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     };
 
     const charCountPadding = {
-      lg: "pb-11",
-      xl: "pb-13",
-      "2xl": "pb-13",
+      lg: "pb-10",
+      xl: "pb-12",
+      "2xl": "pb-12",
     };
 
     return (
@@ -67,9 +67,15 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         />
         {showCharCount && maxLength && (
           <Badge
-            color="neutral"
+            color={
+              charCount >= maxLength
+                ? "error"
+                : charCount >= 0.8 * maxLength
+                  ? "warning"
+                  : "neutral"
+            }
             className={cn(
-              "absolute text-foreground-neutral font-mono",
+              "absolute",
               badgeInset[resolvedSize],
             )}
             label={`${charCount}/${maxLength}`}

--- a/packages/eclipse/src/components/textarea.tsx
+++ b/packages/eclipse/src/components/textarea.tsx
@@ -1,21 +1,54 @@
 "use client";
 
 import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "../lib/cn";
 import { Badge } from "./badge";
 
-interface TextareaProps extends React.ComponentProps<"textarea"> {
+const textareaVariants = cva(
+  "border border-stroke-neutral bg-background-default text-foreground-neutral disabled:cursor-not-allowed disabled:text-foreground-neutral disabled:bg-background-neutral-weak disabled:stroke-neutral-weak focus-visible:text-foreground-neutral focus:text-foreground-neutral aria-invalid:border-stroke-error aria-invalid:text-foreground-error rounded-square text-sm transition-colors flex field-sizing-content min-h-16 w-full outline-none",
+  {
+    variants: {
+      size: {
+        lg: "p-2",
+        xl: "p-3",
+        "2xl": "p-3",
+      },
+    },
+    defaultVariants: {
+      size: "lg",
+    },
+  },
+);
+
+interface TextareaProps
+  extends Omit<React.ComponentProps<"textarea">, "size">,
+    VariantProps<typeof textareaVariants> {
   showCharCount?: boolean;
 }
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, showCharCount = false, maxLength, onChange, ...rest }, ref) => {
+  ({ className, showCharCount = false, maxLength, onChange, size, ...rest }, ref) => {
     const [charCount, setCharCount] = React.useState(0);
 
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       setCharCount(e.target.value.length);
       onChange?.(e);
+    };
+
+    const resolvedSize = size ?? "lg";
+
+    const badgeInset = {
+      lg: "bottom-2 right-2",
+      xl: "bottom-3 right-3",
+      "2xl": "bottom-3 right-3",
+    };
+
+    const charCountPadding = {
+      lg: "pb-11",
+      xl: "pb-13",
+      "2xl": "pb-13",
     };
 
     return (
@@ -24,8 +57,8 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           ref={ref}
           data-slot="textarea"
           className={cn(
-            "border border-stroke-neutral bg-background-default text-foreground-neutral disabled:cursor-not-allowed disabled:text-foreground-neutral disabled:bg-background-neutral-weak disabled:stroke-neutral-weak focus-visible:text-foreground-neutral focus:text-foreground-neutral aria-invalid:border-stroke-error aria-invalid:text-foreground-error rounded-square p-2 text-sm transition-colors flex field-sizing-content min-h-16 w-full outline-none",
-            showCharCount && maxLength && "pb-8",
+            textareaVariants({ size }),
+            showCharCount && maxLength && charCountPadding[resolvedSize],
             className,
           )}
           {...rest}
@@ -35,7 +68,10 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         {showCharCount && maxLength && (
           <Badge
             color="neutral"
-            className="absolute bottom-1 right-1 text-foreground-neutral font-mono"
+            className={cn(
+              "absolute text-foreground-neutral font-mono",
+              badgeInset[resolvedSize],
+            )}
             label={`${charCount}/${maxLength}`}
           ></Badge>
         )}
@@ -46,4 +82,4 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 
 Textarea.displayName = "Textarea";
 
-export { Textarea };
+export { Textarea, textareaVariants };


### PR DESCRIPTION
## Summary                                                

- Refactored `Input`, `Textarea`, and `Badge` components to use [class-variance-authority](https://cva.style) (CVA) for size variants, matching the existing `Button` pattern
- `Input`: size variants `lg` (default), `xl`, `2xl` with balanced padding
- `Textarea`: size variants `lg` (default), `xl`, `2xl` with size-aware badge inset and bottom padding when character count is shown
- `Badge`: size variants `md` (default), `lg` with `min-w` matching element size tokens
- Exported `inputVariants`, `textareaVariants`, and `badgeVariants` from the package index for external composition
- Updated Eclipse documentation for all three components with live examples, props, and variant usage

## Test plan

- [ ] Verify Input renders correctly at each size (`lg`, `xl`, `2xl`)
- [ ] Verify Textarea renders correctly at each size, with and without `showCharCount`
- [ ] Verify Badge renders correctly at `md` and `lg` sizes
- [ ] Confirm badge positioning inside Textarea aligns with padding at each size
- [ ] Check that existing consumers are unaffected (default sizes match prior behavior for Input and Textarea; Badge default changed from `lg` to `md`)
- [ ] Review Eclipse docs pages for Input, Textarea, and Badge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Badge now supports size variants (md, lg) with md as default.
  * Input supports structured size variants via the variant system.
  * Textarea supports size variants (lg, xl, 2xl) and dynamic character-count positioning.

* **Documentation**
  * Added size-variant examples and usage for Badge, Input, and Textarea.
  * Updated component prop references and live examples for consistency and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->