### PR TITLE
fix(orm-page): update cta from `create database` -> `read the docs`

### DIFF
--- a/apps/site/src/app/orm/page.tsx
+++ b/apps/site/src/app/orm/page.tsx
@@ -57,7 +57,12 @@ const CardFooter = () => (
           <div className="flex justify-center md:justify-start gap-3">
             {badge.list &&
               badge.list.map((item: any) => (
-                <Button asChild variant="orm" key={item.label} className="text-base">
+                <Button
+                  asChild
+                  variant="orm"
+                  key={item.label}
+                  className="text-base"
+                >
                   <a href={item.url}>{item.label}</a>
                 </Button>
               ))}
@@ -80,9 +85,9 @@ const twoCol = [
           </h2>
         </div>
         <p className="text-foreground-neutral-weak! text-base">
-          Database workflows can feel brittle and error-prone. Prisma ORM increases productivity and
-          confidence when working with databases and makes workflows like data modeling, migrations
-          and querying easy.
+          Database workflows can feel brittle and error-prone. Prisma ORM
+          increases productivity and confidence when working with databases and
+          makes workflows like data modeling, migrations and querying easy.
         </p>
       </>
     ),
@@ -111,8 +116,8 @@ const twoCol = [
           Works with your favorite databases and frameworks
         </h2>
         <p className="text-foreground-neutral-weak! text-base">
-          Prisma's compatibility with popular tools ensures no stack lock-in, lower integration
-          costs, and smooth transitions.
+          Prisma's compatibility with popular tools ensures no stack lock-in,
+          lower integration costs, and smooth transitions.
         </p>
         <Link href="/stack" className="link-btn orm w-fit mx-auto lg:mx-0">
           <span>Learn more</span>
@@ -144,10 +149,15 @@ const twoCol_2 = [
           </h2>
         </div>
         <p className="text-foreground-neutral-weak! text-base">
-          A meaningful comparison of database query latencies across database providers and ORM
-          libraries in the Node.js & TypeScript ecosystem.
+          A meaningful comparison of database query latencies across database
+          providers and ORM libraries in the Node.js & TypeScript ecosystem.
         </p>
-        <Button asChild variant="orm" size="xl" className="w-fit mx-auto lg:w-full">
+        <Button
+          asChild
+          variant="orm"
+          size="xl"
+          className="w-fit mx-auto lg:w-full"
+        >
           <a href="https://benchmarks.prisma.io">
             Explore Benchmarks
             <i className="fa-regular fa-arrow-right" />
@@ -177,9 +187,10 @@ const twoCol_2 = [
           </h2>
         </div>
         <p className="text-foreground-neutral-weak! text-base">
-          Prisma Client is a query builder that’s tailored to your schema. We designed its API to be
-          intuitive, both for SQL veterans and developers brand new to databases. The
-          auto-completion helps you figure out your query without the need for documentation.
+          Prisma Client is a query builder that’s tailored to your schema. We
+          designed its API to be intuitive, both for SQL veterans and developers
+          brand new to databases. The auto-completion helps you figure out your
+          query without the need for documentation.
         </p>
         <Link href="/client" className="link-btn orm w-fit mx-auto lg:mx-0">
           <span>Learn more</span>
@@ -292,14 +303,19 @@ export default function ORM() {
             </h1>
           </div>
           <p className="text-center text-foreground-neutral max-w-2xl mx-auto">
-            Prisma ORM elevates developer experience with intuitive data modeling, automated
-            migrations, and type-safety.
+            Prisma ORM elevates developer experience with intuitive data
+            modeling, automated migrations, and type-safety.
           </p>
           <div className="flex flex-col md:flex-row gap-4 items-center justify-center">
-            <Button asChild variant="orm" size="3xl" className="font-sans-display! font-[650]">
+            <Button
+              asChild
+              variant="orm"
+              size="3xl"
+              className="font-sans-display! font-[650]"
+            >
               <a href={prismaPostgresQuickstartUrl}>
-                Create database
-                <i className="fa-regular fa-database" />
+                Read the docs
+                <i className="fa-regular fa-arrow-right" />
               </a>
             </Button>
             {/*<Button
@@ -338,16 +354,28 @@ export default function ORM() {
           <div className="grid md:grid-cols-2 gap-9">
             {twoCol_3.map((stat, index) => (
               <div key={stat.title} className="flex flex-col gap-4">
-                <Action size="4xl" color="orm" className={cn(index === 0 && "p-0", "relative")}>
+                <Action
+                  size="4xl"
+                  color="orm"
+                  className={cn(index === 0 && "p-0", "relative")}
+                >
                   <Image src={stat.icon} alt={stat.title} fill loading="lazy" />
                 </Action>
                 <h4 className="text-2xl text-center md:text-left font-sans-display stretch-display text-foreground-neutral">
                   {stat.title}
                 </h4>
-                <p className="text-center md:text-left text-foreground-neutral-weak">{stat.description}</p>
-                <Button asChild variant="default-strong" size="xl" className="w-fit mx-auto md:mx-0">
+                <p className="text-center md:text-left text-foreground-neutral-weak">
+                  {stat.description}
+                </p>
+                <Button
+                  asChild
+                  variant="default-strong"
+                  size="xl"
+                  className="w-fit mx-auto md:mx-0"
+                >
                   <a href={stat.btn.url}>
-                    {stat.btn.label} {stat.btn.icon && <i className={stat.btn.icon} />}
+                    {stat.btn.label}{" "}
+                    {stat.btn.icon && <i className={stat.btn.icon} />}
                   </a>
                 </Button>
               </div>
@@ -364,8 +392,8 @@ export default function ORM() {
           </h3>
           <div className="content flex flex-col lg:flex-row gap-3 lg:gap-12 items-center md:items-start lg:items-center">
             <p className="max-w-94 w-full text-center md:text-left text-foreground-neutral-weak text-md">
-              Integrate Prisma into your development ecosystem and focus on your team’s core
-              competencies
+              Integrate Prisma into your development ecosystem and focus on your
+              team’s core competencies
             </p>
             <Button asChild variant="orm" size="2xl">
               <a href="/enterprise">
@@ -412,8 +440,8 @@ export default function ORM() {
                 Ready to get started?
               </h2>
               <p className="text-foreground-neutral-weak max-w-121">
-                Start from scratch, add Prisma ORM to your existing project, or explore how to build
-                an app using your favorite framework.
+                Start from scratch, add Prisma ORM to your existing project, or
+                explore how to build an app using your favorite framework.
               </p>
             </div>
             <div className="flex flex-col md:flex-row gap-6">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the primary call-to-action on the ORM page from "Create database" to "Read the docs" with an updated icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->