### PR TITLE
fix(eclipse): replace useEffectEvent with ref-based stable callback

### DIFF
--- a/packages/eclipse/src/components/ui/tabs.tsx
+++ b/packages/eclipse/src/components/ui/tabs.tsx
@@ -61,12 +61,10 @@ export function Tabs({
   const valueToIdMap = useMemo(() => new Map<string, string>(), []);
   const onValueChangeRef = useRef(_onValueChange);
   onValueChangeRef.current = _onValueChange;
-  const [value, setValue] =
-    _value === undefined
-      ? // eslint-disable-next-line react-hooks/rules-of-hooks -- not supposed to change controlled/uncontrolled
-        useState(defaultValue)
-      : // eslint-disable-next-line react-hooks/rules-of-hooks -- not supposed to change controlled/uncontrolled
-        [_value, useCallback((v: string) => onValueChangeRef.current?.(v), [])];
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const stableOnValueChange = useCallback((v: string) => onValueChangeRef.current?.(v), []);
+  const value = _value !== undefined ? _value : internalValue;
+  const setValue = _value !== undefined ? stableOnValueChange : setInternalValue;
 
   useLayoutEffect(() => {
     if (!groupId) return;

--- a/packages/eclipse/src/components/ui/tabs.tsx
+++ b/packages/eclipse/src/components/ui/tabs.tsx
@@ -4,7 +4,7 @@ import {
   type ComponentProps,
   createContext,
   use,
-  useEffectEvent,
+  useCallback,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -59,12 +59,14 @@ export function Tabs({
 }: TabsProps) {
   const tabsRef = useRef<HTMLDivElement>(null);
   const valueToIdMap = useMemo(() => new Map<string, string>(), []);
+  const onValueChangeRef = useRef(_onValueChange);
+  onValueChangeRef.current = _onValueChange;
   const [value, setValue] =
     _value === undefined
       ? // eslint-disable-next-line react-hooks/rules-of-hooks -- not supposed to change controlled/uncontrolled
         useState(defaultValue)
       : // eslint-disable-next-line react-hooks/rules-of-hooks -- not supposed to change controlled/uncontrolled
-        [_value, useEffectEvent((v: string) => _onValueChange?.(v))];
+        [_value, useCallback((v: string) => onValueChangeRef.current?.(v), [])];
 
   useLayoutEffect(() => {
     if (!groupId) return;

--- a/packages/eclipse/src/components/ui/tabs.tsx
+++ b/packages/eclipse/src/components/ui/tabs.tsx
@@ -60,7 +60,9 @@ export function Tabs({
   const tabsRef = useRef<HTMLDivElement>(null);
   const valueToIdMap = useMemo(() => new Map<string, string>(), []);
   const onValueChangeRef = useRef(_onValueChange);
-  onValueChangeRef.current = _onValueChange;
+  useLayoutEffect(() => {
+    onValueChangeRef.current = _onValueChange;
+  }, [_onValueChange]);
   const [internalValue, setInternalValue] = useState(defaultValue);
   const stableOnValueChange = useCallback((v: string) => onValueChangeRef.current?.(v), []);
   const value = _value !== undefined ? _value : internalValue;


### PR DESCRIPTION
useEffectEvent is React 19-only and breaks consumers on older React versions. Replaced with a ref that tracks the latest onValueChange callback, wrapped in a stable useCallback with no deps — same semantics, broader compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of value changes in the tabs component so controlled and uncontrolled modes behave more consistently and predictably, reducing unexpected updates and improving stability. No changes to public APIs or component signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->