### PR TITLE
feat(docs): add cursor plugin link

### DIFF
--- a/apps/docs/content/docs/ai/tools/cursor.mdx
+++ b/apps/docs/content/docs/ai/tools/cursor.mdx
@@ -22,18 +22,17 @@ While this guide is focused on Cursor, these patterns should work with any AI ed
 
 ## Prisma Plugin
 
-The [Prisma plugin for Cursor](https://cursor.com/marketplace/prisma) provides integration with the Prism MCP server, various skills for working with Prisma ORM and Prisma Postgres, and automation for database development
+The [Prisma plugin for Cursor](https://cursor.com/marketplace/prisma) provides integration with the Prisma MCP server, various skills for working with Prisma ORM and Prisma Postgres, and automation for database development.
 
 <Button asChild variant="ppg" className="w-fit mx-0">
-<a
-  href="https://cursor.com/marketplace/prisma"
-  target="_blank"
-  rel="noopener noreferrer"
-  aria-label="Install Prisma Plugin for Cursor"
->
-  Install the Prisma plugin for Cursor
-</a>
-
+  <a
+    href="https://cursor.com/marketplace/prisma"
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label="Install Prisma Plugin for Cursor"
+  >
+    Install the Prisma plugin for Cursor
+  </a>
 </Button>
 
 ## Prisma MCP server

--- a/apps/docs/content/docs/ai/tools/cursor.mdx
+++ b/apps/docs/content/docs/ai/tools/cursor.mdx
@@ -20,18 +20,37 @@ While this guide is focused on Cursor, these patterns should work with any AI ed
 
 :::
 
+## Prisma Plugin
+
+The [Prisma plugin for Cursor](https://cursor.com/marketplace/prisma) provides integration with the Prism MCP server, various skills for working with Prisma ORM and Prisma Postgres, and automation for database development
+
+<Button asChild variant="ppg" className="w-fit mx-0">
+<a
+  href="https://cursor.com/marketplace/prisma"
+  target="_blank"
+  rel="noopener noreferrer"
+  aria-label="Install Prisma Plugin for Cursor"
+>
+  Install the Prisma plugin for Cursor
+</a>
+
+</Button>
+
 ## Prisma MCP server
 
 Prisma provides its own [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) server that lets you manage Prisma Postgres databases, model database schemas and chat through migrations. Learn more about how you can add it to Cursor [here](/ai/tools/mcp-server#cursor). You can also add the Prisma MCP server to Cursor using the [one-click installation](https://docs.cursor.com/context/model-context-protocol#one-click-installation) by clicking on the following link:
 
+<Button asChild variant="ppg" className="w-fit mx-0">
 <a
   href="https://pris.ly/cursor-prisma-mcp-web"
   target="_blank"
   rel="noopener noreferrer"
   aria-label="Install Prisma MCP server in Cursor"
 >
-  <img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Install MCP Server" />
+  Install MCP Server
 </a>
+</Button> 
+
 
 This will prompt you to open the Cursor app in your browser. Once opened, you'll be guided to install the Prisma MCP server directly into your Cursor configuration.
 

--- a/apps/docs/src/mdx-components.tsx
+++ b/apps/docs/src/mdx-components.tsx
@@ -30,6 +30,7 @@ import {
   TableCaption,
   Input,
   Alert,
+  Button
 } from "@prisma/eclipse";
 
 function withDocsBasePathForImageSrc(src: unknown): unknown {
@@ -53,6 +54,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     TabsTrigger,
     ...components,
     // Eclipse CodeBlock tab components - globally available for code blocks
+    Button,
     CodeBlockTabs,
     CodeBlockTabsList,
     CodeBlockTabsTrigger,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Prisma Plugin" section in the Cursor docs with a direct install link to the plugin marketplace.
  * Updated the Prisma MCP Server install CTA to use a consistent, accessible button (replacing the previous image-based CTA).
  * Standardized install links to use accessible button elements for improved usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->