### PR TITLE
Fix review feedback on docs SEO remediation

### DIFF
--- a/apps/docs/content/docs/orm/more/comparisons/prisma-and-drizzle.mdx
+++ b/apps/docs/content/docs/orm/more/comparisons/prisma-and-drizzle.mdx
@@ -326,7 +326,7 @@ Prisma isn’t just an ORM—it’s a complete type-safe data toolkit:
 
 Both Drizzle and Prisma ORM support multiple and different kinds of databases. Drizzle achieves this support through driver implementations created by Drizzle, which integrate with existing third-party database drivers.
 
-Prisma ORM has begun adding support for [third-party database drivers](https://www.prisma.io/blog/serverless-database-drivers-kml1ehxorxzv). Prisma also defaults connections to TLS, which improves security.
+Prisma ORM has begun adding support for [third-party database drivers](https://www.prisma.io/blog/serverless-database-drivers-KML1ehXORxZV). Prisma also defaults connections to TLS, which improves security.
 
 Additionally, Prisma ORM supports CockroachDB, Microsoft SQL Server, and MongoDB, which Drizzle does not currently support. Prisma ORM also offers the [relation mode](/orm/prisma-schema/data-model/relations/relation-mode) that allows Prisma ORM to emulate foreign key constraints for those database engines that do not support it. Drizzle currently supports Cloudflare D1, `bun:sqlite`, and SQLite via HTTP Proxy, which Prisma ORM currently does not.
 

--- a/apps/docs/content/docs/orm/prisma-client/queries/pagination.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/queries/pagination.mdx
@@ -35,16 +35,18 @@ const firstPage = await prisma.post.findMany({
 
 const lastPost = firstPage[firstPage.length - 1];
 
-const nextPage = await prisma.post.findMany({
-  take: 10,
-  skip: 1,
-  cursor: {
-    id: lastPost.id,
-  },
-  orderBy: {
-    id: "asc",
-  },
-});
+const nextPage = lastPost
+  ? await prisma.post.findMany({
+      take: 10,
+      skip: 1,
+      cursor: {
+        id: lastPost.id,
+      },
+      orderBy: {
+        id: "asc",
+      },
+    })
+  : [];
 ```
 
 ## Which approach to choose
@@ -57,4 +59,3 @@ const nextPage = await prisma.post.findMany({
 - [Filtering and sorting](/orm/prisma-client/queries/filtering-and-sorting)
 - [Query Insights](/query-insights)
 - [Prisma Client API reference](/orm/reference/prisma-client-reference#cursor)
-

--- a/apps/docs/content/docs/orm/reference/prisma-client-reference.mdx
+++ b/apps/docs/content/docs/orm/reference/prisma-client-reference.mdx
@@ -1532,7 +1532,7 @@ See: [Using Raw SQL (`aggregateRaw()`)](/orm/prisma-client/using-raw-sql/raw-que
 
 ### `select`
 
-`select` defines which fields are included in the object that Prisma Client returns. See: [Select fields and include relations](/orm/prisma-client/queries/select-fields) .
+`select` defines which fields are included in the object that Prisma Client returns. See: [Select fields and include relations](/orm/prisma-client/queries/select-fields).
 
 #### Remarks
 
@@ -1694,7 +1694,7 @@ const result = await prisma.user.findMany({
 
 ### `include`
 
-`include` defines which relations are included in the result that Prisma Client returns. See: [Select fields and include relations](/orm/prisma-client/queries/select-fields) .
+`include` defines which relations are included in the result that Prisma Client returns. See: [Select fields and include relations](/orm/prisma-client/queries/select-fields).
 
 #### Remarks
 

--- a/apps/docs/scripts/audit-redirects.mjs
+++ b/apps/docs/scripts/audit-redirects.mjs
@@ -13,8 +13,10 @@ const broadDestinations = new Set([
 ]);
 
 function normalizeRoute(route) {
-  if (route.length > 1 && route.endsWith("/")) return route.slice(0, -1);
-  return route;
+  const cleanRoute = route.split(/[?#]/, 1)[0];
+
+  if (cleanRoute.length > 1 && cleanRoute.endsWith("/")) return cleanRoute.slice(0, -1);
+  return cleanRoute;
 }
 
 function toDocsRoute(url) {

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -486,11 +486,6 @@
       "permanent": true
     },
     {
-      "source": "/docs/optimize/:path*",
-      "destination": "/docs/query-insights",
-      "permanent": true
-    },
-    {
       "source": "/docs/v6/optimize",
       "destination": "/docs/query-insights",
       "permanent": true


### PR DESCRIPTION
## Summary
- fix the review feedback on the first docs SEO remediation PR
- remove the early duplicate `/docs/optimize/:path*` redirect that shadowed specific optimize recommendation redirects
- harden the redirect audit path normalization and fix the failing external blog link

## Validation
- ran `pnpm --filter docs run audit:redirects`
- verified `https://www.prisma.io/blog/serverless-database-drivers-KML1ehXORxZV` returns `200`

## Stack
- base PR: #7832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced cursor-based pagination documentation to properly handle edge cases when retrieving subsequent pages
  * Updated external reference links in database support section
  * Corrected formatting in ORM reference documentation

* **Chores**
  * Improved URL redirect routing and query parameter handling for better accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->