### PR TITLE
Fix next batch of docs redirect destinations

### DIFF
--- a/apps/docs/content/docs/orm/more/dev-environment/index.mdx
+++ b/apps/docs/content/docs/orm/more/dev-environment/index.mdx
@@ -1,0 +1,21 @@
+---
+title: Dev environment
+description: Set up your local Prisma ORM development environment, including editor tooling and environment variables.
+url: /orm/more/dev-environment
+metaTitle: Prisma ORM development environment
+metaDescription: Learn how to set up your Prisma ORM development environment, editor tooling, and environment variables.
+---
+
+These guides cover the local development environment around Prisma ORM: editor setup, configuration ergonomics, and environment variable management.
+
+## Start here
+
+- [Environment variables](/orm/more/dev-environment/environment-variables)
+- [Editor setup](/orm/more/dev-environment/editor-setup)
+
+## Related pages
+
+- [Prisma schema overview](/orm/prisma-schema/overview)
+- [Prisma CLI](/cli)
+- [Prisma Config reference](/orm/reference/prisma-config-reference)
+

--- a/apps/docs/content/docs/orm/more/dev-environment/meta.json
+++ b/apps/docs/content/docs/orm/more/dev-environment/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Dev environment",
-  "pages": ["environment-variables", "editor-setup"]
+  "pages": ["index", "environment-variables", "editor-setup"]
 }

--- a/apps/docs/content/docs/postgres/database/index.mdx
+++ b/apps/docs/content/docs/postgres/database/index.mdx
@@ -1,0 +1,29 @@
+---
+title: Database
+description: Overview of Prisma Postgres database operations, connections, pooling, backups, and query analysis.
+url: /postgres/database
+metaTitle: Prisma Postgres database guides
+metaDescription: Explore Prisma Postgres database guides for connections, pooling, query insights, backups, and local development.
+---
+
+This section covers the operational side of Prisma Postgres: how to connect, how pooling works, how to inspect query behavior, and how to manage your database in development and production.
+
+## Start here
+
+- [Connecting to your database](/postgres/database/connecting-to-your-database)
+- [Connection pooling](/postgres/database/connection-pooling)
+- [Query Insights](/postgres/database/query-insights)
+
+## Operations and maintenance
+
+- [Backups](/postgres/database/backups)
+- [PostgreSQL extensions](/postgres/database/postgres-extensions)
+- [Serverless driver](/postgres/database/serverless-driver)
+- [Local development](/postgres/database/local-development)
+
+## Related pages
+
+- [Prisma Postgres overview](/postgres)
+- [Troubleshooting](/postgres/troubleshooting)
+- [FAQ](/postgres/faq)
+

--- a/apps/docs/content/docs/postgres/database/meta.json
+++ b/apps/docs/content/docs/postgres/database/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Database",
   "pages": [
+    "index",
     "connecting-to-your-database",
     "connection-pooling",
     "query-insights",

--- a/apps/docs/content/docs/postgres/import-from-existing-database.mdx
+++ b/apps/docs/content/docs/postgres/import-from-existing-database.mdx
@@ -1,0 +1,27 @@
+---
+title: Import from existing database
+description: Choose the right path to import data from PostgreSQL or MySQL into Prisma Postgres.
+url: /postgres/import-from-existing-database
+metaTitle: Import from existing database into Prisma Postgres
+metaDescription: Choose the right import guide for moving an existing PostgreSQL or MySQL database into Prisma Postgres.
+---
+
+Use this page to choose the right import path for moving an existing database into Prisma Postgres.
+
+## Choose your source database
+
+- [Import from PostgreSQL](/prisma-postgres/import-from-existing-database-postgresql)
+- [Import from MySQL](/prisma-postgres/import-from-existing-database-mysql)
+
+## Before you start
+
+- Create a Prisma Postgres database first.
+- Gather the connection details for your existing database.
+- Use a [direct connection](/postgres/database/connecting-to-your-database) when importing data into Prisma Postgres.
+
+## Related pages
+
+- [Connecting to your database](/postgres/database/connecting-to-your-database)
+- [Prisma Postgres overview](/postgres)
+- [Create a database with `create-db`](/postgres/npx-create-db)
+

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1161,7 +1161,7 @@
     { "source": "/docs/orm/tools/prisma-cli", "destination": "/docs/cli", "permanent": true },
     {
       "source": "/docs/platform/platform-cli",
-      "destination": "/docs/cli/console/platform",
+      "destination": "/docs/cli/console",
       "permanent": true
     },
     {
@@ -1227,7 +1227,7 @@
     },
     {
       "source": "/docs/platform/platform-cli/commands",
-      "destination": "/docs/cli/console/platform",
+      "destination": "/docs/cli/console",
       "permanent": true
     },
     {
@@ -1259,11 +1259,6 @@
     {
       "source": "/docs/postgres/database/api-reference/error-reference",
       "destination": "/docs/postgres/error-reference",
-      "permanent": true
-    },
-    {
-      "source": "/docs/postgres/database",
-      "destination": "/docs/postgres/database/caching",
       "permanent": true
     },
     { "source": "/docs/showcase", "destination": "/docs", "permanent": true },
@@ -1662,12 +1657,12 @@
     },
     {
       "source": "/docs/guides/upgrade-from-prisma-1/should-you-upgrade",
-      "destination": "/docs/guides/upgrade-from-prisma-1/how-to-upgrade",
+      "destination": "/docs/guides/upgrade-prisma-orm/v1",
       "permanent": true
     },
     {
       "source": "/docs/reference/tools-and-interfaces/prisma-schema/models",
-      "destination": "/docs/reference/tools-and-interfaces/prisma-schema/data-model",
+      "destination": "/docs/orm/prisma-schema/data-model/models",
       "permanent": true
     },
     {
@@ -1732,7 +1727,7 @@
     },
     {
       "source": "/docs/reference/tools-and-interfaces/prisma-schema/prisma-schema-file",
-      "destination": "/docs/reference/tools-and-interfaces/prisma-schema",
+      "destination": "/docs/orm/prisma-schema/overview",
       "permanent": true
     },
     {


### PR DESCRIPTION
## Summary
- add missing hub pages for Prisma Postgres import flows, Prisma Postgres database docs, and ORM dev environment docs
- retarget broken legacy redirects to real current docs for platform CLI and Prisma schema pages
- redirect the old Prisma 1 upgrade path to the current upgrade guide

## Validation
- ran `pnpm --filter docs run audit:redirects`
- reduced the redirect table by another missing-destination batch while keeping the remaining backlog focused on old setup-prisma and legacy concept paths

## Stack
- base PR: #7833
- original remediation PR: #7832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new guide for ORM development environment setup, including editor tooling and environment variable management.
  * Added comprehensive Postgres database documentation covering connection pooling, backups, extensions, and serverless driver topics.
  * Added guide for importing existing PostgreSQL or MySQL databases into Prisma Postgres.
  * Updated documentation navigation structure and routing redirects for improved discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->