### PR TITLE
docs: update PrismaClient initialization for v7 mandatory driver adapters

### DIFF
--- a/apps/docs/content/docs/orm/index.mdx
+++ b/apps/docs/content/docs/orm/index.mdx
@@ -142,7 +142,9 @@ const user = await prisma.user.create({
 :::note
 
 ### Prisma 7 Connection Requirements
-Starting with **Prisma 7**, providing a [driver adapter](/orm/core-concepts/supported-databases/database-drivers) is mandatory to connect to your database. This change standardizes database connectivity across Node.js, Serverless, and Edge environments.
+Starting with **Prisma 7**, providing a [driver adapter](/orm/core-concepts/supported-databases/database-drivers) is mandatory for direct database connections. This change standardizes database connectivity across Node.js, Serverless, and Edge environments.
+
+If you use Prisma Accelerate, instantiate Prisma Client with `accelerateUrl` and the Accelerate extension instead of a driver adapter.
 
 To ensure compatibility:
 * **Install an adapter:** Use the specific package for your database (e.g., `@prisma/adapter-pg`, `@prisma/adapter-mysql`, etc.).

--- a/apps/docs/content/docs/orm/index.mdx
+++ b/apps/docs/content/docs/orm/index.mdx
@@ -115,11 +115,11 @@ npx prisma generate
 
 ```ts
 import { PrismaClient } from "./generated/client";
-// Import the driver adapter for your specific database
-import { PrismaAdapter } from "@prisma/adapter-xyz"; 
+// Import the driver adapter for your specific database (example uses PostgreSQL)
+import { PrismaPg } from "@prisma/adapter-pg";
 
 // Initialize the adapter according to your driver's requirements
-const adapter = new PrismaAdapter(...);
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
 
 // Pass the adapter instance to PrismaClient
 const prisma = new PrismaClient({ adapter });

--- a/apps/docs/content/docs/orm/index.mdx
+++ b/apps/docs/content/docs/orm/index.mdx
@@ -115,8 +115,14 @@ npx prisma generate
 
 ```ts
 import { PrismaClient } from "./generated/client";
+// Import the driver adapter for your specific database
+import { PrismaAdapter } from "@prisma/adapter-xyz"; 
 
-const prisma = new PrismaClient();
+// Initialize the adapter according to your driver's requirements
+const adapter = new PrismaAdapter(...);
+
+// Pass the adapter instance to PrismaClient
+const prisma = new PrismaClient({ adapter });
 
 // Find all users with their posts
 const users = await prisma.user.findMany({
@@ -133,6 +139,18 @@ const user = await prisma.user.create({
   },
 });
 ```
+:::note
+
+### Prisma 7 Connection Requirements
+Starting with **Prisma 7**, providing a [driver adapter](/orm/core-concepts/supported-databases/database-drivers) is mandatory to connect to your database. This change standardizes database connectivity across Node.js, Serverless, and Edge environments.
+
+To ensure compatibility:
+* **Install an adapter:** Use the specific package for your database (e.g., `@prisma/adapter-pg`, `@prisma/adapter-mysql`, etc.).
+* **Enable ESM:** Your `package.json` must include `"type": "module"`.
+
+For detailed instructions, see the [V7 Upgrade Guide](/guides/upgrade-prisma-orm/v7).
+
+:::
 
 ## Next steps
 


### PR DESCRIPTION
Updating  PrismaClient initialization documentation to reflect mandatory driver adapters for the v7 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Prisma Client setup: explicitly configure a database driver adapter when connecting directly to a database.
  * Added a "Prisma 7 Connection Requirements" callout explaining driver adapter needs, how to use Prisma Accelerate with accelerateUrl + extension, and the requirement to enable ESM (`"type": "module"`).
  * Included links to supported adapter docs and the V7 upgrade guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->