### PR TITLE
fix: DR-8014 Soft-redirect stub pages indexed as thin content

### DIFF
--- a/apps/docs/content/docs/accelerate/caching.mdx
+++ b/apps/docs/content/docs/accelerate/caching.mdx
@@ -4,6 +4,7 @@ description: Learn everything you need to know to use Accelerate's global databa
 url: /accelerate/caching
 metaTitle: 'Accelerate: Caching'
 metaDescription: Learn everything you need to know to use Accelerate's global database caching.
+noindex: true
 ---
 
 Prisma Accelerate provides global caching for read queries using TTL, Stale-While-Revalidate (SWR), or a combination of both. It's included as part of Prisma Postgres, but can also be used with your own database by enabling Accelerate in the [Prisma Data Platform](https://console.prisma.io?utm_source=docs) and [configuring it with your database](/accelerate/getting-started).

--- a/apps/docs/content/docs/accelerate/connection-pooling.mdx
+++ b/apps/docs/content/docs/accelerate/connection-pooling.mdx
@@ -4,6 +4,7 @@ description: Learn about everything you need to know to use Accelerate's connect
 url: /accelerate/connection-pooling
 metaTitle: 'Prisma Accelerate: Connection Pooling'
 metaDescription: Learn about everything you need to know to use Accelerate's connection pooling.
+noindex: true
 ---
 
 Accelerate provides built-in connection pooling to efficiently manage database connections. It's included as part of [Prisma Postgres](/postgres), but you can also use it with your own database by enabling Accelerate in the [Prisma Data Platform](https://console.prisma.io?utm_source=docs) and [connecting it to your database](/accelerate/getting-started).

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -1,7 +1,15 @@
 import remarkDirective from "remark-directive";
-import { remarkDirectiveAdmonition, remarkMdxFiles } from "fumadocs-core/mdx-plugins";
+import {
+  remarkDirectiveAdmonition,
+  remarkMdxFiles,
+} from "fumadocs-core/mdx-plugins";
 import { remarkImage } from "fumadocs-core/mdx-plugins";
-import { defineConfig, defineDocs, frontmatterSchema, metaSchema } from "fumadocs-mdx/config";
+import {
+  defineConfig,
+  defineDocs,
+  frontmatterSchema,
+  metaSchema,
+} from "fumadocs-mdx/config";
 import lastModified from "fumadocs-mdx/plugins/last-modified";
 import { z } from "zod";
 import convert from "npm-to-yarn";
