### PR TITLE
fix(site): proxy docs .mdx URLs before site markdown rewrite

### DIFF
--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -732,6 +732,11 @@ const config = {
           destination: "/sitemap-site.xml",
         },
         {
+          source: "/docs/:path*.mdx",
+          destination: `${DOCS_ORIGIN}/docs/:path*.mdx`,
+          missing: [{ type: "host", value: DOCS_ORIGIN_HOST }],
+        },
+        {
           source: "/:path*.mdx",
           destination: "/llms.mdx/:path*",
         },


### PR DESCRIPTION
## What changed

Adds a docs-specific `.mdx` rewrite in the site app before the generic site markdown rewrite.

## Why

`www.prisma.io/docs/...mdx` was being captured by the site-level `/:path*.mdx` rewrite and routed to `/llms.mdx/docs/...`, but the site `llms.mdx` route is a 404 placeholder and the docs `llms.mdx` route expects the slug without the leading `docs` segment.

This lets `/docs/prisma-orm/add-to-existing-project/sqlite.mdx` proxy through to the docs app, where the existing docs rewrite resolves it to the markdown mirror.

## Validation

- `curl -sSIL http://localhost:3000/docs/prisma-orm/add-to-existing-project/sqlite.mdx` returns `200` with `content-type: text/markdown; charset=utf-8`
- `NEXT_DOCS_ORIGIN=https://docs.prisma.io NEXT_BLOG_ORIGIN=https://blog.prisma.io pnpm --filter site build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved routing configuration for documentation files to ensure proper external origin proxying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->