### PR TITLE
Fix command syntax for D1 database insertion

### DIFF
--- a/apps/docs/content/docs/guides/deployment/cloudflare-d1.mdx
+++ b/apps/docs/content/docs/guides/deployment/cloudflare-d1.mdx
@@ -209,10 +209,10 @@ Let's create some dummy data that we can query once the Worker is running:
 
 ```npm
 # For the local database
-npx wrangler d1 execute __YOUR_D1_DATABASE_NAME__ --command "INSERT INTO \"User\" (\"email\", \"name\") VALUES ('jane@prisma.io', 'Jane Doe (Local)');" --local
+npx wrangler d1 execute __YOUR_D1_DATABASE_NAME__ --command="INSERT INTO \"User\" (\"email\", \"name\") VALUES ('jane@prisma.io', 'Jane Doe (Local)');" --local
 
 # For the remote database
-npx wrangler d1 execute __YOUR_D1_DATABASE_NAME__ --command "INSERT INTO \"User\" (\"email\", \"name\") VALUES ('jane@prisma.io', 'Jane Doe (Remote)');" --remote
+npx wrangler d1 execute __YOUR_D1_DATABASE_NAME__ --command="INSERT INTO \"User\" (\"email\", \"name\") VALUES ('jane@prisma.io', 'Jane Doe (Remote)');" --remote
 ```
 
 :::info


### PR DESCRIPTION
I tested this command in Windows PowerShell and found the ='s to be necessary for correct execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cloudflare D1 deployment documentation command examples with corrected syntax formatting for local and remote data insertion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->