### PR TITLE
fix: DR-7981 Update logo-parade techs

### DIFF
--- a/apps/site/src/components/logo-parade.tsx
+++ b/apps/site/src/components/logo-parade.tsx
@@ -4,13 +4,6 @@ import Image from "next/image";
 
 const logoParade = [
   {
-    label: "Gatsby",
-    imageUrl: `/icons/companies/gatsby.svg`,
-    url: "https://www.gatsbyjs.com",
-    width: 107,
-    height: 29,
-  },
-  {
     label: "Rapha",
     imageUrl: `/icons/companies/rapha.svg`,
     url: "https://www.rapha.cc/",
@@ -70,13 +63,6 @@ const logoParade = [
     label: "Insta",
     imageUrl: `/icons/companies/insta.svg`,
     url: "",
-    width: 225,
-    height: 55,
-  },
-  {
-    label: "Outrider",
-    imageUrl: `/icons/companies/outrider.svg`,
-    url: "https://outrider.org/",
     width: 225,
     height: 55,
   },

--- a/packages/ui/src/components/logo-parade.tsx
+++ b/packages/ui/src/components/logo-parade.tsx
@@ -4,13 +4,6 @@ import { cn } from "../lib/cn";
 
 const logoParade = [
   {
-    label: "Gatsby",
-    imageUrl: `/icons/companies/gatsby.svg`,
-    url: "https://www.gatsbyjs.com",
-    width: 107,
-    height: 29,
-  },
-  {
     label: "Rapha",
     imageUrl: `/icons/companies/rapha.svg`,
     url: "https://www.rapha.cc/",
@@ -71,13 +64,6 @@ const logoParade = [
     label: "Insta",
     imageUrl: `/icons/companies/insta.svg`,
     url: "",
-    width: 225,
-    height: 55,
-  },
-  {
-    label: "Outrider",
-    imageUrl: `/icons/companies/outrider.svg`,
-    url: "https://outrider.org/",
     width: 225,
     height: 55,
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Gatsby and Outrider logos from the logo parade display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->