### PR TITLE
Improve Prisma AI docs context for v7 guidance

### DIFF
--- a/apps/docs/content/docs/ai/prompts/prisma-7.mdx
+++ b/apps/docs/content/docs/ai/prompts/prisma-7.mdx
@@ -8,7 +8,7 @@ url: /ai/prompts/prisma-7
 
 ## How to use
 
-Include this prompt in your AI assistant to guide in upgrading to Prisma ORM 7.0.
+Include this prompt in your AI assistant to guide in upgrading to Prisma ORM 7.
 
 - **GitHub Copilot**: Type `#<filename>` to reference the prompt file.
 - **Cursor**: Use `@Files` and select your prompt file.
@@ -82,10 +82,10 @@ alwaysApply: false
 ## 1) Dependencies
 
 - Upgrade/install:
-  - Dev: `prisma@latest` (7.0.0), `tsx`, `dotenv` (skip if Bun).
-  - Runtime: `@prisma/client@latest` (7.0.0).
+  - Dev: `prisma@latest`, `tsx`, `dotenv` (skip if Bun).
+  - Runtime: `@prisma/client@latest`.
   - **One** database adapter that matches the datasource:
-    - Postgres: `@prisma/adapter-ppg`
+    - Postgres: `@prisma/adapter-pg`
     - SQLite: `@prisma/adapter-better-sqlite3`
     - MySQL/mariaDB: `@prisma/adapter-mariadb`
     - D1: `@prisma/adapter-d1`
@@ -153,7 +153,9 @@ alwaysApply: false
 
 ---
 
-## 3) Introduce prisma.config.ts Create **prisma.config.ts** at repo root (or prisma.config.mjs), centralizing Prisma CLI config and env management:
+## 3) Introduce prisma.config.ts
+
+Create **prisma.config.ts** at repo root (or prisma.config.mjs), centralizing Prisma CLI config and env management:
 
 ```tsx
 import "dotenv/config";

--- a/apps/docs/content/docs/ai/prompts/prisma-7.mdx
+++ b/apps/docs/content/docs/ai/prompts/prisma-7.mdx
@@ -8,7 +8,7 @@ url: /ai/prompts/prisma-7
 
 ## How to use
 
-Include this prompt in your AI assistant to guide in upgrading to Prisma ORM 7.
+Include this prompt in your AI agent to upgrade to Prisma ORM 7.
 
 - **GitHub Copilot**: Type `#<filename>` to reference the prompt file.
 - **Cursor**: Use `@Files` and select your prompt file.

--- a/apps/docs/content/docs/ai/tools/cursor.mdx
+++ b/apps/docs/content/docs/ai/tools/cursor.mdx
@@ -10,8 +10,9 @@ metaDescription: Learn tips and best practices for using Prisma ORM with the Cur
 
 This guide provides detailed instructions for effectively using Prisma with Cursor to:
 
-- Define project-specific best practices with `.cursorrules`.
-- Using Cursor's context-aware capabilities.
+- Configure the Prisma MCP server for database workflows.
+- Define project-specific Prisma guidance with Project Rules or `AGENTS.md`.
+- Use Cursor's context-aware capabilities.
 - Generate schemas, queries, and seed data tailored to your database.
 
 :::note
