### PR TITLE
Add title typography utilities

### DIFF
--- a/apps/eclipse/content/design-system/tokens/typography.mdx
+++ b/apps/eclipse/content/design-system/tokens/typography.mdx
@@ -3,7 +3,7 @@ title: Typography
 description: Typography utility classes from the Eclipse Design System
 ---
 
-The Eclipse Design System provides utility classes for consistent typography across three categories: **Headings**, **Text**, and **Code**. Each maps to specific font families, sizes, weights, and line heights defined as design tokens.
+The Eclipse Design System provides utility classes for consistent typography across four categories: **Titles**, **Headings**, **Text**, and **Code**. Each maps to specific font families, sizes, weights, and line heights defined as design tokens.
 
 ## Font Families
 
@@ -26,6 +26,53 @@ The Eclipse Design System provides utility classes for consistent typography acr
     </div>
   </div>
 </div>
+
+## Titles
+
+Title styles use the **Mona Sans VF** display font with heavy weights and extended widths for maximum visual impact. Use these for hero sections, page titles, and marketing content.
+
+<div className="not-prose my-8 space-y-6">
+  <div className="space-y-1 p-4 border border-stroke-neutral rounded-lg">
+    <p className="text-xs font-mono text-foreground-neutral-weak mb-2">.type-title-5xl &middot; 64px/72px &middot; weight 900 &middot; width 125</p>
+    <p className="type-title-5xl">The quick brown fox</p>
+  </div>
+  <div className="space-y-1 p-4 border border-stroke-neutral rounded-lg">
+    <p className="text-xs font-mono text-foreground-neutral-weak mb-2">.type-title-4xl &middot; 40px/48px &middot; weight 900 &middot; width 125</p>
+    <p className="type-title-4xl">The quick brown fox jumps over the lazy dog</p>
+  </div>
+  <div className="space-y-1 p-4 border border-stroke-neutral rounded-lg">
+    <p className="text-xs font-mono text-foreground-neutral-weak mb-2">.type-title-3xl &middot; 30px/36px &middot; weight 900 &middot; width 125</p>
+    <p className="type-title-3xl">The quick brown fox jumps over the lazy dog</p>
+  </div>
+  <div className="space-y-1 p-4 border border-stroke-neutral rounded-lg">
+    <p className="text-xs font-mono text-foreground-neutral-weak mb-2">.type-title-xl &middot; 20px/28px &middot; weight 800 &middot; width 110</p>
+    <p className="type-title-xl">The quick brown fox jumps over the lazy dog</p>
+  </div>
+  <div className="space-y-1 p-4 border border-stroke-neutral rounded-lg">
+    <p className="text-xs font-mono text-foreground-neutral-weak mb-2">.type-title-lg &middot; 18px/28px &middot; weight 800 &middot; width 110</p>
+    <p className="type-title-lg">The quick brown fox jumps over the lazy dog</p>
+  </div>
+  <div className="space-y-1 p-4 border border-stroke-neutral rounded-lg">
+    <p className="text-xs font-mono text-foreground-neutral-weak mb-2">.type-title-md &middot; 16px/24px &middot; weight 800 &middot; width 110</p>
+    <p className="type-title-md">The quick brown fox jumps over the lazy dog</p>
+  </div>
+  <div className="space-y-1 p-4 border border-stroke-neutral rounded-lg">
+    <p className="text-xs font-mono text-foreground-neutral-weak mb-2">.type-title-sm &middot; 14px/20px &middot; weight 800 &middot; width 125 &middot; uppercase</p>
+    <p className="type-title-sm">The quick brown fox jumps over the lazy dog</p>
+  </div>
+</div>
+
+### Title reference
+
+| Class | Font | Size | Line height | Weight | Width | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `type-title-5xl` | Mona Sans VF | 64px (4rem) | 72px (4.5rem) | 900 | 125 | |
+| `type-title-4xl` | Mona Sans VF | 40px (2.5rem) | 48px (3rem) | 900 | 125 | |
+| `type-title-3xl` | Mona Sans VF | 30px (1.875rem) | 36px (2.25rem) | 900 | 125 | |
+| `type-title-xl` | Mona Sans VF | 20px (1.25rem) | 28px (1.75rem) | 800 | 110 | |
+| `type-title-lg` | Mona Sans VF | 18px (1.125rem) | 28px (1.75rem) | 800 | 110 | |
+| `type-title-md` | Mona Sans VF | 16px (1rem) | 24px (1.5rem) | 800 | 110 | |
+| `type-title-sm` | Mona Sans VF | 14px (0.875rem) | 20px (1.25rem) | 800 | 125 | Uppercase, letter-spaced |
 
 ## Headings
 