@@ -49,6 +57,7 @@ export const docs = defineDocs({
       metaTitle: z.string(),
       metaDescription: z.string(),
       aiPrompt: z.string().optional(),
+      noindex: z.boolean().optional(),
     }),
     postprocess: {
       includeProcessedMarkdown: true,

--- a/apps/docs/src/app/(docs)/(default)/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/(docs)/(default)/[[...slug]]/page.tsx
@@ -4,7 +4,11 @@ import { notFound } from "next/navigation";
 import { getMDXComponents } from "@/mdx-components";
 import type { Metadata } from "next";
 import { createRelativeLink } from "fumadocs-ui/mdx";
-import { CopyPromptButton, LLMCopyButton, ViewOptions } from "@/components/page-actions";
+import {
+  CopyPromptButton,
+  LLMCopyButton,
+  ViewOptions,
+} from "@/components/page-actions";
 import { getPromptContent } from "@/lib/get-prompt-content";
 import {
   DocsBody,
@@ -14,13 +18,20 @@ import {
   EditOnGitHub,
   PageLastUpdate,
 } from "@/components/layout/notebook/page";
-import { TechArticleSchema, BreadcrumbSchema } from "@/components/structured-data";
+import {
+  TechArticleSchema,
+  BreadcrumbSchema,
+} from "@/components/structured-data";
 
 interface PageParams {
   slug?: string[];
 }
 
-export default async function Page({ params }: { params: Promise<PageParams> }) {
+export default async function Page({
+  params,
+}: {
+  params: Promise<PageParams>;
+}) {
   const { slug } = await params;
   const page = source.getPage(slug);
   if (!page) notFound();
@@ -28,7 +39,9 @@ export default async function Page({ params }: { params: Promise<PageParams> }) 
   const MDX = page.data.body;
 
   const aiPromptSlug = (page.data as { aiPrompt?: string }).aiPrompt;
-  const promptContent = aiPromptSlug ? await getPromptContent(aiPromptSlug) : null;
+  const promptContent = aiPromptSlug
+    ? await getPromptContent(aiPromptSlug)
+    : null;
 
   return (
     <>
@@ -44,9 +57,13 @@ export default async function Page({ params }: { params: Promise<PageParams> }) 
         <div className="flex flex-col md:flex-row items-start gap-4 pt-2 pb-1 md:justify-between">
           <DocsTitle>{page.data.title}</DocsTitle>
           <div className="flex flex-row gap-2 items-center">
-            {promptContent && <CopyPromptButton fullPrompt={promptContent.fullPrompt} />}
+            {promptContent && (
+              <CopyPromptButton fullPrompt={promptContent.fullPrompt} />
+            )}
             {!page.url.startsWith("/management-api/endpoints") && (
-              <LLMCopyButton markdownUrl={`${withDocsBasePath(page.url)}.mdx`} />
+              <LLMCopyButton
+                markdownUrl={`${withDocsBasePath(page.url)}.mdx`}
+              />
             )}
 
             <ViewOptions
@@ -68,7 +85,9 @@ export default async function Page({ params }: { params: Promise<PageParams> }) 
             href={`https://github.com/prisma/docs/edit/main/apps/docs/content/docs/${page.path}`}
           />
           {(page.data as { lastModified?: Date }).lastModified && (
-            <PageLastUpdate date={(page.data as { lastModified: Date }).lastModified} />
+            <PageLastUpdate
+              date={(page.data as { lastModified: Date }).lastModified}
+            />
           )}
         </div>
       </DocsPage>
@@ -92,9 +111,12 @@ export async function generateMetadata({
   const title = page.data.metaTitle ?? page.data.title;
   const description = page.data.metaDescription ?? page.data.description;
 
+  const noindex = (page.data as { noindex?: boolean }).noindex;
+
   return {
     title,
     description,
+    ...(noindex && { robots: { index: false, follow: true } }),
     alternates: {
       canonical: withDocsBasePath(page.url),
     },

--- a/apps/docs/src/app/(docs)/sitemap.ts
+++ b/apps/docs/src/app/(docs)/sitemap.ts
@@ -12,31 +12,41 @@ function getPriority(slugCount: number) {
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = getBaseUrl();
-  const url = (path: string): string => new URL(withDocsBasePath(path), baseUrl).toString();
+  const url = (path: string): string =>
+    new URL(withDocsBasePath(path), baseUrl).toString();
 
   // v7 pages (default)
-  const items = source.getPages().map((page) => {
-    const lastModified = (page.data as { lastModified?: Date }).lastModified;
+  const items = source
+    .getPages()
+    .filter((page) => !(page.data as { noindex?: boolean }).noindex)
+    .map((page) => {
+      const lastModified = (page.data as { lastModified?: Date }).lastModified;
 
-    return {
-      url: url(page.url),
-      lastModified: lastModified ? new Date(lastModified) : undefined,
-      changeFrequency: "weekly",
-      priority: getPriority(page.slugs.length),
-    } as MetadataRoute.Sitemap[number];
-  });
+      return {
+        url: url(page.url),
+        lastModified: lastModified ? new Date(lastModified) : undefined,
+        changeFrequency: "weekly",
+        priority: getPriority(page.slugs.length),
+      } as MetadataRoute.Sitemap[number];
+    });
 
   // v6 pages
-  const v6Items = sourceV6.getPages().map((page) => {
-    const lastModified = (page.data as { lastModified?: Date }).lastModified;
+  const v6Items = sourceV6
+    .getPages()
+    .filter((page) => !(page.data as { noindex?: boolean }).noindex)
+    .map((page) => {
+      const lastModified = (page.data as { lastModified?: Date }).lastModified;
 
-    return {
-      url: url(page.url),
-      lastModified: lastModified ? new Date(lastModified) : undefined,
-      changeFrequency: "weekly",
-      priority: 0.4, // Lower priority than v7
-    } as MetadataRoute.Sitemap[number];
-  });
+      return {
+        url: url(page.url),
+        lastModified: lastModified ? new Date(lastModified) : undefined,
+        changeFrequency: "weekly",
+        priority: 0.4, // Lower priority than v7
+      } as MetadataRoute.Sitemap[number];
+    });
 
-  return [...items.filter((v) => v !== undefined), ...v6Items.filter((v) => v !== undefined)];
+  return [
+    ...items.filter((v) => v !== undefined),
+    ...v6Items.filter((v) => v !== undefined),
+  ];
 }

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,61 +1,234 @@
 {
   "redirects": [
-    { "source": "/docs/tags/alpine", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/accelerate/connection-pooling",
+      "destination": "/docs/postgres/database/connection-pooling",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/alpine",
+      "destination": "/docs",
+      "permanent": true
+    },
     { "source": "/docs/tags/apm", "destination": "/docs", "permanent": true },
     {
       "source": "/docs/tags/application-performance-monitoring",
       "destination": "/docs",
       "permanent": true
     },
-    { "source": "/docs/tags/best-practices", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/tags/best-practices",
+      "destination": "/docs",
+      "permanent": true
+    },
     { "source": "/docs/tags/ci-cd", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/containerization", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/data-migration", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/database", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/datadog", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/deployment", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/docker", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/dynamic-usage", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/embedding", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/expand-and-contract", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/framework", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/tags/containerization",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/data-migration",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/database",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/datadog",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/deployment",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/docker",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/dynamic-usage",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/embedding",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/expand-and-contract",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/framework",
+      "destination": "/docs",
+      "permanent": true
+    },
     { "source": "/docs/tags/git", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/guides", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/migration", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/monorepo", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/multiple-databases", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/multiple-prisma-clients", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/my-sql", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/nest-js", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/next-js", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/tags/guides",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/migration",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/monorepo",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/multiple-databases",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/multiple-prisma-clients",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/my-sql",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/nest-js",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/next-js",
+      "destination": "/docs",
+      "permanent": true
+    },
     { "source": "/docs/tags/nuxt", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/optimization", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/tags/optimization",
+      "destination": "/docs",
+      "permanent": true
+    },
     { "source": "/docs/tags/orm", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/pnpm-workspace", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/postgre-sql", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/postgresql", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/prisma", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/prisma-migrate", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/prisma-orm", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/prisma-postgres", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/prisma-studio", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/production", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/react-router", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/rest-api", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/schema", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/schema-evolution", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/tags/pnpm-workspace",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/postgre-sql",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/postgresql",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/prisma",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/prisma-migrate",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/prisma-orm",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/prisma-postgres",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/prisma-studio",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/production",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/react-router",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/rest-api",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/schema",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/schema-evolution",
+      "destination": "/docs",
+      "permanent": true
+    },
     { "source": "/docs/tags/spans", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/sq-lite", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/testing", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/tracing", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/turborepo", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/tutorials", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/vercel", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tags/workflows", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/tags/sq-lite",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/testing",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/tracing",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/turborepo",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/tutorials",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/vercel",
+      "destination": "/docs",
+      "permanent": true
+    },
+    {
+      "source": "/docs/tags/workflows",
+      "destination": "/docs",
+      "permanent": true
+    },
     { "source": "/docs/search", "destination": "/docs", "permanent": true },
     { "source": "/docs/tags", "destination": "/docs", "permanent": true },
     { "source": "/docs/about", "destination": "/docs", "permanent": true },
-    { "source": "/docs/about/docs-components", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/about/docs-components",
+      "destination": "/docs",
+      "permanent": true
+    },
     {
       "source": "/docs/about/docs-components/frontmatter",
       "destination": "/docs",
@@ -66,7 +239,11 @@
       "destination": "/docs",
       "permanent": true
     },
-    { "source": "/docs/about/style-guide", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/about/style-guide",
+      "destination": "/docs",
+      "permanent": true
+    },
     {
       "source": "/docs/about/style-guide/boilerplate-content",
       "destination": "/docs",
@@ -97,13 +274,21 @@
       "destination": "/docs",
       "permanent": true
     },
-    { "source": "/docs/about/style-guide/word-choice", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/about/style-guide/word-choice",
+      "destination": "/docs",
+      "permanent": true
+    },
     {
       "source": "/docs/about/style-guide/writing-style",
       "destination": "/docs",
       "permanent": true
     },
-    { "source": "/docs/about/template", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/about/template",
+      "destination": "/docs",
+      "permanent": true
+    },
     {
       "source": "/docs/getting-started/prisma-orm/add-to-existing-project/cockroachdb",
       "destination": "/docs/prisma-orm/add-to-existing-project/cockroachdb",
@@ -254,7 +439,11 @@
       "destination": "/docs/postgres/import-from-existing-database",
       "permanent": true
     },
-    { "source": "/docs/getting-started", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/getting-started",
+      "destination": "/docs",
+      "permanent": true
+    },
     {
       "source": "/docs/accelerate/api-reference",
       "destination": "/docs/accelerate/reference/api-reference",
@@ -305,7 +494,11 @@
       "destination": "/docs/guides/authentication/better-auth/nextjs",
       "permanent": true
     },
-    { "source": "/docs/guides/bun", "destination": "/docs/guides/runtimes/bun", "permanent": true },
+    {
+      "source": "/docs/guides/bun",
+      "destination": "/docs/guides/runtimes/bun",
+      "permanent": true
+    },
     {
       "source": "/docs/guides/clerk-astro",
       "destination": "/docs/guides/authentication/clerk/astro",
@@ -511,7 +704,11 @@
       "destination": "/docs/postgres/query-insights",
       "permanent": true
     },
-    { "source": "/docs/orm/more", "destination": "/docs/orm/more/releases", "permanent": true },
+    {
+      "source": "/docs/orm/more",
+      "destination": "/docs/orm/more/releases",
+      "permanent": true
+    },
     {
       "source": "/docs/orm/more/ai-tools/chatgpt",
       "destination": "/docs/ai/tools/chatgpt",
@@ -762,7 +959,11 @@
       "destination": "/docs/orm/more/troubleshooting/typescript-performance",
       "permanent": true
     },
-    { "source": "/docs/orm/overview", "destination": "/docs/orm", "permanent": true },
+    {
+      "source": "/docs/orm/overview",
+      "destination": "/docs/orm",
+      "permanent": true
+    },
     {
       "source": "/docs/orm/overview/beyond-prisma-orm",
       "destination": "/docs/orm",
@@ -848,7 +1049,11 @@
       "destination": "/docs/orm/reference/supported-databases",
       "permanent": true
     },
-    { "source": "/docs/orm/overview/introduction", "destination": "/docs/orm", "permanent": true },
+    {
+      "source": "/docs/orm/overview/introduction",
+      "destination": "/docs/orm",
+      "permanent": true
+    },
     {
       "source": "/docs/orm/overview/introduction/data-modeling",
       "destination": "/docs/orm",
@@ -909,8 +1114,16 @@
       "destination": "/docs/console/more/support",
       "permanent": true
     },
-    { "source": "/docs/platform/about", "destination": "/docs/console", "permanent": true },
-    { "source": "/docs/platform", "destination": "/docs/console", "permanent": true },
+    {
+      "source": "/docs/platform/about",
+      "destination": "/docs/console",
+      "permanent": true
+    },
+    {
+      "source": "/docs/platform",
+      "destination": "/docs/console",
+      "permanent": true
+    },
     {
       "source": "/docs/platform/maturity-levels",
       "destination": "/docs/console",
@@ -966,7 +1179,11 @@
       "destination": "/docs/orm/reference/prisma-cli-reference",
       "permanent": true
     },
-    { "source": "/docs/orm/tools/prisma-studio", "destination": "/docs/studio", "permanent": true },
+    {
+      "source": "/docs/orm/tools/prisma-studio",
+      "destination": "/docs/studio",
+      "permanent": true
+    },
     {
       "source": "/docs/postgres/database/prisma-studio/embedding-studio",
       "destination": "/docs/studio/integrations/embedding",
@@ -1097,7 +1314,11 @@
       "destination": "/docs/orm/prisma-client/queries/advanced/query-optimization-performance",
       "permanent": true
     },
-    { "source": "/v6/optimize/:path*", "destination": "/query-insights", "permanent": true },
+    {
+      "source": "/v6/optimize/:path*",
+      "destination": "/query-insights",
+      "permanent": true
+    },
     {
       "source": "/v6/postgres/query-optimization/:path*",
       "destination": "/query-insights",
@@ -1198,8 +1419,16 @@
       "destination": "/docs/orm/prisma-schema/data-model/models",
       "permanent": true
     },
-    { "source": "/docs/orm/tools", "destination": "/docs/studio", "permanent": true },
-    { "source": "/docs/orm/tools/prisma-cli", "destination": "/docs/cli", "permanent": true },
+    {
+      "source": "/docs/orm/tools",
+      "destination": "/docs/studio",
+      "permanent": true
+    },
+    {
+      "source": "/docs/orm/tools/prisma-cli",
+      "destination": "/docs/cli",
+      "permanent": true
+    },
     {
       "source": "/docs/platform/platform-cli",
       "destination": "/docs/cli/console/platform",
@@ -1250,7 +1479,11 @@
       "destination": "/docs/management-api/sdk",
       "permanent": true
     },
-    { "source": "/docs/postgres/introduction", "destination": "/docs/postgres", "permanent": true },
+    {
+      "source": "/docs/postgres/introduction",
+      "destination": "/docs/postgres",
+      "permanent": true
+    },
     {
       "source": "/docs/postgres/integrations",
       "destination": "/docs/postgres/integrations/raycast",
@@ -1276,7 +1509,11 @@
       "destination": "/docs/postgres/troubleshooting",
       "permanent": true
     },
-    { "source": "/docs/postgres/more/faq", "destination": "/docs/postgres/faq", "permanent": true },
+    {
+      "source": "/docs/postgres/more/faq",
+      "destination": "/docs/postgres/faq",
+      "permanent": true
+    },
     {
       "source": "/docs/postgres/more",
       "destination": "/docs/postgres/error-reference",
@@ -1368,7 +1605,11 @@
       "destination": "/docs/orm/prisma-client/setup-and-configuration/introduction",
       "permanent": true
     },
-    { "source": "/docs/get-started", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/get-started",
+      "destination": "/docs",
+      "permanent": true
+    },
     {
       "source": "/docs/orm/prisma-client/setup-and-configuration/databases-configuration/prisma-config-ts",
       "destination": "/docs/orm/reference/prisma-config-reference",
@@ -1379,7 +1620,11 @@
       "destination": "/docs/orm/prisma-client/setup-and-configuration/introduction",
       "permanent": true
     },
-    { "source": "/docs/v5/guides", "destination": "/docs/guides", "permanent": true },
+    {
+      "source": "/docs/v5/guides",
+      "destination": "/docs/guides",
+      "permanent": true
+    },
     {
       "source": "/docs/guides/database/seed-database",
       "destination": "/docs/cli/db/seed",
@@ -1700,7 +1945,11 @@
       "destination": "https://v1.prisma.io/docs/1.34/prisma-server/database-connector-MYSQL-jgfs/",
       "permanent": true
     },
-    { "source": "/docs/guides/troubleshooting", "destination": "/docs/guides", "permanent": true },
+    {
+      "source": "/docs/guides/troubleshooting",
+      "destination": "/docs/guides",
+      "permanent": true
+    },
     {
       "source": "/docs/guides/troubleshooting/autocompletion-in-graphql-resolvers-with-js",
       "destination": "/docs/guides",
@@ -2026,7 +2275,11 @@
       "destination": "/docs/concepts/components/prisma-schema/relations#relational-databases",
       "permanent": true
     },
-    { "source": "/docs/mongodb", "destination": "/docs/orm/", "permanent": true },
+    {
+      "source": "/docs/mongodb",
+      "destination": "/docs/orm/",
+      "permanent": true
+    },
     {
       "source": "/docs/concepts/components/prisma-migrate/type-mapping",
       "destination": "/docs/orm/prisma-migrate/workflows/native-database-types",
@@ -2307,7 +2560,11 @@
       "destination": "/docs/orm/more/dev-environment/editor-setup",
       "permanent": true
     },
-    { "source": "/docs/about/about-the-docs", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/about/about-the-docs",
+      "destination": "/docs",
+      "permanent": true
+    },
     {
       "source": "/docs/concepts/components/preview-features/sql-server/sql-server-start-from-scratch-typescript",
       "destination": "/docs/prisma-orm/quickstart/sql-server",
@@ -2843,7 +3100,11 @@
       "destination": "/docs/orm/more/releases",
       "permanent": true
     },
-    { "source": "/docs/concepts", "destination": "/docs/orm", "permanent": true },
+    {
+      "source": "/docs/concepts",
+      "destination": "/docs/orm",
+      "permanent": true
+    },
     {
       "source": "/docs/concepts/overview/why-prisma",
       "destination": "/docs/orm",
@@ -2949,7 +3210,11 @@
       "destination": "/docs/orm",
       "permanent": true
     },
-    { "source": "/docs/concepts/overview", "destination": "/docs/orm", "permanent": true },
+    {
+      "source": "/docs/concepts/overview",
+      "destination": "/docs/orm",
+      "permanent": true
+    },
     {
       "source": "/docs/concepts/components/prisma-client/working-with-prismaclient/generating-prisma-client",
       "destination": "/docs/orm/prisma-client/setup-and-configuration/introduction",
@@ -3495,7 +3760,11 @@
       "destination": "/docs/orm/prisma-schema/postgresql-extensions",
       "permanent": true
     },
-    { "source": "/docs/concepts/components", "destination": "/docs/studio", "permanent": true },
+    {
+      "source": "/docs/concepts/components",
+      "destination": "/docs/studio",
+      "permanent": true
+    },
     {
       "source": "/docs/reference/api-reference/prisma-client-reference",
       "destination": "/docs/orm/reference/prisma-client-reference",
@@ -3661,7 +3930,11 @@
       "destination": "/docs/orm/reference/prisma-cli-reference",
       "permanent": true
     },
-    { "source": "/docs/data-platform", "destination": "/docs/console", "permanent": true },
+    {
+      "source": "/docs/data-platform",
+      "destination": "/docs/console",
+      "permanent": true
+    },
     {
       "source": "/docs/about/prisma/example-projects",
       "destination": "https://github.com/prisma/prisma-examples/",
@@ -3672,13 +3945,21 @@
       "destination": "/docs/orm/more/releases#roadmap",
       "permanent": true
     },
-    { "source": "/docs/about/prisma/faq", "destination": "/docs/support", "permanent": true },
+    {
+      "source": "/docs/about/prisma/faq",
+      "destination": "/docs/support",
+      "permanent": true
+    },
     {
       "source": "/docs/about/prisma/limitations",
       "destination": "/docs/orm/prisma-schema/data-model/models#limitations",
       "permanent": true
     },
-    { "source": "/docs/about/prisma", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/about/prisma",
+      "destination": "/docs",
+      "permanent": true
+    },
     {
       "source": "/docs/concepts/overview/prisma-in-your-stack/graphql",
       "destination": "/docs/orm",
@@ -3689,7 +3970,11 @@
       "destination": "/docs/orm",
       "permanent": true
     },
-    { "source": "/docs/accelerate/concepts", "destination": "/docs/accelerate", "permanent": true },
+    {
+      "source": "/docs/accelerate/concepts",
+      "destination": "/docs/accelerate",
+      "permanent": true
+    },
     {
       "source": "/docs/data-platform/accelerate/concepts",
       "destination": "/docs/accelerate",
@@ -3760,13 +4045,21 @@
       "destination": "/docs/platform/about#environment",
       "permanent": true
     },
-    { "source": "/docs/platform/concepts", "destination": "/docs/console", "permanent": true },
+    {
+      "source": "/docs/platform/concepts",
+      "destination": "/docs/console",
+      "permanent": true
+    },
     {
       "source": "/docs/more/roadmap",
       "destination": "/docs/orm/more/releases#roadmap",
       "permanent": true
     },
-    { "source": "/docs/orm/overview/going-beyond", "destination": "/docs/orm", "permanent": true },
+    {
+      "source": "/docs/orm/overview/going-beyond",
+      "destination": "/docs/orm",
+      "permanent": true
+    },
     {
       "source": "/docs/orm/prisma-client/queries/raw-database-access",
       "destination": "/docs/orm/prisma-client/using-raw-sql",
@@ -3817,7 +4110,11 @@
       "destination": "/docs/guides/switch-to-prisma-orm/from-drizzle",
       "permanent": true
     },
-    { "source": "/docs/guides/realtime-apps", "destination": "/docs/postgres", "permanent": true },
+    {
+      "source": "/docs/guides/realtime-apps",
+      "destination": "/docs/postgres",
+      "permanent": true
+    },
     {
       "source": "/docs/orm/more/help-and-troubleshooting/creating-bug-reports",
       "destination": "https://github.com/prisma/prisma/issues/new?assignees=&labels=kind/bug&projects=&template=bug_report.yml",
@@ -3948,13 +4245,21 @@
       "destination": "/docs/guides/making-guides",
       "permanent": true
     },
-    { "source": "/docs/guides/cursor", "destination": "/docs/ai/tools/cursor", "permanent": true },
+    {
+      "source": "/docs/guides/cursor",
+      "destination": "/docs/ai/tools/cursor",
+      "permanent": true
+    },
     {
       "source": "/docs/guides/multiple-prisma-clients",
       "destination": "/docs/guides/database/multiple-databases",
       "permanent": true
     },
-    { "source": "/docs/postgres/overview", "destination": "/docs/postgres", "permanent": true },
+    {
+      "source": "/docs/postgres/overview",
+      "destination": "/docs/postgres",
+      "permanent": true
+    },
     {
       "source": "/docs/postgres/mcp-server",
       "destination": "/docs/ai/tools/mcp-server",
@@ -4070,7 +4375,11 @@
       "destination": "/docs/postgres/query-optimization/recommendations/_category_.json",
       "permanent": true
     },
-    { "source": "/docs/optimize/:path*", "destination": "/docs/query-insights", "permanent": true },
+    {
+      "source": "/docs/optimize/:path*",
+      "destination": "/docs/query-insights",
+      "permanent": true
+    },
     {
       "source": "/docs/postgres/database/api-reference/management-api",
       "destination": "/docs/management-api",
@@ -4241,7 +4550,11 @@
       "destination": "/docs/orm/prisma-client/observability-and-logging/opentelemetry-tracing",
       "permanent": true
     },
-    { "source": "/docs/llm-full.txt", "destination": "/docs/llms-full.txt", "permanent": true },
+    {
+      "source": "/docs/llm-full.txt",
+      "destination": "/docs/llms-full.txt",
+      "permanent": true
+    },
     {
       "source": "/docs/orm/prisma-client/setup-and-configuration/databases-connections/mysql",
       "destination": "/docs/orm/core-concepts/supported-databases/mysql",
@@ -4387,7 +4700,11 @@
       "destination": "/docs/guides/upgrade-prisma-orm/v7",
       "permanent": true
     },
-    { "source": "/docs/design-system", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/design-system",
+      "destination": "/docs",
+      "permanent": true
+    },
     {
       "source": "/docs/reference/data-import-and-export/data-import-ol2eoh8xie",
       "destination": "/docs/orm/prisma-schema/introspection",
@@ -4760,7 +5077,7 @@
     },
     {
       "source": "/docs/guides/database/accelerate/connection-pooling",
-      "destination": "/docs/accelerate/connection-pooling",
+      "destination": "/docs/postgres/database/connection-pooling",
       "permanent": true
     },
     {
@@ -4783,7 +5100,11 @@
       "destination": "/docs/orm/prisma-client/deployment/serverless/deploy-to-vercel",
       "permanent": true
     },
-    { "source": "/docs/cli/generate.md", "destination": "/docs/cli/generate", "permanent": true },
+    {
+      "source": "/docs/cli/generate.md",
+      "destination": "/docs/cli/generate",
+      "permanent": true
+    },
     {
       "source": "/docs/getting-started/setup-prisma/start-from-scratch/relational-databases-typescript-postg",
       "destination": "/docs/prisma-orm/quickstart/postgresql",
@@ -4839,7 +5160,11 @@
       "destination": "/docs/prisma-orm/add-to-existing-project/mysql",
       "permanent": true
     },
-    { "source": "/docs/postgres/iac", "destination": "/docs/postgres", "permanent": true },
+    {
+      "source": "/docs/postgres/iac",
+      "destination": "/docs/postgres",
+      "permanent": true
+    },
     {
       "source": "/docs/orm/more/help-and-troubleshooting/help-articles/database-connector-timeout-errors",
       "destination": "/docs/orm/prisma-migrate/workflows/troubleshooting",
@@ -4910,8 +5235,16 @@
       "destination": "/docs/prisma-orm/quickstart/prisma-postgres",
       "permanent": true
     },
-    { "source": "/docs/ai/promt", "destination": "/docs/ai/prompts/prisma-7", "permanent": true },
-    { "source": "/docs/ai/prompt", "destination": "/docs/ai/prompts/prisma-7", "permanent": true },
+    {
+      "source": "/docs/ai/promt",
+      "destination": "/docs/ai/prompts/prisma-7",
+      "permanent": true
+    },
+    {
+      "source": "/docs/ai/prompt",
+      "destination": "/docs/ai/prompts/prisma-7",
+      "permanent": true
+    },
     {
       "source": "/docs/orm/more/development-environment/environment-variables/managing-env-files-and-setting-variables",
       "destination": "/docs/orm/more/dev-environment/environment-variables#using-multiple-env-files",
@@ -5012,7 +5345,11 @@
       "destination": "/docs/orm/prisma-client/setup-and-configuration/introduction",
       "permanent": true
     },
-    { "source": "/docs/pulse/what-is-pulse", "destination": "/docs/postgres", "permanent": true },
+    {
+      "source": "/docs/pulse/what-is-pulse",
+      "destination": "/docs/postgres",
+      "permanent": true
+    },
     {
       "source": "/docs/concepts/more/comparisons/prisma-and-typeorm",
       "destination": "/docs/guides/switch-to-prisma-orm/from-sql-orms",
@@ -5023,7 +5360,11 @@
       "destination": "/docs/orm/prisma-client/queries/crud",
       "permanent": true
     },
-    { "source": "/docs/pulse/getting-started", "destination": "/docs/postgres", "permanent": true },
+    {
+      "source": "/docs/pulse/getting-started",
+      "destination": "/docs/postgres",
+      "permanent": true
+    },
     {
       "source": "/docs/data-platform/data-proxy/prisma-cli-with-data-proxy",
       "destination": "/docs/accelerate/getting-started",
@@ -5144,7 +5485,11 @@
       "destination": "/docs/prisma-orm/add-to-existing-project/prisma-postgres",
       "permanent": true
     },
-    { "source": "/docs/www.google.com", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/www.google.com",
+      "destination": "/docs",
+      "permanent": true
+    },
     {
       "source": "/docs/reference/tools-and-interfaces/prisma-client/advanced-usage-of-generated-types",
       "destination": "/docs/orm/prisma-client/type-safety/operating-against-partial-structures-of-model-types",
@@ -5240,7 +5585,11 @@
       "destination": "/docs/guides/upgrade-prisma-orm/v5",
       "permanent": true
     },
-    { "source": "/docs/more", "destination": "/docs/orm/more/releases", "permanent": true },
+    {
+      "source": "/docs/more",
+      "destination": "/docs/orm/more/releases",
+      "permanent": true
+    },
     {
       "source": "/docs/orm/prisma-migrate/workflows/resolving-migration-issues-in-production",
       "destination": "/docs/orm/prisma-migrate/workflows/troubleshooting",
@@ -5253,7 +5602,7 @@
     },
     {
       "source": "/docs/orm/accelerate/getting-started/connection-pooler/client-extensions",
-      "destination": "/docs/accelerate/connection-pooling",
+      "destination": "/docs/postgres/database/connection-pooling",
       "permanent": true
     },
     {
@@ -5336,19 +5685,31 @@
       "destination": "/docs/orm",
       "permanent": true
     },
-    { "source": "/docs/ai/tools", "destination": "/docs/ai", "permanent": true },
+    {
+      "source": "/docs/ai/tools",
+      "destination": "/docs/ai",
+      "permanent": true
+    },
     {
       "source": "/docs/orm/prisma-schema/special-fields-and-types/working-with-json-fields",
       "destination": "/docs/orm",
       "permanent": true
     },
-    { "source": "/docs/guides/other/prisma-dev", "destination": "/docs/guides", "permanent": true },
+    {
+      "source": "/docs/guides/other/prisma-dev",
+      "destination": "/docs/guides",
+      "permanent": true
+    },
     {
       "source": "/docs/concepts/components/prisma-migrate/migration-troubleshooting",
       "destination": "/docs/concepts",
       "permanent": true
     },
-    { "source": "/docs/guide/nextjs", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/guide/nextjs",
+      "destination": "/docs",
+      "permanent": true
+    },
     {
       "source": "/docs/orm/prisma-client/queries/multi-tenancy",
       "destination": "/docs/orm",
@@ -5464,7 +5825,11 @@
       "destination": "/docs/reference",
       "permanent": true
     },
-    { "source": "/docs/pulse", "destination": "/docs/postgres", "permanent": true },
+    {
+      "source": "/docs/pulse",
+      "destination": "/docs/postgres",
+      "permanent": true
+    },
     {
       "source": "/docs/getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-postgresql-vercel-postgres",
       "destination": "/docs/getting-started",
@@ -5485,7 +5850,11 @@
       "destination": "/docs/orm",
       "permanent": true
     },
-    { "source": "/docs/guides/other/nextjs", "destination": "/docs/guides", "permanent": true },
+    {
+      "source": "/docs/guides/other/nextjs",
+      "destination": "/docs/guides",
+      "permanent": true
+    },
     {
       "source": "/docs/orm/more/development-environment/environment-variables/env-files",
       "destination": "/docs/orm",
@@ -5586,7 +5955,11 @@
       "destination": "/docs",
       "permanent": true
     },
-    { "source": "/docs/orm/more/production", "destination": "/docs/orm", "permanent": true },
+    {
+      "source": "/docs/orm/more/production",
+      "destination": "/docs/orm",
+      "permanent": true
+    },
     {
       "source": "/docs/guides/database/developing-with-prisma-migrate/create-baseline-prisma-migrate",
       "destination": "/docs/guides",
@@ -5767,9 +6140,21 @@
       "destination": "/docs/getting-started",
       "permanent": true
     },
-    { "source": "/docs/guides/other/baselining", "destination": "/docs/guides", "permanent": true },
-    { "source": "/docs/orm/more/changelog", "destination": "/docs/orm", "permanent": true },
-    { "source": "/docs/orm/prisma-migrate/seeding", "destination": "/docs/orm", "permanent": true },
+    {
+      "source": "/docs/guides/other/baselining",
+      "destination": "/docs/guides",
+      "permanent": true
+    },
+    {
+      "source": "/docs/orm/more/changelog",
+      "destination": "/docs/orm",
+      "permanent": true
+    },
+    {
+      "source": "/docs/orm/prisma-migrate/seeding",
+      "destination": "/docs/orm",
+      "permanent": true
+    },
     {
       "source": "/docs/guides/migrate/developing-with-prisma-migrate/create-baseline",
       "destination": "/docs/guides",
@@ -6000,9 +6385,17 @@
       "destination": "/docs/orm/prisma-client/deployment/edge/overview",
       "permanent": true
     },
-    { "source": "/docs/guide/:path*", "destination": "/docs/guides/:path*", "permanent": true },
+    {
+      "source": "/docs/guide/:path*",
+      "destination": "/docs/guides/:path*",
+      "permanent": true
+    },
     { "source": "/docs/-:junk", "destination": "/docs", "permanent": true },
-    { "source": "/docs/tutorials/-:junk", "destination": "/docs/tutorials", "permanent": true },
+    {
+      "source": "/docs/tutorials/-:junk",
+      "destination": "/docs/tutorials",
+      "permanent": true
+    },
     {
       "source": "/docs/prisma-orm/:flow/:db/page/:page",
       "destination": "/docs/prisma-orm/:flow/:db",
@@ -6033,7 +6426,11 @@
       "destination": "/docs/guides/upgrade-prisma-orm/v1",
       "permanent": true
     },
-    { "source": "/docs/about/style-guide/:slug", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/about/style-guide/:slug",
+      "destination": "/docs",
+      "permanent": true
+    },
     {
       "source": "/docs/orm/overview/introduction/:slug",
       "destination": "/docs/orm",
@@ -6045,7 +6442,11 @@
       "permanent": true
     },
     { "source": "/docs/tags/:slug", "destination": "/docs", "permanent": true },
-    { "source": "/docs/about/:slug", "destination": "/docs", "permanent": true },
+    {
+      "source": "/docs/about/:slug",
+      "destination": "/docs",
+      "permanent": true
+    },
     {
       "source": "/docs/concepts/overview/prisma-in-your-stack/:slug",
       "destination": "/docs/orm",
@@ -6062,7 +6463,11 @@
       "permanent": true
     },
 
-    { "source": "/docs/cli/console/auth", "destination": "/docs/cli/console", "permanent": true },
+    {
+      "source": "/docs/cli/console/auth",
+      "destination": "/docs/cli/console",
+      "permanent": true
+    },
     {
       "source": "/docs/cli/console/workspace",
       "destination": "/docs/cli/console",
@@ -6078,7 +6483,11 @@
       "destination": "/docs/cli/console",
       "permanent": true
     },
-    { "source": "/docs/cli/console/apikey", "destination": "/docs/cli/console", "permanent": true },
+    {
+      "source": "/docs/cli/console/apikey",
+      "destination": "/docs/cli/console",
+      "permanent": true
+    },
     {
       "source": "/docs/cli/console/platform",
       "destination": "/docs/cli/console",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked caching and connection-pooling documentation pages to be excluded from search engine indexing.
  * Updated redirects to route connection-pooling documentation to the correct URL path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->