### PR TITLE
fix: DR-7997 Update blog cache headers

### DIFF
--- a/apps/blog/src/app/(blog)/page.tsx
+++ b/apps/blog/src/app/(blog)/page.tsx
@@ -1,81 +1,27 @@
 import { blog, getPageImage } from "@/lib/source";
-import { BlogGrid, type BlogCardItem } from "@/components/BlogGrid";
-import { CategoryTagFilter } from "@/components/CategoryTagFilter";
+import { type BlogCardItem } from "@/components/BlogGrid";
 import { BLOG_HOME_DESCRIPTION, BLOG_HOME_TITLE } from "@/lib/blog-metadata";
 import type { Metadata } from "next";
 import { withBlogBasePath, withBlogBasePathForImageSrc } from "@/lib/url";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@prisma/eclipse";
-import { LargeSearchToggle } from "@/components/search-toggle";
+import { Suspense } from "react";
+import { BlogHomeClient } from "@/components/BlogHomeClient";
 
-const SHOW_ALL = "show-all";
-const PAGE_SIZE = 12;
-
-type BlogHomeSearchParams = {
-  page?: string | string[];
-  tag?: string | string[];
-};
-
-function getFirstQueryValue(value?: string | string[]): string | undefined {
-  if (Array.isArray(value)) {
-    return value[0];
-  }
-
-  return value;
-}
-
-function parsePage(value: string | undefined): number {
-  const parsed = Number.parseInt(value ?? "1", 10);
-  return Number.isNaN(parsed) || parsed < 1 ? 1 : parsed;
-}
-
-function buildBlogHref(tag: string, page: number): string {
-  const params = new URLSearchParams();
-
-  if (tag !== SHOW_ALL) {
-    params.set("tag", tag);
-  }
-
-  if (page > 1) {
-    params.set("page", String(page));
-  }
-
-  const query = params.toString();
-  const basePath = withBlogBasePath("/");
-  return query ? `${basePath}?${query}` : basePath;
-}
-
-function getPaginationSequence(totalPages: number, currentPage: number) {
-  if (totalPages <= 7) {
-    return Array.from({ length: totalPages }, (_, index) => index + 1);
-  }
-
-  const pages: Array<number | "ellipsis"> = [1];
-  const start = Math.max(2, currentPage - 1);
-  const end = Math.min(totalPages - 1, currentPage + 1);
-
-  if (start > 2) {
-    pages.push("ellipsis");
-  }
-
-  for (let page = start; page <= end; page += 1) {
-    pages.push(page);
-  }
-
-  if (end < totalPages - 1) {
-    pages.push("ellipsis");
-  }
-
-  pages.push(totalPages);
-  return pages;
-}
+/**
+ * Opt into full static rendering for this route.
+ *
+ * Previously, the page accepted `searchParams` as a Server Component prop which
+ * forced Next.js into dynamic rendering and emitted:
+ *   Cache-Control: private, no-cache, no-store
+ *
+ * By removing `searchParams` from this component and delegating URL-based
+ * filtering/pagination to the `BlogHomeClient` client component (which reads
+ * `useSearchParams()` after hydration), the page is now statically rendered and
+ * receives proper public cache headers from Next.js / Vercel's edge network.
+ *
+ * All post data is passed as props so the RSC payload ships the full dataset —
+ * no extra network round-trip is needed during client hydration.
+ */
+export const revalidate = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
@@ -100,12 +46,7 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default async function BlogHome({
-  searchParams,
-}: {
-  searchParams?: Promise<BlogHomeSearchParams> | BlogHomeSearchParams;
-}) {
-  const resolvedSearchParams = (await Promise.resolve(searchParams)) ?? {};
+export default async function BlogHome() {
   const posts = blog.getPages().sort((a, b) => {
     const aTime =
       a.data.date instanceof Date
@@ -127,7 +68,6 @@ export default async function BlogHome({
   const items: BlogCardItem[] = posts.map((post) => {
     const data = post.data as any;
 
-    // Safely convert date to ISO string with validation
     let dateISO = "";
     if (data.date) {
       try {
@@ -135,8 +75,7 @@ export default async function BlogHome({
         if (!isNaN(dateObj.getTime())) {
           dateISO = dateObj.toISOString();
         }
-      } catch (error) {
-        // If date conversion fails, fall back to empty string
+      } catch {
         dateISO = "";
       }
     }
@@ -156,90 +95,26 @@ export default async function BlogHome({
 
   const uniqueTags = [
     ...new Set(
-      items.flatMap((item) => item.tags ?? []).filter((tag): tag is string => Boolean(tag)),
+      items
+        .flatMap((item) => item.tags ?? [])
+        .filter((tag): tag is string => Boolean(tag)),
     ),
   ];
-  const validTags = new Set(uniqueTags);
-  const tagFromQuery = getFirstQueryValue(resolvedSearchParams.tag);
-  const currentCategory = tagFromQuery && validTags.has(tagFromQuery) ? tagFromQuery : SHOW_ALL;
-  const filteredItems =
-    currentCategory === SHOW_ALL
-      ? items
-      : items.filter((item) => item.tags?.includes(currentCategory));
-
-  const totalPages = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE));
-  const pageFromQuery = parsePage(getFirstQueryValue(resolvedSearchParams.page));
-  const currentPage = Math.max(1, Math.min(pageFromQuery, totalPages));
-
-  const shouldShowFeatured = currentCategory === SHOW_ALL && currentPage === 1;
-  const featuredPost = shouldShowFeatured ? filteredItems[0] : undefined;
-  const postsToRender = shouldShowFeatured
-    ? filteredItems.slice(1, PAGE_SIZE)
-    : filteredItems.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
-
-  const paginationSequence = getPaginationSequence(totalPages, currentPage);
 
   return (
     <main className="flex-1 w-full max-w-249 mx-auto px-4 py-8 z-1">
       <h1 className="stretch-display text-4xl font-bold mb-2 landing-h1 text-center mt-9 font-sans-display">
         Blog
       </h1>
-      <div className="pt-6 pb-12 mt-10">
-        <div className="flex justify-between items-center gap-4 mb-8">
-          <CategoryTagFilter
-            uniqueTags={uniqueTags}
-            currentCategory={currentCategory}
-            className="flex justify-center flex-wrap gap-1"
-          />
-          <LargeSearchToggle className="w-20 h-full md:w-52" />
-        </div>
-
-        <BlogGrid
-          items={postsToRender}
-          featuredPost={featuredPost}
-          currentCategory={currentCategory}
-        />
-
-        <div className="mt-8">
-          {totalPages > 1 ? (
-            <Pagination>
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious
-                    href={buildBlogHref(currentCategory, Math.max(1, currentPage - 1))}
-                    aria-disabled={currentPage === 1}
-                  />
-                </PaginationItem>
-                {paginationSequence.map((entry, index) => (
-                  <PaginationItem key={`${entry}-${index}`}>
-                    {entry === "ellipsis" ? (
-                      <PaginationEllipsis />
-                    ) : (
-                      <PaginationLink
-                        href={buildBlogHref(currentCategory, entry)}
-                        isActive={entry === currentPage}
-                        className={
-                          entry === currentPage
-                            ? "bg-background-neutral border border-stroke-neutral shadow-box-low hover:bg-background-neutral-strong"
-                            : undefined
-                        }
-                      >
-                        {entry}
-                      </PaginationLink>
-                    )}
-                  </PaginationItem>
-                ))}
-                <PaginationItem>
-                  <PaginationNext
-                    href={buildBlogHref(currentCategory, Math.min(totalPages, currentPage + 1))}
-                    aria-disabled={currentPage === totalPages}
-                  />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
-          ) : null}
-        </div>
-      </div>
+      {/*
+       * Suspense is required here because BlogHomeClient uses useSearchParams().
+       * During static pre-rendering Next.js renders the fallback; after hydration
+       * the client component takes over and applies URL-driven filtering instantly
+       * since all post data is already present in the RSC payload.
+       */}
+      <Suspense fallback={<div className="pt-6 pb-12 mt-10 min-h-96" />}>
+        <BlogHomeClient items={items} uniqueTags={uniqueTags} />
+      </Suspense>
     </main>
   );
 }

--- a/apps/blog/src/components/BlogHomeClient.tsx
+++ b/apps/blog/src/components/BlogHomeClient.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { BlogGrid, type BlogCardItem } from "@/components/BlogGrid";
+import { CategoryTagFilter } from "@/components/CategoryTagFilter";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@prisma/eclipse";
+import { LargeSearchToggle } from "@/components/search-toggle";
+import { withBlogBasePath } from "@/lib/url";
+
+const SHOW_ALL = "show-all";
+const PAGE_SIZE = 12;
+
+function parsePage(value: string | null): number {
+  const parsed = Number.parseInt(value ?? "1", 10);
+  return Number.isNaN(parsed) || parsed < 1 ? 1 : parsed;
+}
+
+function buildBlogHref(tag: string, page: number): string {
+  const params = new URLSearchParams();
+
+  if (tag !== SHOW_ALL) {
+    params.set("tag", tag);
+  }
+
+  if (page > 1) {
+    params.set("page", String(page));
+  }
+
+  const query = params.toString();
+  const basePath = withBlogBasePath("/");
+  return query ? `${basePath}?${query}` : basePath;
+}
+
+function getPaginationSequence(totalPages: number, currentPage: number) {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  const pages: Array<number | "ellipsis"> = [1];
+  const start = Math.max(2, currentPage - 1);
+  const end = Math.min(totalPages - 1, currentPage + 1);
+
+  if (start > 2) {
+    pages.push("ellipsis");
+  }
+
+  for (let page = start; page <= end; page += 1) {
+    pages.push(page);
+  }
+
+  if (end < totalPages - 1) {
+    pages.push("ellipsis");
+  }
+
+  pages.push(totalPages);
+  return pages;
+}
+
+interface BlogHomeClientProps {
+  items: BlogCardItem[];
+  uniqueTags: string[];
+}
+
+export function BlogHomeClient({ items, uniqueTags }: BlogHomeClientProps) {
+  const searchParams = useSearchParams();
+
+  const tagFromQuery = searchParams.get("tag") ?? undefined;
+  const validTags = new Set(uniqueTags);
+  const currentCategory = tagFromQuery && validTags.has(tagFromQuery) ? tagFromQuery : SHOW_ALL;
+
+  const filteredItems =
+    currentCategory === SHOW_ALL
+      ? items
+      : items.filter((item) => item.tags?.includes(currentCategory));
+
+  const totalPages = Math.max(1, Math.ceil(filteredItems.length / PAGE_SIZE));
+  const currentPage = Math.max(1, Math.min(parsePage(searchParams.get("page")), totalPages));
+
+  const shouldShowFeatured = currentCategory === SHOW_ALL && currentPage === 1;
+  const featuredPost = shouldShowFeatured ? filteredItems[0] : undefined;
+  const postsToRender = shouldShowFeatured
+    ? filteredItems.slice(1, PAGE_SIZE)
+    : filteredItems.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+  const paginationSequence = getPaginationSequence(totalPages, currentPage);
+
+  return (
+    <div className="pt-6 pb-12 mt-10">
+      <div className="flex justify-between items-center gap-4 mb-8">
+        <CategoryTagFilter
+          uniqueTags={uniqueTags}
+          currentCategory={currentCategory}
+          className="flex justify-center flex-wrap gap-1"
+        />
+        <LargeSearchToggle className="w-20 h-full md:w-52" />
+      </div>
+
+      <BlogGrid
+        items={postsToRender}
+        featuredPost={featuredPost}
+        currentCategory={currentCategory}
+      />
+
+      <div className="mt-8">
+        {totalPages > 1 ? (
+          <Pagination>
+            <PaginationContent>
+              <PaginationItem>
+                <PaginationPrevious
+                  href={buildBlogHref(currentCategory, Math.max(1, currentPage - 1))}
+                  aria-disabled={currentPage === 1}
+                />
+              </PaginationItem>
+              {paginationSequence.map((entry, index) => (
+                <PaginationItem key={`${entry}-${index}`}>
+                  {entry === "ellipsis" ? (
+                    <PaginationEllipsis />
+                  ) : (
+                    <PaginationLink
+                      href={buildBlogHref(currentCategory, entry)}
+                      isActive={entry === currentPage}
+                      className={
+                        entry === currentPage
+                          ? "bg-background-neutral border border-stroke-neutral shadow-box-low hover:bg-background-neutral-strong"
+                          : undefined
+                      }
+                    >
+                      {entry}
+                    </PaginationLink>
+                  )}
+                </PaginationItem>
+              ))}
+              <PaginationItem>
+                <PaginationNext
+                  href={buildBlogHref(currentCategory, Math.min(totalPages, currentPage + 1))}
+                  aria-disabled={currentPage === totalPages}
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Two files changed:

**`BlogHomeClient.tsx`** (new `"use client"` component) — owns all URL-driven logic by calling `useSearchParams()` after hydration. Receives the full sorted post list and unique tags as props from the server, so no extra data fetches are needed on the client.

**`(blog)/page.tsx`** (updated server component) — `searchParams` prop removed entirely, post processing stays server-side, and the dynamic section is wrapped in `<Suspense>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved blog page rendering architecture with enhanced static content generation and optimized client-side filtering and pagination handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->