### PR TITLE
fix(web): prevent UTM click handler from breaking cross-app navigation

### DIFF
--- a/apps/blog/src/components/utm-persistence.tsx
+++ b/apps/blog/src/components/utm-persistence.tsx
@@ -76,18 +76,29 @@ export function UtmPersistence() {
       }
 
       const nextHref = `${targetUrl.pathname}${targetUrl.search}${targetUrl.hash}`;
-      const internalPathname =
-        targetUrl.pathname === BLOG_PREFIX
-          ? "/"
-          : targetUrl.pathname.replace(new RegExp(`^${BLOG_PREFIX}(?:/|$)`), "/");
-      const nextInternalHref =
-        `${internalPathname}${targetUrl.search}${targetUrl.hash}`;
+      const isBlogPath =
+        targetUrl.pathname === BLOG_PREFIX ||
+        targetUrl.pathname.startsWith(`${BLOG_PREFIX}/`);
       const isModifiedClick =
         event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
 
-      if (isInternalLink && anchor.target !== "_blank" && !isModifiedClick) {
+      if (
+        isInternalLink &&
+        isBlogPath &&
+        anchor.target !== "_blank" &&
+        !isModifiedClick
+      ) {
+        const internalPathname =
+          targetUrl.pathname === BLOG_PREFIX
+            ? "/"
+            : targetUrl.pathname.replace(
+                new RegExp(`^${BLOG_PREFIX}(?:/|$)`),
+                "/",
+              );
         event.preventDefault();
-        router.push(nextInternalHref);
+        router.push(
+          `${internalPathname}${targetUrl.search}${targetUrl.hash}`,
+        );
         return;
       }
 

--- a/apps/site/src/components/utm-persistence.tsx
+++ b/apps/site/src/components/utm-persistence.tsx
@@ -80,7 +80,20 @@ export function UtmPersistence() {
       const isModifiedClick =
         event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
 
-      if (isInternalLink && anchor.target !== "_blank" && !isModifiedClick) {
+      // Paths proxied to other apps via rewrites — must use full navigation
+      // so the server-side rewrite kicks in instead of client-side routing.
+      const isProxiedPath =
+        targetUrl.pathname === "/docs" ||
+        targetUrl.pathname.startsWith("/docs/") ||
+        targetUrl.pathname === "/blog" ||
+        targetUrl.pathname.startsWith("/blog/");
+
+      if (
+        isInternalLink &&
+        !isProxiedPath &&
+        anchor.target !== "_blank" &&
+        !isModifiedClick
+      ) {
         event.preventDefault();
         router.push(nextHref);
         return;


### PR DESCRIPTION
## Summary
- **Site app**: Clicking "Docs" or "Blog" from pages with UTM params (e.g. `/?utm_term=devrel`) did nothing — `router.push("/docs")` tried client-side routing to a proxied path that doesn't exist as a page in the site app
- **Blog app**: Clicking any non-blog link (Pricing, Docs, etc.) from `/blog?utm_term=devrel` → 404 because `router.push("/pricing")` got `basePath: "/blog"` prepended → `/blog/pricing`
- Fix: each app's UTM click handler now only uses `router.push()` for paths it owns. Cross-app links fall through to `anchor.setAttribute()` so the browser does a full navigation and server rewrites apply correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined internal link routing logic to improve navigation accuracy across the site
  * Enhanced handling for links within blog and documentation sections to ensure proper navigation flow
  * Optimized routing behavior for distinct route types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->