### PR TITLE
fix(post-card): prevent CLS on post images

### DIFF
--- a/packages/ui/src/components/post-card.tsx
+++ b/packages/ui/src/components/post-card.tsx
@@ -46,7 +46,9 @@ export function PostCard({
 
   const titleClassName = cn(
     "text-foreground-neutral font-mona-sans mt-4 mb-2",
-    isFeatured ? "text-2xl font-bold" : "text-md md:text-lg font-[650] sm:font-bold",
+    isFeatured
+      ? "text-2xl font-bold"
+      : "text-md md:text-lg font-[650] sm:font-bold",
   );
   const excerptClassName = cn(
     "text-sm text-foreground-neutral-weak line-clamp-2",
@@ -61,13 +63,28 @@ export function PostCard({
     <>
       <div>
         <div className="eyebrow flex gap-2 items-center">
-          {post.badge && <Badge color="success" label={post.badge} className="w-fit text-xs" />}
-          {post.date && <span className="text-xs text-foreground-neutral-weak">{post.date}</span>}
+          {post.badge && (
+            <Badge
+              color="success"
+              label={post.badge}
+              className="w-fit text-xs"
+            />
+          )}
+          {post.date && (
+            <span className="text-xs text-foreground-neutral-weak">
+              {post.date}
+            </span>
+          )}
         </div>
         {post.title && <h2 className={titleClassName}>{post.title}</h2>}
         {post.excerpt && <p className={excerptClassName}>{post.excerpt}</p>}
       </div>
-      {post.author && <AuthorAvatarGroup authors={[post.author]} className={authorClassName} />}
+      {post.author && (
+        <AuthorAvatarGroup
+          authors={[post.author]}
+          className={authorClassName}
+        />
+      )}
     </>
   );
 
@@ -78,7 +95,7 @@ export function PostCard({
           <img
             src={post.imageSrc}
             alt={post.imageAlt ?? post.title}
-            className={imageClassName}
+            className={cn(imageClassName, "absolute inset-0 w-full h-full")}
             loading={isFeatured ? "eager" : "lazy"}
           />
         </div>
@@ -93,7 +110,12 @@ export function PostCard({
           {postBody}
         </Card>
       ) : (
-        <div className={cn("flex flex-col justify-between", !vertical && "order-1")}>
+        <div
+          className={cn(
+            "flex flex-col justify-between",
+            !vertical && "order-1",
+          )}
+        >
           {postBody}
         </div>
       )}


### PR DESCRIPTION
## Fix post-card CLS via aspect-ratio wrapper

### What changed
`packages/ui/src/components/post-card.tsx` — the `<img>` inside `PostCard`
was absolutely positioned inside its wrapper to fill the pre-reserved slot.

### Why the reported numbers were wrong
The original issue cited 288 of 317 images missing `width` and `height`
attributes, measured against the **rendered DOM**. That count is inflated
because Next.js `<Image fill>` intentionally emits `<img>` tags with no
`width`/`height` attributes — it uses the parent's CSS aspect-ratio box to
reserve space instead. A DOM-level scraper treats every `fill`-mode image
as broken, even though it's correctly handled.

A source-level audit tells the real story:

| | Total | ✅ OK | ❌ Missing |
|---|---|---|---|
| Plain `<img>` tags | 4 | 3 | **1** |
| Next.js `<Image>` (fill or w+h) | 54 | 54 | 0 |

One image was actually broken: the `<img>` in `PostCard` had no dimensions
and no layout constraint, causing a genuine CLS hit.

### The fix
The wrapper div already had `relative aspect-video`, which reserves the
correct vertical space via CSS before the image loads. Making the `<img>`
`absolute inset-0 w-full h-full` fills that slot — the same thing
`next/image fill` renders to in the DOM, with no framework dependency added
to the package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refactored post card component styling and layout structure for improved code organization and rendering consistency.

* **Refactor**
  * Optimized image layout handling and className composition within the post card component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->