### PR TITLE
fix: DR-7565 footer dropdown bug

### DIFF
--- a/packages/ui/src/components/footer.tsx
+++ b/packages/ui/src/components/footer.tsx
@@ -126,8 +126,8 @@ const Footer = ({
                     </Link>
                   ) : (
                     <DropdownMenu key={idx} modal={false}>
-                      <DropdownMenuTrigger className="focus-visible:outline-none">
-                        <span className="text-foreground-neutral-weak text-lg flex cursor-pointer font-medium box-border no-underline leading-[1.39] px-8 -ml-8 py-1.5 transition-colors relative w-max items-center hover:bg-background-ppg-strong rounded-square transition-all">
+                      <DropdownMenuTrigger className="focus-visible:outline-none px-2.5 -ml-2.5 py-1.5 w-[calc(100%+10px)] hover:bg-background-ppg-strong rounded-square transition-all">
+                        <span className="text-foreground-neutral-weak text-lg w-full flex cursor-pointer font-medium box-border no-underline leading-[1.39] relative items-center">
                           {link.title}
                           <i className="fa-regular fa-chevron-down text-foreground-neutral-weaker ml-2 text-base text-inherit" />
                         </span>
@@ -157,7 +157,7 @@ const Footer = ({
             ))}
           </div>
           <div className="h-px w-full bg-stroke-neutral-weak my-6" />
-          
+
           {/* Compliance Footer */}
           <div className="gap-6 md:items-center justify-between flex md:flex-nowrap flex-wrap w-full md:pb-0 pb-11">
             <PDPStatus className="justify-start order-1" />

--- a/packages/ui/src/components/footer.tsx
+++ b/packages/ui/src/components/footer.tsx
@@ -125,7 +125,7 @@ const Footer = ({
                       {link.title}
                     </Link>
                   ) : (
-                    <DropdownMenu key={idx}>
+                    <DropdownMenu key={idx} modal={false}>
                       <DropdownMenuTrigger className="focus-visible:outline-none">
                         <span className="text-foreground-neutral-weak text-lg flex cursor-pointer font-medium box-border no-underline leading-[1.39] px-8 -ml-8 py-1.5 transition-colors relative w-max items-center hover:bg-background-ppg-strong rounded-square transition-all">
                           {link.title}


### PR DESCRIPTION
modal={false} tells Radix not to lock scroll when the dropdown opens, so closing it won't trigger a scrollbar width change or any body style toggling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the footer dropdown to use a non‑modal, inline dropdown for smoother interaction with page content.
  * Adjusted trigger and content structure, spacing, padding, and width for a more compact, consistent footer link presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->