### PR TITLE
fix: DR-8001 Remove Twiga links/mentions

### DIFF
--- a/apps/site/src/components/logo-parade.tsx
+++ b/apps/site/src/components/logo-parade.tsx
@@ -25,13 +25,6 @@ const logoParade = [
     height: 40,
   },
   {
-    label: "Twiga",
-    imageUrl: `/icons/companies/twiga.svg`,
-    url: "https://twiga.com/",
-    width: 55,
-    height: 61,
-  },
-  {
     label: "Panther",
     imageUrl: `/icons/companies/panther.svg`,
     url: "https://www.panther.co/",

--- a/packages/ui/src/components/logo-parade.tsx
+++ b/packages/ui/src/components/logo-parade.tsx
@@ -25,13 +25,6 @@ const logoParade = [
     height: 40,
   },
   {
-    label: "Twiga",
-    imageUrl: `/icons/companies/twiga.svg`,
-    url: "https://twiga.com/",
-    width: 55,
-    height: 61,
-  },
-  {
     label: "Panther",
     imageUrl: `/icons/companies/panther.svg`,
     url: "https://www.panther.co/",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Twiga from the company logo carousel displayed throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->