### PR TITLE
fix: convert multi-line npm code blocks line-by-line for correct package manager tabs

### DIFF
--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -14,6 +14,15 @@ import lastModified from "fumadocs-mdx/plugins/last-modified";
 import { z } from "zod";
 import convert from "npm-to-yarn";
 
+// npm-to-yarn only converts the last line of multi-line strings,
+// so we split, convert each line, and rejoin.
+function convertLine(cmd: string, pm: "npm" | "pnpm" | "yarn" | "bun"): string {
+  return cmd
+    .split("\n")
+    .map((line) => convert(line, pm))
+    .join("\n");
+}
+
 // You can customise Zod schemas for frontmatter and `meta.json` here
 // see https://fumadocs.dev/docs/mdx/collections
 export const docs = defineDocs({
@@ -89,12 +98,12 @@ export default defineConfig({
         id: "package-manager",
       },
       packageManagers: [
-        { command: (cmd: string) => convert(cmd, "npm"), name: "npm" },
-        { command: (cmd: string) => convert(cmd, "pnpm"), name: "pnpm" },
-        { command: (cmd: string) => convert(cmd, "yarn"), name: "yarn" },
+        { command: (cmd: string) => convertLine(cmd, "npm"), name: "npm" },
+        { command: (cmd: string) => convertLine(cmd, "pnpm"), name: "pnpm" },
+        { command: (cmd: string) => convertLine(cmd, "yarn"), name: "yarn" },
         {
           command: (cmd: string) => {
-            const converted = convert(cmd, "bun");
+            const converted = convertLine(cmd, "bun");
             if (!converted) return undefined;
             return converted.replace(/^bun x /, "bunx --bun ");
           },


### PR DESCRIPTION
## Summary
- Fixes the `npm-to-yarn` library only converting the last line of multi-line code blocks, causing yarn/pnpm/bun tabs to show unconverted `npm` commands
- Adds a `convertLine` wrapper that splits multi-line input, converts each line individually, and rejoins — fixing all 140+ affected docs pages without any MDX content changes

Fixes #7618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multi-line package manager command conversions in documentation to properly handle npm, pnpm, yarn, and bun syntax transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->