### PR TITLE
perf(scripts): audit and fix third-party script loading across all apps

### DIFF
--- a/apps/blog/src/app/layout.tsx
+++ b/apps/blog/src/app/layout.tsx
@@ -26,9 +26,25 @@ export const metadata: Metadata = {
 
 export default function Layout({ children }: LayoutProps<"/">) {
   return (
-    <html lang="en" className={`${inter.variable} ${barlow.variable}`} suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`${inter.variable} ${barlow.variable}`}
+      suppressHydrationWarning
+    >
       <head>
-        <Script src={EclipseFA} crossOrigin="anonymous" data-auto-add-css="false" />
+        {/* FontAwesome — not render-critical; explicit strategy prevents accidental beforeInteractive promotion */}
+        <Script
+          src={EclipseFA}
+          crossOrigin="anonymous"
+          data-auto-add-css="false"
+          strategy="afterInteractive"
+        />
+        {/* CookieYes CMP — must be present on every public-facing app for GDPR/ePrivacy compliance */}
+        <Script
+          id="cookieyes"
+          src="https://cdn-cookieyes.com/client_data/96980f76df67ad5235fc3f0d/script.js"
+          strategy="afterInteractive"
+        />
       </head>
       <body className="flex flex-col min-h-screen relative">
         <div className="bg-blog absolute inset-0 -z-1 overflow-hidden" />

--- a/apps/blog/src/instrumentation-client.ts
+++ b/apps/blog/src/instrumentation-client.ts
@@ -1,13 +1,52 @@
 import posthog from "posthog-js";
 
+/**
+ * Returns true if the visitor has already accepted analytics cookies via
+ * CookieYes (i.e. the consent cookie is present and includes "analytics:yes").
+ * Used to immediately opt returning visitors in without waiting for the banner.
+ */
+function hasAnalyticsConsent(): boolean {
+  try {
+    const match = document.cookie
+      .split("; ")
+      .find((c) => c.startsWith("cookieyes-consent="));
+    if (!match) return false;
+    return decodeURIComponent(match.split("=")[1]).includes("analytics:yes");
+  } catch {
+    return false;
+  }
+}
+
+// Initialise opted-out by default — no data is sent until the visitor
+// explicitly accepts analytics via the CookieYes banner.
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   capture_pageview: "history_change",
   defaults: "2025-11-30",
-  loaded: (posthog) => {
-    posthog.register({
+  opt_out_capturing_by_default: true,
+  loaded: (ph) => {
+    ph.register({
       site_name: "mono-blog",
       environment: "production",
     });
   },
+});
+
+// Returning visitor: consent cookie already present — opt in straight away.
+if (hasAnalyticsConsent()) {
+  posthog.opt_in_capturing();
+}
+
+// Live consent updates: fired by CookieYes when the visitor interacts with
+// the banner or changes their preferences.
+document.addEventListener("cookieyes-consent-update", (event: Event) => {
+  const detail = (event as CustomEvent<{ accepted: string[] }>).detail;
+  if (
+    Array.isArray(detail?.accepted) &&
+    detail.accepted.includes("analytics")
+  ) {
+    posthog.opt_in_capturing();
+  } else {
+    posthog.opt_out_capturing();
+  }
 });

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -30,28 +30,49 @@ export const metadata: Metadata = {
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={`${inter.variable} ${barlow.variable}`} suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`${inter.variable} ${barlow.variable}`}
+      suppressHydrationWarning
+    >
       <head>
-        <Script src={EclipseFA} crossOrigin="anonymous" data-auto-add-css="false" />
+        {/* CookieYes CMP — declared first so its consent hooks are in place
+            before any other consent-gated script can execute */}
         <Script
-          src="https://ingest.promptwatch.com/js/client.min.js"
+          id="cookieyes"
+          src="https://cdn-cookieyes.com/client_data/96980f76df67ad5235fc3f0d/script.js"
           strategy="afterInteractive"
+        />
+        {/* FontAwesome — icons are non-critical; explicit strategy avoids
+            Next.js silently defaulting to afterInteractive without a source hint */}
+        <Script
+          src={EclipseFA}
+          crossOrigin="anonymous"
+          data-auto-add-css="false"
+          strategy="afterInteractive"
+        />
+        {/* PromptWatch — type="text/plain" keeps the script inert in the browser
+            until CookieYes activates it once analytics consent is granted */}
+        <script
+          type="text/plain"
+          src="https://ingest.promptwatch.com/js/client.min.js"
           data-project-id="25f18e15-6306-4faa-b5c2-8078804778ac"
           data-cookieyes="cookieyes-analytics"
+          data-cookieyes-category="analytics"
         />
       </head>
       <body className="flex flex-col min-h-screen">
         <Provider>{children}</Provider>
-        <Script
+        {/* Tolt affiliate tracking — type="text/plain" + data-cookieyes mirrors
+            the consent-gate pattern used in the site app; stays inert until
+            CookieYes activates it after analytics consent */}
+        <script
           async
+          type="text/plain"
           src="https://cdn.tolt.io/tolt.js"
           data-tolt="fda67739-7ed0-42d2-b716-6da0edbec191"
           data-cookieyes="cookieyes-analytics"
-        />
-        <Script
-          async
-          src="https://cdn-cookieyes.com/client_data/96980f76df67ad5235fc3f0d/script.js"
-          id="cookieyes"
+          data-cookieyes-category="analytics"
         />
       </body>
     </html>

--- a/apps/docs/src/instrumentation-client.ts
+++ b/apps/docs/src/instrumentation-client.ts
@@ -1,16 +1,57 @@
 import posthog from "posthog-js";
 import * as Sentry from "@sentry/nextjs";
 
+/**
+ * Returns true when the visitor has already accepted analytics cookies via
+ * the CookieYes consent banner. Checked on every page load so that returning
+ * visitors who previously consented are opted-in immediately, without waiting
+ * for the banner to re-appear.
+ */
+function hasAnalyticsConsent(): boolean {
+  try {
+    const match = document.cookie
+      .split("; ")
+      .find((c) => c.startsWith("cookieyes-consent="));
+    if (!match) return false;
+    return decodeURIComponent(match.split("=")[1]).includes("analytics:yes");
+  } catch {
+    return false;
+  }
+}
+
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   capture_pageview: "history_change",
   defaults: "2025-11-30",
-  loaded: (posthog) => {
-    posthog.register({
-      site_name: "mono-docs", // or 'docs-site', 'app-site', etc.
+  // Do not capture anything until the visitor explicitly grants analytics
+  // consent via CookieYes. Opt-in logic is handled below.
+  opt_out_capturing_by_default: true,
+  loaded: (ph) => {
+    ph.register({
+      site_name: "mono-docs",
       environment: "production",
     });
   },
+});
+
+// Returning visitor: consent cookie already present — opt in immediately.
+if (hasAnalyticsConsent()) {
+  posthog.opt_in_capturing();
+}
+
+// New / updating visitor: react to live banner interactions.
+// CookieYes fires "cookieyes-consent-update" on the document whenever the
+// visitor accepts or rejects categories from the consent banner.
+document.addEventListener("cookieyes-consent-update", (event: Event) => {
+  const detail = (event as CustomEvent<{ accepted: string[] }>).detail;
+  if (
+    Array.isArray(detail?.accepted) &&
+    detail.accepted.includes("analytics")
+  ) {
+    posthog.opt_in_capturing();
+  } else {
+    posthog.opt_out_capturing();
+  }
 });
 
 Sentry.init({

--- a/apps/site/src/app/layout.tsx
+++ b/apps/site/src/app/layout.tsx
@@ -7,7 +7,10 @@ import type { Metadata } from "next";
 import Script from "next/script";
 import type React from "react";
 import { SITE_HOME_DESCRIPTION, SITE_HOME_TITLE } from "@/lib/site-metadata";
-import { NavigationWrapper, FooterWrapper } from "@/components/navigation-wrapper";
+import {
+  NavigationWrapper,
+  FooterWrapper,
+} from "@/components/navigation-wrapper";
 import { Footer } from "@prisma-docs/ui/components/footer";
 import { JsonLd } from "@prisma-docs/ui/components/json-ld";
 import { ThemeProvider } from "@prisma-docs/ui/components/theme-provider";
@@ -152,7 +155,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           src={WebFA}
           crossOrigin="anonymous"
           data-auto-add-css="false"
-          strategy="beforeInteractive"
+          strategy="afterInteractive"
         />
         <Script
           id="cookieyes"
@@ -190,7 +193,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <Provider>
           <ThemeProvider defaultTheme="system" storageKey="theme">
             <UtmPersistence />
-            <NavigationWrapper links={baseOptions().links} utm={{ source: "website" }} />
+            <NavigationWrapper
+              links={baseOptions().links}
+              utm={{ source: "website" }}
+            />
             {children}
             <FooterWrapper />
           </ThemeProvider>

--- a/apps/site/src/components/enterprise/form.tsx
+++ b/apps/site/src/components/enterprise/form.tsx
@@ -11,6 +11,10 @@ export const EnterpriseForm = () => (
       title="Enterprise - Contact form"
       allow="autoplay; clipboard-write; encrypted-media"
     />
-    <Script src="https://tally.so/widgets/embed.js" onLoad={() => window.Tally?.loadEmbeds()} />
+    <Script
+      src="https://tally.so/widgets/embed.js"
+      strategy="lazyOnload"
+      onLoad={() => window.Tally?.loadEmbeds()}
+    />
   </>
 );

--- a/apps/site/src/components/partners/form.tsx
+++ b/apps/site/src/components/partners/form.tsx
@@ -11,6 +11,10 @@ export const Form = () => (
       allow="autoplay; clipboard-write; encrypted-media"
       title="Partners - Contact form"
     />
-    <Script src="https://tally.so/widgets/embed.js" onLoad={() => window.Tally?.loadEmbeds()} />
+    <Script
+      src="https://tally.so/widgets/embed.js"
+      strategy="lazyOnload"
+      onLoad={() => window.Tally?.loadEmbeds()}
+    />
   </div>
 );

--- a/apps/site/src/instrumentation-client.ts
+++ b/apps/site/src/instrumentation-client.ts
@@ -1,13 +1,52 @@
 import posthog from "posthog-js";
 
+/**
+ * Returns true if the visitor has already accepted the "analytics" category
+ * via the CookieYes consent banner (i.e. on a return visit where the consent
+ * cookie is already present).
+ */
+function hasAnalyticsConsent(): boolean {
+  try {
+    const match = document.cookie
+      .split("; ")
+      .find((c) => c.startsWith("cookieyes-consent="));
+    if (!match) return false;
+    return decodeURIComponent(match.split("=")[1]).includes("analytics:yes");
+  } catch {
+    return false;
+  }
+}
+
+// Initialise PostHog in an opted-out state so no events are captured before
+// the visitor has had a chance to interact with the consent banner.
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   capture_pageview: "history_change",
   defaults: "2025-11-30",
-  loaded: (posthog) => {
-    posthog.register({
+  opt_out_capturing_by_default: true,
+  loaded: (ph) => {
+    ph.register({
       site_name: "mono-site",
       environment: "production",
     });
   },
+});
+
+// Returning visitor: consent cookie is already set — opt in immediately so we
+// don't lose the session pageview.
+if (hasAnalyticsConsent()) {
+  posthog.opt_in_capturing();
+}
+
+// First-time visitor: react to the CookieYes banner interaction in real time.
+document.addEventListener("cookieyes-consent-update", (event: Event) => {
+  const detail = (event as CustomEvent<{ accepted: string[] }>).detail;
+  if (
+    Array.isArray(detail?.accepted) &&
+    detail.accepted.includes("analytics")
+  ) {
+    posthog.opt_in_capturing();
+  } else {
+    posthog.opt_out_capturing();
+  }
 });


### PR DESCRIPTION
- Fix FontAwesome strategy from beforeInteractive to afterInteractive on site (was blocking the HTML parser on every page load)
- Add CookieYes CMP to blog app, which had no consent layer
- Fix docs layout so CookieYes loads first; convert Tolt and PromptWatch to type="text/plain" to eliminate the race condition where they could execute before CookieYes set up its interception hooks
- Gate PostHog behind CookieYes consent on all three apps (blog, docs, site): opt_out_capturing_by_default + cookie check for returning visitors + live cookieyes-consent-update listener for first-time visitors
- Set strategy="lazyOnload" on Tally embed scripts in enterprise and partners forms (both are below the fold and were competing with hydration)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented cookie consent management system to control analytics tracking across the platform.
  * Analytics now respect user consent preferences, with tracking disabled by default until explicitly authorized.

* **Improvements**
  * Optimized script loading performance across multiple pages.
  * Enhanced privacy compliance by deferring tracking scripts until consent is granted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->