### PR TITLE
add security.txt disclosure policy

### DIFF
--- a/apps/site/public/.well-known/security.txt
+++ b/apps/site/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:security@prisma.io
+Expires: 2027-04-28T00:00:00Z
+Preferred-Languages: en
+Canonical: https://www.prisma.io/.well-known/security.txt
+Policy: https://github.com/prisma/prisma/security/policy


### PR DESCRIPTION
## Summary
- Add a static security.txt at `/.well-known/security.txt` for responsible disclosure discovery.
- Include Prisma security contact, canonical URL, preferred language, expiry, and policy link.

## Validation
- Ran `git diff --check --cached` before commit.
- Confirmed the staged diff only added `apps/site/public/.well-known/security.txt`.

## Notes
- No build run; this is a static public asset only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized, publicly-accessible security resource containing vulnerability reporting channels, security contact information, and links to security policies, enabling security researchers to easily identify and use appropriate channels for responsible vulnerability disclosure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->