@@ -177,8 +224,9 @@ Code styles use the **Mona Sans Mono VF** monospace font. Use it for displaying 
 ## Usage
 
 ```tsx
-<h1 className="type-heading-2xl">Page Title</h1>
-<h2 className="type-heading-lg">Section Heading</h2>
+<h1 className="type-title-4xl">Hero Title</h1>
+<h2 className="type-heading-2xl">Page Heading</h2>
+<h3 className="type-heading-lg">Section Heading</h3>
 <p className="type-text-md">Body text paragraph.</p>
 <p className="type-text-sm-strong">Emphasized small text.</p>
 <code className="type-code-sm">inlineCode()</code>

--- a/packages/eclipse/src/components/banner.tsx
+++ b/packages/eclipse/src/components/banner.tsx
@@ -10,7 +10,7 @@ import { buttonVariants } from "./ui/button";
  * Banner variants based on color prop
  */
 const bannerVariants = cva(
-  "py-3 px-6 flex items-center justify-center type-text-sm-strong",
+  "py-3 px-6 flex items-center justify-center type-text-sm",
   {
     variants: {
       color: {

--- a/packages/eclipse/src/styles/globals.css
+++ b/packages/eclipse/src/styles/globals.css
@@ -69,6 +69,10 @@
   --text-2xl--line-height: 2rem;
   --text-3xl: 1.875rem;
   --text-3xl--line-height: 2.25rem;
+  --text-4xl: 2.5rem;
+  --text-4xl--line-height: 3rem;
+  --text-5xl: 4rem;
+  --text-5xl--line-height: 4.5rem;
 
   /* Background Colors */
   --color-background-default: #ffffff;
@@ -352,6 +356,71 @@
     background: linear-gradient(90deg, var(--color-background-ppg) 0%, var(--color-background-orm) 100%);
   }
 
+  /* Typography - Titles */
+  .type-title-5xl,
+  .type-title-4xl,
+  .type-title-3xl,
+  .type-title-xl,
+  .type-title-lg,
+  .type-title-md,
+  .type-title-sm {
+    font: normal 900 var(--text-2xl)/var(--text-2xl--line-height) var(--font-sans-display);
+    font-feature-settings: var(--font-sans-display-settings);
+    font-variant-numeric: lining-nums tabular-nums slashed-zero;
+  }
+
+  .type-title-5xl,
+  .type-title-4xl,
+  .type-title-3xl {
+    font-width: 125%;
+  }
+
+  .type-title-5xl {
+    font-size: var(--text-5xl);
+    line-height: var(--text-5xl--line-height);
+  }
+
+  .type-title-4xl {
+    font-size: var(--text-4xl);
+    line-height: var(--text-4xl--line-height);
+  }
+
+  .type-title-3xl {
+    font-size: var(--text-3xl);
+    line-height: var(--text-3xl--line-height);
+  }
+
+  .type-title-xl,
+  .type-title-lg,
+  .type-title-md {
+    font-weight: 800;
+    font-width: 110%;
+  }
+
+  .type-title-xl {
+    font-size: var(--text-xl);
+    line-height: var(--text-xl--line-height);
+  }
+
+  .type-title-lg {
+    font-size: var(--text-lg);
+    line-height: var(--text-lg--line-height);
+  }
+
+  .type-title-md {
+    font-size: var(--text-md);
+    line-height: var(--text-md--line-height);
+  }
+
+  .type-title-sm {
+    font-size: var(--text-sm);
+    font-weight: 800;
+    font-width: 125%;
+    line-height: var(--text-sm--line-height);
+    letter-spacing: 0.06875rem;
+    text-transform: uppercase;
+  }
+
   /* Typography - Headings */
   .type-heading-2xl,
   .type-heading-xl,
@@ -412,6 +481,7 @@
   .type-text-xs-stronger {
     font: normal 400 var(--text-md)/var(--text-md--line-height) var(--font-sans);
     font-feature-settings: var(--font-sans-settings);
+    font-variant-numeric: lining-nums proportional-nums slashed-zero;
   }
 
   .type-text-sm,

--- a/packages/eclipse/src/styles/globals.css
+++ b/packages/eclipse/src/styles/globals.css
@@ -367,11 +367,7 @@
     font: normal 900 var(--text-2xl)/var(--text-2xl--line-height) var(--font-sans-display);
     font-feature-settings: var(--font-sans-display-settings);
     font-variant-numeric: lining-nums tabular-nums slashed-zero;
-  }
-
-  .type-title-5xl,
-  .type-title-4xl,
-  .type-title-3xl {
+    font-stretch: 125%;
     font-width: 125%;
   }
 
@@ -394,6 +390,7 @@
   .type-title-lg,
   .type-title-md {
     font-weight: 800;
+    font-stretch: 110%;
     font-width: 110%;
   }
 
@@ -415,7 +412,6 @@
   .type-title-sm {
     font-size: var(--text-sm);
     font-weight: 800;
-    font-width: 125%;
     line-height: var(--text-sm--line-height);
     letter-spacing: 0.06875rem;
     text-transform: uppercase;


### PR DESCRIPTION
## Summary                                                                   
   - Add `type-title-*` utility classes (5xl, 4xl, 3xl, xl, lg, md, sm) to Eclipse globals.css using Mona Sans display font with variable weight and width
   - Add `--text-4xl` and `--text-5xl` font size tokens
   - Add `font-variant-numeric` to text utility base rule for consistent number rendering
   - Fix banner component to use `type-text-sm` instead of `type-text-sm-strong` 
   - Document new title utilities in Eclipse typography tokens page with live previews and reference table
                                                                  
   ## Test plan                                    
   - [ ] Verify title classes render with correct font-width in browser dev tools
   - [ ] Check Eclipse docs typography page displays title previews correctly
   - [ ] Confirm banner component renders with updated text weight
   - [ ] Verify dark mode rendering of title styles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Titles typography category with expanded title size tokens (5xl through sm) and comprehensive styling rules.

* **Documentation**
  * Updated typography docs with a new Titles section, usage examples replacing previous heading examples, and a reference table for title classes.

* **Style**
  * Refined banner text weight for consistency and added typography tokens and numeric font-variant settings across text and title styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->