@@ -35,138 +36,35 @@ Prisma provides its own [Model Context Protocol](https://modelcontextprotocol.io
 
 This will prompt you to open the Cursor app in your browser. Once opened, you'll be guided to install the Prisma MCP server directly into your Cursor configuration.
 
-## Defining project-specific rules with `.cursorrules`
+## Define project-specific rules
 
-The [`.cursorrules` file](https://docs.cursor.com/context/rules-for-ai#cursorrules) in Cursor allows you to enforce best practices and development standards tailored to your Prisma projects. By defining clear and consistent rules, you can ensure that Cursor generates clean, maintainable, and project-specific code with minimal manual adjustments.
+[Cursor Rules](https://docs.cursor.com/context/rules) provide persistent instructions to Cursor's Agent and Inline Edit. For Prisma projects, prefer one of these current options:
 
-To implement these rules, create a `.cursorrules` file in the root of your project. Below is an example configuration:
+- **Project Rules**: Create a version-controlled `.cursor/rules/prisma.mdc` file for structured rules.
+- **`AGENTS.md`**: Create an `AGENTS.md` file in the project root for simple, readable agent instructions.
 
-<details>
-<summary>
- Example `.cursorrules` file
-</summary>
+The legacy `.cursorrules` file is still supported by Cursor, but Cursor recommends Project Rules for new projects.
 
-```text title=".cursorrules"
-You are a senior TypeScript/JavaScript programmer with expertise in Prisma, clean code principles, and modern backend development.
-Generate code, corrections, and refactorings that comply with the following guidelines:
-TypeScript General Guidelines
-Basic Principles
-- Use English for all code and documentation.
-- Always declare explicit types for variables and functions.
-  - Avoid using "any".
-  - Create precise, descriptive types.
-- Use JSDoc to document public classes and methods.
-- Maintain a single export per file.
-- Write self-documenting, intention-revealing code.
-Nomenclature
-- Use PascalCase for classes and interfaces.
-- Use camelCase for variables, functions, methods.
-- Use kebab-case for file and directory names.
-- Use UPPERCASE for environment variables and constants.
-- Start function names with a verb.
-- Use verb-based names for boolean variables:
-  - isLoading, hasError, canDelete
-- Use complete words, avoiding unnecessary abbreviations.
-  - Exceptions: standard abbreviations like API, URL
-  - Accepted short forms:
-    - i, j for loop indices
-    - err for errors
-    - ctx for contexts
-Functions
-- Write concise, single-purpose functions.
-  - Aim for less than 20 lines of code.
-- Name functions descriptively with a verb.
-- Minimize function complexity:
-  - Use early returns.
-  - Extract complex logic to utility functions.
-- Leverage functional programming techniques:
-  - Prefer map, filter, reduce.
-  - Use arrow functions for simple operations.
-  - Use named functions for complex logic.
-- Use object parameters for multiple arguments.
-- Maintain a single level of abstraction.
-Data Handling
-- Encapsulate data in composite types.
-- Prefer immutability.
-  - Use readonly for unchanging data.
-  - Use as const for literal values.
-- Validate data at the boundaries.
-Error Handling
-- Use specific, descriptive error types.
-- Provide context in error messages.
-- Use global error handling where appropriate.
-- Log errors with sufficient context.
-Prisma-Specific Guidelines
-Schema Design
-- Use meaningful, domain-driven model names.
-- Leverage Prisma schema features:
-  - Use @id for primary keys.
-  - Use @unique for natural unique identifiers.
-  - Utilize @relation for explicit relationship definitions.
-- Keep schemas normalized and DRY.
-- Use meaningful field names and types.
-- Implement soft delete with deletedAt timestamp.
-- Use Prisma's native type decorators.
-Prisma Client Usage
-- Always use type-safe Prisma client operations.
-- Prefer transactions for complex, multi-step operations.
-- Handle optional relations explicitly.
-- Use Prisma's filtering and pagination capabilities.
-Database Migrations
-- Create migrations for schema changes.
-- Use descriptive migration names.
-- Review migrations before applying.
-- Never modify existing migrations.
-- Keep migrations idempotent.
-Error Handling with Prisma
-- Catch and handle Prisma-specific errors:
-  - PrismaClientKnownRequestError
-  - PrismaClientUnknownRequestError
-  - PrismaClientValidationError
-- Provide user-friendly error messages.
-- Log detailed error information for debugging.
-Testing Prisma Code
-- Use in-memory database for unit tests.
-- Mock Prisma client for isolated testing.
-- Test different scenarios:
-  - Successful operations
-  - Error cases
-  - Edge conditions
-- Use factory methods for test data generation.
-- Implement integration tests with actual database.
-Performance Considerations
-- Use select and include judiciously.
-- Avoid N+1 query problems.
-- Use findMany with take and skip for pagination.
-- Leverage Prisma's distinct for unique results.
-- Profile and optimize database queries.
-Security Best Practices
-- Never expose raw Prisma client in APIs.
-- Use input validation before database operations.
-- Implement row-level security.
-- Sanitize and validate all user inputs.
-- Use Prisma's built-in protections against SQL injection.
-Coding Style
-- Keep Prisma-related code in dedicated repositories/modules.
-- Separate data access logic from business logic.
-- Create repository patterns for complex queries.
-- Use dependency injection for Prisma services.
-Code Quality
-- Follow SOLID principles.
-- Prefer composition over inheritance.
-- Write clean, readable, and maintainable code.
-- Continuously refactor and improve code structure.
-Development Workflow
-- Use version control (Git).
-- Implement comprehensive test coverage.
-- Use continuous integration.
-- Perform regular code reviews.
-- Keep dependencies up to date.
+Below is a concise Project Rule you can add to `.cursor/rules/prisma.mdc`:
+
+```markdown title=".cursor/rules/prisma.mdc"
+---
+description: Prisma ORM and Prisma Postgres guidance
+globs: **/*.{ts,tsx,js,jsx,prisma,json}
+alwaysApply: false
+---
+
+- Prefer current Prisma documentation from https://www.prisma.io/docs and the Prisma LLM feed at https://pris.ly/llms.txt.
+- For Prisma ORM v7 projects, use the `prisma-client` generator with an explicit `output`.
+- Keep database connection URLs in `prisma.config.ts`; do not add `url = env("DATABASE_URL")` to the Prisma schema unless the project is intentionally using older Prisma ORM conventions.
+- Use `prisma.config.ts` with `datasource.url = env("DATABASE_URL")` for Prisma CLI commands.
+- Instantiate Prisma Client with the correct driver adapter for the database, for example `@prisma/adapter-pg` for PostgreSQL.
+- When creating or managing Prisma Postgres databases, prefer the Prisma MCP server tools instead of guessing CLI/API steps.
+- Before changing Prisma setup, inspect `package.json`, `prisma.config.*`, `schema.prisma`, existing generated client imports, and the installed Prisma version.
+- Preserve existing Prisma Accelerate usage unless explicitly asked to migrate it.
 ```
 
-</details>
-
-This file ensures consistent and maintainable code generation, reducing manual intervention while improving project quality.
+For a simpler repo-wide setup, you can paste the same guidance into `AGENTS.md`.
 
 ## Using Cursor's context-aware capabilities
 
@@ -178,7 +76,7 @@ To improve Cursor's understanding of Prisma-related suggestions in your project,
 
 ### Adding additional Prisma documentation
 
-Cursor already includes built-in context from Prisma documentation, so you don't need to add anything to make us of our docs!
+Cursor may already have Prisma documentation available in its built-in docs context, but external documentation indexes can lag behind the latest Prisma release. Add the Prisma LLM feed explicitly when you need Cursor to follow the current recommended setup.
 
 To stay updated with the latest changes or incorporate additional context, add these resources as `@Docs` context:
 

--- a/apps/docs/content/docs/ai/tools/cursor.mdx
+++ b/apps/docs/content/docs/ai/tools/cursor.mdx
@@ -62,6 +62,18 @@ alwaysApply: false
 - When creating or managing Prisma Postgres databases, prefer the Prisma MCP server tools instead of guessing CLI/API steps.
 - Before changing Prisma setup, inspect `package.json`, `prisma.config.*`, `schema.prisma`, existing generated client imports, and the installed Prisma version.
 - Preserve existing Prisma Accelerate usage unless explicitly asked to migrate it.
+
+## Prisma application best practices
+
+- Validate inputs at API boundaries before calling Prisma Client.
+- Use `select` or scoped `include` to avoid over-fetching data.
+- Use transactions for multi-step writes that must succeed or fail together.
+- Handle known Prisma errors intentionally, especially constraint and validation errors.
+- Prefer integration tests against the same database provider used in production when testing Prisma behavior.
+- Mock Prisma Client only for isolated unit tests where database behavior is not under test.
+- Review generated migrations before applying them to shared or production environments.
+- Avoid exposing database-specific errors directly to end users.
+- Keep Prisma-related database access separate from unrelated business logic when it improves maintainability.
 ```
 
 For a simpler repo-wide setup, you can paste the same guidance into `AGENTS.md`.

--- a/apps/docs/content/docs/cli/init.mdx
+++ b/apps/docs/content/docs/cli/init.mdx
@@ -23,7 +23,7 @@ The command creates a `prisma` directory containing a `schema.prisma` file. By d
 | `-h`, `--help`          | Display help message                                                                                      |
 | `--db`                  | Provision a fully managed Prisma Postgres database on the Prisma Data Platform                            |
 | `--datasource-provider` | Define the datasource provider: `postgresql`, `mysql`, `sqlite`, `sqlserver`, `mongodb`, or `cockroachdb` |
-| `--generator-provider`  | Define the generator provider to use (default: `prisma-client-js`)                                        |
+| `--generator-provider`  | Define the generator provider to use (default: `prisma-client`)                                           |
 | `--preview-feature`     | Define a preview feature to use (can be specified multiple times)                                         |
 | `--output`              | Define Prisma Client generator output path                                                                |
 | `--url`                 | Define a custom datasource URL                                                                            |
@@ -54,7 +54,7 @@ npx prisma init --datasource-provider mysql
 
 ### Specify a generator provider
 
-Set up a project with a specific generator provider:
+Set up a project with the legacy `prisma-client-js` generator instead of the default `prisma-client` generator:
 
 ```npm
 npx prisma init --generator-provider prisma-client-js
@@ -132,6 +132,7 @@ datasource db {
 A TypeScript configuration file for Prisma:
 
 ```typescript
+import "dotenv/config";
 import { defineConfig, env } from "prisma/config";
 
 export default defineConfig({

--- a/apps/docs/src/app/llms-full-v6.txt/route.ts
+++ b/apps/docs/src/app/llms-full-v6.txt/route.ts
@@ -1,0 +1,24 @@
+import { sourceV6 } from "@/lib/source";
+import { getLLMText } from "@/lib/get-llm-text";
+
+export const revalidate = false;
+
+export async function GET() {
+  const description = `# Prisma Documentation v6 - Legacy Full Content Feed
+
+This file contains the complete Prisma v6 documentation in machine-readable format.
+Use this legacy feed only for projects that are intentionally staying on Prisma ORM v6.
+
+---
+
+`;
+
+  const scan = sourceV6.getPages().map(getLLMText);
+  const scanned = await Promise.all(scan);
+
+  return new Response(description + scanned.join("\n\n"), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/apps/docs/src/app/llms-full.txt/route.ts
+++ b/apps/docs/src/app/llms-full.txt/route.ts
@@ -1,4 +1,4 @@
-import { source, sourceV6 } from "@/lib/source";
+import { source } from "@/lib/source";
 import { getLLMText } from "@/lib/get-llm-text";
 
 export const revalidate = false;
@@ -7,14 +7,13 @@ export async function GET() {
   const description = `# Prisma Documentation - Full Content Feed
 
 This file contains the complete Prisma documentation in machine-readable format.
-Includes both v7 (current) and v6 documentation.
+Includes v7 documentation only.
 
 ---
 
 `;
 
-  const allPages = [...source.getPages(), ...sourceV6.getPages()];
-  const scan = allPages.map(getLLMText);
+  const scan = source.getPages().map(getLLMText);
   const scanned = await Promise.all(scan);
 
   return new Response(description + scanned.join("\n\n"), {

--- a/apps/docs/src/app/llms.txt/route.ts
+++ b/apps/docs/src/app/llms.txt/route.ts
@@ -44,7 +44,8 @@ ${v6DocsList}
 
 ## Options
 
-- [Full documentation with content](${baseUrl}${withDocsBasePath("/llms-full.txt")})
+- [Full current documentation with content](${baseUrl}${withDocsBasePath("/llms-full.txt")})
+- [Legacy v6 documentation with content](${baseUrl}${withDocsBasePath("/llms-full-v6.txt")})
 `;
 
   return new Response(content, {


### PR DESCRIPTION
## Summary

This PR makes Prisma's AI-facing documentation less likely to steer coding agents toward stale setup patterns.

It fixes current Prisma v7 guidance, aligns the prisma init reference with generated v7-style examples, updates Cursor guidance to use current Project Rules / AGENTS.md patterns, and separates the latest LLM docs feed from legacy v6 content.

## Why

Coding agents often combine model memory, local files, docs indexes, web results, and MCP/tool output. When current docs, legacy docs, and AI prompts are bundled together or contradict each other, agents can pick outdated patterns such as schema-level DATABASE_URL, prisma-client-js, or incorrect adapter packages.

## Validation

- Searched for stale/incorrect Prisma adapter references.
- Checked Cursor guidance no longer recommends .cursorrules as the primary path.
- Verified LLM feed routing keeps latest docs separate from legacy v6 content.
- Ran pnpm --filter docs run types:check; route types generated successfully, then the command failed on unrelated existing TypeScript errors in eclipse-showcase.tsx and packages/ui/src/components/utm-persistence.tsx.
- Ran pnpm --filter docs run lint:code; it reports existing code-block title violations across the docs repo, with none in the touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Prisma setup text, removed explicit "v7.0" version labels, corrected the Postgres adapter name, and improved formatting in config examples.
  * Updated Cursor guidance to use Project Rules, clarified Prisma LLM feed usage and database URL placement, and added MCP server checklist for DB workflows.
  * Revised CLI init docs to reflect the current default generator and updated startup example.

* **New Features**
  * Added a separate legacy Prisma v6 plain-text documentation feed and updated the full-docs listing to show both current and legacy options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->