### PR TITLE
feat(docs): agent-friendly docs changes

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -199,6 +199,26 @@ const securityHeaders = [
   },
 ];
 
+const llmsTxtHeader = {
+  key: "Link",
+  value: '</docs/llms.txt>; rel="llms-txt"',
+};
+
+const docsMarkdownHeaders = [
+  {
+    key: "Link",
+    value:
+      '</docs/:path.md>; rel="alternate"; type="text/markdown", </docs/llms.txt>; rel="llms-txt"',
+  },
+];
+
+const docsRootMarkdownHeaders = [
+  {
+    key: "Link",
+    value: '</docs.md>; rel="alternate"; type="text/markdown", </docs/llms.txt>; rel="llms-txt"',
+  },
+];
+
 const allowedDevOrigins = (process.env.ALLOWED_DEV_ORIGINS ?? "localhost,127.0.0.1,192.168.1.48")
   .split(",")
   .map((origin) => origin.trim())
@@ -226,6 +246,10 @@ const config = {
         source: "/:path*.mdx",
         destination: "/llms.mdx/:path*",
       },
+      {
+        source: "/:path*.md",
+        destination: "/llms.mdx/:path*",
+      },
     ];
   },
   basePath: "/docs",
@@ -241,7 +265,16 @@ const config = {
     return [
       {
         source: "/:path*",
-        headers: securityHeaders,
+        headers: [...securityHeaders, llmsTxtHeader],
+      },
+      {
+        source: "/",
+        headers: docsRootMarkdownHeaders,
+      },
+      {
+        source:
+          "/:path((?!api(?:/|$)|llms(?:\\.|/|$)|og(?:/|$)|rss\\.xml$|sitemap(?:\\.xml)?$|favicon\\.ico$|.*\\.[^/]+$).+)",
+        headers: docsMarkdownHeaders,
       },
     ];
   },

--- a/apps/docs/src/app/llms-full-v6.txt/route.ts
+++ b/apps/docs/src/app/llms-full-v6.txt/route.ts
@@ -1,5 +1,6 @@
 import { sourceV6 } from "@/lib/source";
 import { getLLMText } from "@/lib/get-llm-text";
+import { createLLMsFullResponse } from "@/lib/llms";
 
 export const revalidate = false;
 
@@ -13,12 +14,5 @@ Use this legacy feed only for projects that are intentionally staying on Prisma 
 
 `;
 
-  const scan = sourceV6.getPages().map(getLLMText);
-  const scanned = await Promise.all(scan);
-
-  return new Response(description + scanned.join("\n\n"), {
-    headers: {
-      "Content-Type": "text/plain; charset=utf-8",
-    },
-  });
+  return createLLMsFullResponse(description, sourceV6.getPages(), getLLMText);
 }

--- a/apps/docs/src/app/llms-full.txt/route.ts
+++ b/apps/docs/src/app/llms-full.txt/route.ts
@@ -1,5 +1,6 @@
 import { source } from "@/lib/source";
 import { getLLMText } from "@/lib/get-llm-text";
+import { createLLMsFullResponse } from "@/lib/llms";
 
 export const revalidate = false;
 
@@ -13,12 +14,5 @@ Includes v7 documentation only.
 
 `;
 
-  const scan = source.getPages().map(getLLMText);
-  const scanned = await Promise.all(scan);
-
-  return new Response(description + scanned.join("\n\n"), {
-    headers: {
-      "Content-Type": "text/plain; charset=utf-8",
-    },
-  });
+  return createLLMsFullResponse(description, source.getPages(), getLLMText);
 }

--- a/apps/docs/src/app/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/src/app/llms.mdx/[[...slug]]/route.ts
@@ -1,6 +1,6 @@
 import { getLLMText } from "@/lib/get-llm-text";
 import { source, sourceV6 } from "@/lib/source";
-import { notFound } from "next/navigation";
+import { getBaseUrl, withDocsBasePath } from "@/lib/urls";
 
 export const revalidate = false;
 
@@ -14,10 +14,75 @@ function resolvePage(slug: string[] | undefined) {
   );
 }
 
+function normalizePath(path: string) {
+  return path.toLowerCase().replace(/[^a-z0-9/]+/g, "-");
+}
+
+function getDistance(a: string, b: string) {
+  const previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+  const current = Array.from({ length: b.length + 1 }, () => 0);
+
+  for (let i = 1; i <= a.length; i++) {
+    current[0] = i;
+
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      current[j] = Math.min(current[j - 1] + 1, previous[j] + 1, previous[j - 1] + cost);
+    }
+
+    previous.splice(0, previous.length, ...current);
+  }
+
+  return previous[b.length];
+}
+
+function getNearestPages(slug: string[] | undefined) {
+  const requestedPath = normalizePath(`/${(slug ?? []).join("/")}`);
+
+  return [...source.getPages(), ...sourceV6.getPages()]
+    .map((page) => ({
+      page,
+      distance: getDistance(requestedPath, normalizePath(page.url)),
+    }))
+    .sort((a, b) => a.distance - b.distance)
+    .slice(0, 5)
+    .map(({ page }) => page);
+}
+
+function getMarkdownNotFoundResponse(slug: string[] | undefined) {
+  const baseUrl = getBaseUrl();
+  const nearestPages = getNearestPages(slug);
+  const nearestLinks = nearestPages
+    .map((page) => {
+      const description = page.data.description ? `: ${page.data.description}` : "";
+      return `- [\`${page.data.title}\`](${baseUrl}${withDocsBasePath(page.url)})${description}`;
+    })
+    .join("\n");
+
+  const content = `# Not found
+
+The requested documentation page was not found.
+
+- [Documentation index](${baseUrl}${withDocsBasePath("/llms.txt")})
+- [Full documentation](${baseUrl}${withDocsBasePath("/llms-full.txt")})
+
+## Nearest matches
+
+${nearestLinks || "_No nearby documentation pages found._"}
+`;
+
+  return new Response(content, {
+    status: 404,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}
+
 export async function GET(_req: Request, { params }: RouteContext<"/llms.mdx/[[...slug]]">) {
   const { slug } = await params;
   const page = resolvePage(slug);
-  if (!page) notFound();
+  if (!page) return getMarkdownNotFoundResponse(slug);
 
   const content = await getLLMText(page);
 

--- a/apps/docs/src/app/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/src/app/llms.mdx/[[...slug]]/route.ts
@@ -4,6 +4,9 @@ import { getBaseUrl, withDocsBasePath } from "@/lib/urls";
 
 export const revalidate = false;
 
+const MAX_NEAREST_MATCH_SEGMENTS = 12;
+const MAX_NEAREST_MATCH_PATH_LENGTH = 240;
+
 function resolvePage(slug: string[] | undefined) {
   const slugs = slug ?? [];
 
@@ -36,8 +39,19 @@ function getDistance(a: string, b: string) {
   return previous[b.length];
 }
 
+function getBoundedRequestedPath(slug: string[] | undefined) {
+  const slugs = slug ?? [];
+  if (slugs.length > MAX_NEAREST_MATCH_SEGMENTS) return undefined;
+
+  const requestedPath = `/${slugs.join("/")}`;
+  if (requestedPath.length > MAX_NEAREST_MATCH_PATH_LENGTH) return undefined;
+
+  return normalizePath(requestedPath);
+}
+
 function getNearestPages(slug: string[] | undefined) {
-  const requestedPath = normalizePath(`/${(slug ?? []).join("/")}`);
+  const requestedPath = getBoundedRequestedPath(slug);
+  if (!requestedPath) return [];
 
   return [...source.getPages(), ...sourceV6.getPages()]
     .map((page) => ({

--- a/apps/docs/src/app/llms.txt/route.ts
+++ b/apps/docs/src/app/llms.txt/route.ts
@@ -1,38 +1,47 @@
 import { source, sourceV6 } from "@/lib/source";
 import { getBaseUrl, withDocsBasePath } from "@/lib/urls";
+import {
+  commonQueries,
+  filterAvailableLLMsLinks,
+  filterAvailableLLMsSections,
+  filterPagesForLLMsIndex,
+  formatLLMsLink,
+  formatLLMsPageLink,
+  formatLLMsSectionLink,
+  llmsSections,
+} from "@/lib/llms";
 
 export const revalidate = false;
 
 export async function GET() {
   const baseUrl = getBaseUrl();
-  const latestPages = source.getPages().sort((a, b) => a.data.title.localeCompare(b.data.title));
+  const latestPages = filterPagesForLLMsIndex(source.getPages()).sort((a, b) =>
+    a.data.title.localeCompare(b.data.title),
+  );
   const v6Pages = sourceV6.getPages().sort((a, b) => a.data.title.localeCompare(b.data.title));
 
-  const latestDocsList = latestPages
-    .map((page) => {
-      const title = page.data.title;
-      const description = page.data.description || "";
-      const path = `${baseUrl}${withDocsBasePath(page.url)}`;
-
-      return `- [\`${title}\`](${path}): ${description}`;
-    })
+  const commonQueriesList = filterAvailableLLMsLinks(commonQueries, latestPages)
+    .map((link) => formatLLMsLink(link, baseUrl))
     .join("\n");
-
-  const v6DocsList = v6Pages
-    .map((page) => {
-      const title = page.data.title;
-      const description = page.data.description || "";
-      const path = `${baseUrl}${withDocsBasePath(page.url)}`;
-
-      return `- [\`${title}\`](${path}): ${description}`;
-    })
+  const subIndexList = filterAvailableLLMsSections(llmsSections, latestPages)
+    .map((section) => formatLLMsSectionLink(section, baseUrl))
     .join("\n");
+  const latestDocsList = latestPages.map((page) => formatLLMsPageLink(page, baseUrl)).join("\n");
+  const v6DocsList = v6Pages.map((page) => formatLLMsPageLink(page, baseUrl)).join("\n");
 
   const content = `# Prisma Documentation
 
 > This documentation covers Prisma v7 (current) and v6 (legacy).
 > Prefer the Latest section for current recommendations.
 > v6 pages are maintained for backwards compatibility only.
+
+## Common Queries
+
+${commonQueriesList}
+
+## Product Area Indexes
+
+${subIndexList}
 
 ## Latest
 

--- a/apps/docs/src/app/llms/[...slug]/route.ts
+++ b/apps/docs/src/app/llms/[...slug]/route.ts
@@ -1,0 +1,54 @@
+import {
+  filterAvailableLLMsSections,
+  filterPagesForLLMsIndex,
+  filterPagesForLLMsSection,
+  formatLLMsPageLink,
+  getLLMsSection,
+  llmsSections,
+} from "@/lib/llms";
+import { source } from "@/lib/source";
+import { getBaseUrl } from "@/lib/urls";
+import { notFound } from "next/navigation";
+
+export const revalidate = false;
+
+function parseSectionSlug(slug: string[] | undefined) {
+  if (!slug || slug.length !== 1 || !slug[0].endsWith(".txt")) notFound();
+  return slug[0].slice(0, -".txt".length);
+}
+
+export async function GET(_req: Request, { params }: RouteContext<"/llms/[...slug]">) {
+  const { slug } = await params;
+  const sourcePages = filterPagesForLLMsIndex(source.getPages());
+  const section = getLLMsSection(parseSectionSlug(slug), sourcePages);
+  if (!section) notFound();
+
+  const baseUrl = getBaseUrl();
+  const pages = filterPagesForLLMsSection(sourcePages, section).sort((a, b) =>
+    a.data.title.localeCompare(b.data.title),
+  );
+  const docsList =
+    pages.map((page) => formatLLMsPageLink(page, baseUrl)).join("\n") ||
+    "_No pages currently match this section._";
+
+  const content = `# Prisma Documentation - ${section.title}
+
+> ${section.description}
+
+${docsList}
+`;
+
+  return new Response(content, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}
+
+export function generateStaticParams() {
+  return filterAvailableLLMsSections(llmsSections, filterPagesForLLMsIndex(source.getPages())).map(
+    (section) => ({
+      slug: [`${section.slug}.txt`],
+    }),
+  );
+}

--- a/apps/docs/src/lib/agent-markdown.ts
+++ b/apps/docs/src/lib/agent-markdown.ts
@@ -7,9 +7,6 @@ const AGENT_USER_AGENT_PATTERNS = [
   /claude-user/i,
   /perplexitybot/i,
   /cursor/i,
-  /axios(?:\/|\s|$)/i,
-  /node-fetch/i,
-  /(?:^|[\s;/])got(?:$|[\s;/])/i,
 ];
 
 const SKIPPED_DOCS_PREFIXES = ["/api", "/llms", "/llms.mdx", "/og"];

--- a/apps/docs/src/lib/agent-markdown.ts
+++ b/apps/docs/src/lib/agent-markdown.ts
@@ -1,0 +1,63 @@
+const DOCS_BASE_PATH = "/docs";
+
+const AGENT_USER_AGENT_PATTERNS = [
+  /chatgpt-user/i,
+  /gptbot/i,
+  /claudebot/i,
+  /claude-user/i,
+  /perplexitybot/i,
+  /cursor/i,
+  /axios(?:\/|\s|$)/i,
+  /node-fetch/i,
+  /(?:^|[\s;/])got(?:$|[\s;/])/i,
+];
+
+const SKIPPED_DOCS_PREFIXES = ["/api", "/llms", "/llms.mdx", "/og"];
+const SKIPPED_DOCS_PATHS = new Set(["/favicon.ico", "/rss.xml", "/sitemap", "/sitemap.xml"]);
+
+function stripDocsBasePath(pathname: string) {
+  if (pathname === DOCS_BASE_PATH) return "/";
+  if (pathname.startsWith(`${DOCS_BASE_PATH}/`)) return pathname.slice(DOCS_BASE_PATH.length);
+  return pathname;
+}
+
+function getDocsBasePath(pathname: string) {
+  return pathname === DOCS_BASE_PATH || pathname.startsWith(`${DOCS_BASE_PATH}/`)
+    ? DOCS_BASE_PATH
+    : "";
+}
+
+function normalizeDocsPath(pathname: string) {
+  const docsPath = stripDocsBasePath(pathname);
+  if (docsPath.length > 1 && docsPath.endsWith("/")) return docsPath.slice(0, -1);
+  return docsPath;
+}
+
+export function getAgentMarkdownSignal(headers: Headers) {
+  const accept = headers.get("accept")?.toLowerCase() ?? "";
+  if (accept.split(",").some((value) => value.trim().startsWith("text/markdown"))) {
+    return "accept";
+  }
+
+  const userAgent = headers.get("user-agent") ?? "";
+  if (AGENT_USER_AGENT_PATTERNS.some((pattern) => pattern.test(userAgent))) {
+    return "user-agent";
+  }
+
+  return undefined;
+}
+
+export function getAgentMarkdownRewritePathname(pathname: string) {
+  const docsPath = normalizeDocsPath(pathname);
+
+  if (SKIPPED_DOCS_PATHS.has(docsPath)) return undefined;
+  if (
+    SKIPPED_DOCS_PREFIXES.some((prefix) => docsPath === prefix || docsPath.startsWith(`${prefix}/`))
+  ) {
+    return undefined;
+  }
+  if (/\/[^/]+\.[^/]+$/.test(docsPath)) return undefined;
+
+  const basePath = getDocsBasePath(pathname);
+  return docsPath === "/" ? `${basePath}/llms.mdx` : `${basePath}/llms.mdx${docsPath}`;
+}

--- a/apps/docs/src/lib/get-llm-text.ts
+++ b/apps/docs/src/lib/get-llm-text.ts
@@ -1,13 +1,245 @@
 import { source, sourceV6 } from "@/lib/source";
-import { withDocsBasePath } from "@/lib/urls";
+import { getBaseUrl, withDocsBasePath } from "@/lib/urls";
 import type { InferPageType } from "fumadocs-core/source";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 
-export async function getLLMText(
-  page: InferPageType<typeof source> | InferPageType<typeof sourceV6>,
-) {
-  const processed = await page.data.getText("processed");
+type DocsPage = InferPageType<typeof source> | InferPageType<typeof sourceV6>;
+
+type RelatedPageLink = {
+  title: string;
+  href: string;
+  description?: string;
+};
+
+const sectionTitleCache = new Map<string, string | null>();
+
+function getContentDirectory(page: DocsPage) {
+  return page.url.startsWith("/v6") ? "content/docs.v6" : "content/docs";
+}
+
+function getPageSource(page: DocsPage) {
+  return page.url.startsWith("/v6") ? sourceV6 : source;
+}
+
+function humanizeSlug(slug: string) {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function getPageUrlSegments(page: DocsPage) {
+  const url = page.url.startsWith("/v6") ? page.url.slice("/v6".length) : page.url;
+  return url.split("/").filter(Boolean);
+}
+
+function getSectionTitle(page: DocsPage, slugs: string[]) {
+  if (slugs.length === 0) return undefined;
+
+  const contentDirectory = getContentDirectory(page);
+  const cacheKey = `${contentDirectory}:${slugs.join("/")}`;
+  const cached = sectionTitleCache.get(cacheKey);
+
+  if (cached !== undefined) {
+    return cached ?? undefined;
+  }
+
+  const candidatePaths = [
+    join(process.cwd(), contentDirectory, ...slugs, "meta.json"),
+    join(process.cwd(), contentDirectory, "(index)", ...slugs, "meta.json"),
+  ];
+
+  for (const candidatePath of candidatePaths) {
+    try {
+      const meta = JSON.parse(readFileSync(candidatePath, "utf8")) as { title?: string };
+      if (typeof meta.title === "string" && meta.title.trim().length > 0) {
+        sectionTitleCache.set(cacheKey, meta.title);
+        return meta.title;
+      }
+    } catch {}
+  }
+
+  sectionTitleCache.set(cacheKey, null);
+  return undefined;
+}
+
+function getBreadcrumbName(page: DocsPage, slugs: string[], index: number) {
+  if (index === slugs.length - 1) return page.data.title;
+
+  return getSectionTitle(page, slugs.slice(0, index + 1)) ?? humanizeSlug(slugs[index]);
+}
+
+function getBreadcrumbLine(page: DocsPage) {
+  const segments = getPageUrlSegments(page);
+  const names = segments.map((_, index) => getBreadcrumbName(page, segments, index));
+
+  if (page.url.startsWith("/v6")) names.unshift("v6");
+  return names.length > 0 ? `Location: ${names.join(" > ")}` : undefined;
+}
+
+function resolveHref(href: string, page: DocsPage, baseUrl: string) {
+  if (/^[a-z][a-z\d+.-]*:\/\//i.test(href)) return href;
+  const resolved = getPageSource(page).getPageByHref(href, { dir: dirname(page.path) });
+  if (resolved) return `${baseUrl}${withDocsBasePath(resolved.page.url)}`;
+  if (href.startsWith("/")) return `${baseUrl}${withDocsBasePath(href)}`;
+  return undefined;
+}
+
+function getExplicitRelatedPages(page: DocsPage, baseUrl: string) {
+  const data = page.data as {
+    related?: unknown;
+    relatedPages?: unknown;
+  };
+  const related = data.relatedPages ?? data.related;
+
+  if (!Array.isArray(related)) return [];
+
+  return related.flatMap((entry): RelatedPageLink[] => {
+    if (typeof entry === "string") {
+      const resolved = getPageSource(page).getPageByHref(entry, { dir: dirname(page.path) });
+      const href = resolveHref(entry, page, baseUrl);
+      if (!href) return [];
+
+      return [
+        {
+          title: resolved?.page.data.title ?? entry,
+          href,
+          description: resolved?.page.data.description,
+        },
+      ];
+    }
+
+    if (!entry || typeof entry !== "object") return [];
+
+    const relatedPage = entry as {
+      title?: unknown;
+      href?: unknown;
+      url?: unknown;
+      description?: unknown;
+    };
+    const hrefValue = typeof relatedPage.href === "string" ? relatedPage.href : relatedPage.url;
+    if (typeof hrefValue !== "string") return [];
+
+    const href = resolveHref(hrefValue, page, baseUrl);
+    if (!href) return [];
+
+    return [
+      {
+        title: typeof relatedPage.title === "string" ? relatedPage.title : hrefValue,
+        href,
+        description:
+          typeof relatedPage.description === "string" ? relatedPage.description : undefined,
+      },
+    ];
+  });
+}
+
+function getSiblingRelatedPages(page: DocsPage, baseUrl: string) {
+  const pageSegments = getPageUrlSegments(page);
+  const parentSegments = pageSegments.slice(0, -1);
+
+  return getPageSource(page)
+    .getPages()
+    .filter((candidate) => {
+      const candidateSegments = getPageUrlSegments(candidate);
+      return (
+        candidate.url !== page.url &&
+        candidateSegments.length === pageSegments.length &&
+        parentSegments.every((segment, index) => candidateSegments[index] === segment)
+      );
+    })
+    .sort((a, b) => a.data.title.localeCompare(b.data.title))
+    .slice(0, 5)
+    .map((candidate) => ({
+      title: candidate.data.title,
+      href: `${baseUrl}${withDocsBasePath(candidate.url)}`,
+      description: candidate.data.description,
+    }));
+}
+
+function formatRelatedPages(relatedPages: RelatedPageLink[]) {
+  if (relatedPages.length === 0) return "";
+
+  const links = relatedPages
+    .map((page) => {
+      const description = page.description ? `: ${page.description}` : "";
+      return `- [\`${page.title}\`](${page.href})${description}`;
+    })
+    .join("\n");
+
+  return `\n\n## Related pages\n\n${links}`;
+}
+
+function trimComponentContent(value: string) {
+  const lines = value.replace(/^\n+|\n+$/g, "").split("\n");
+  const indent = lines
+    .filter((line) => line.trim().length > 0)
+    .reduce((minimum, line) => Math.min(minimum, line.match(/^ */)?.[0].length ?? 0), Infinity);
+
+  return lines
+    .map((line) => (Number.isFinite(indent) ? line.slice(indent) : line))
+    .join("\n")
+    .trim();
+}
+
+function cleanCalloutContent(value: string) {
+  return trimComponentContent(value)
+    .replace(/<\/?(?:CalloutTitle|CalloutDescription)>/g, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
+function formatCallout(type: string, content: string) {
+  const label = type.trim().toUpperCase() || "NOTE";
+  const text = cleanCalloutContent(content);
+  if (!text) return "";
+
+  return `> [!${label}]\n${text
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n")}`;
+}
+
+function formatCodeBlockTab(value: string, content: string) {
+  const text = trimComponentContent(content);
+  if (!text) return "";
+
+  return `#### ${value.trim()}\n\n${text}`;
+}
+
+function normalizeProcessedMarkdown(markdown: string) {
+  return markdown
+    .replace(
+      /<CalloutContainer\s+type="([^"]+)"[^>]*>([\s\S]*?)<\/CalloutContainer>/g,
+      (_match, type: string, content: string) => formatCallout(type, content),
+    )
+    .replace(/<CodeBlockTabsList>[\s\S]*?<\/CodeBlockTabsList>/g, "")
+    .replace(
+      /<CodeBlockTab\s+value="([^"]+)"[^>]*>([\s\S]*?)<\/CodeBlockTab>/g,
+      (_match, value: string, content: string) => formatCodeBlockTab(value, content),
+    )
+    .replace(/<\/?CodeBlockTabs[^>]*>/g, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+export async function getLLMText(page: DocsPage) {
+  const processed = normalizeProcessedMarkdown(await page.data.getText("processed"));
+  const breadcrumbLine = getBreadcrumbLine(page);
+  const baseUrl = getBaseUrl();
+  const explicitRelatedPages = getExplicitRelatedPages(page, baseUrl);
+  const relatedPages =
+    explicitRelatedPages.length > 0
+      ? explicitRelatedPages.slice(0, 5)
+      : getSiblingRelatedPages(page, baseUrl);
+  const context = breadcrumbLine ? `${breadcrumbLine}\n\n` : "";
+  const related = formatRelatedPages(relatedPages);
 
   return `# ${page.data.title} (${withDocsBasePath(page.url)})
 
-${processed}`;
+${context}${processed}${related}`;
 }

--- a/apps/docs/src/lib/get-llm-text.ts
+++ b/apps/docs/src/lib/get-llm-text.ts
@@ -186,10 +186,14 @@ function trimComponentContent(value: string) {
 
 function cleanCalloutContent(value: string) {
   return trimComponentContent(value)
+    .replace(
+      /<Callout(?:Title|Description)>([\s\S]*?)<\/Callout(?:Title|Description)>/g,
+      (_match, content: string) => trimComponentContent(content),
+    )
     .replace(/<\/?(?:CalloutTitle|CalloutDescription)>/g, "")
+    .replace(/^(?:[ \t]*\n)+|(?:\n[ \t]*)+$/g, "")
     .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
+    .map((line) => line.replace(/[ \t]+$/g, ""))
     .join("\n");
 }
 

--- a/apps/docs/src/lib/llms.ts
+++ b/apps/docs/src/lib/llms.ts
@@ -1,0 +1,193 @@
+import { withDocsBasePath } from "./urls";
+
+type LLMsLink = {
+  title: string;
+  href: string;
+  description: string;
+};
+
+type LLMsFullPage = {
+  data: {
+    title: string;
+  };
+};
+
+type LLMsSection = {
+  slug: string;
+  title: string;
+  description: string;
+  prefixes: string[];
+};
+
+export const commonQueries: LLMsLink[] = [
+  {
+    title: "Start a new Prisma ORM project",
+    href: "/prisma-orm/quickstart/prisma-postgres",
+    description: "Set up Prisma ORM, Prisma Client, and Prisma Postgres in a new TypeScript app.",
+  },
+  {
+    title: "Connect to Prisma Postgres",
+    href: "/postgres/database/connecting-to-your-database",
+    description:
+      "Choose the right connection string for Prisma ORM, PostgreSQL tools, and serverless runtimes.",
+  },
+  {
+    title: "Run Prisma Postgres locally",
+    href: "/postgres/database/local-development",
+    description:
+      "Use local Prisma Postgres during development and switch to a hosted database for production.",
+  },
+  {
+    title: "Manage database connections",
+    href: "/orm/prisma-client/setup-and-configuration/databases-connections",
+    description:
+      "Configure Prisma Client connection management for long-running and serverless apps.",
+  },
+  {
+    title: "Create and apply migrations",
+    href: "/orm/prisma-migrate/getting-started",
+    description: "Use Prisma Migrate to evolve your database schema in development.",
+  },
+  {
+    title: "Deploy migrations safely",
+    href: "/orm/prisma-client/deployment/deploy-database-changes-with-prisma-migrate",
+    description: "Apply schema changes in production with Prisma Migrate.",
+  },
+  {
+    title: "Set up the Prisma MCP server",
+    href: "/ai/tools/mcp-server",
+    description:
+      "Connect AI agents to Prisma Postgres workflows with the local or remote MCP server.",
+  },
+  {
+    title: "Use the Prisma Client API",
+    href: "/orm/reference/prisma-client-reference",
+    description: "Look up Prisma Client query APIs, options, and generated types.",
+  },
+  {
+    title: "Use the Prisma CLI",
+    href: "/orm/reference/prisma-cli-reference",
+    description:
+      "Look up Prisma CLI commands for init, generate, migrate, db, and studio workflows.",
+  },
+  {
+    title: "Troubleshoot Prisma ORM errors",
+    href: "/orm/reference/errors",
+    description: "Find common Prisma ORM errors and links to deeper troubleshooting pages.",
+  },
+  {
+    title: "Troubleshoot Prisma Postgres",
+    href: "/postgres/troubleshooting",
+    description: "Resolve common Prisma Postgres issues.",
+  },
+  {
+    title: "Review pricing",
+    href: "https://www.prisma.io/pricing",
+    description:
+      "Compare Prisma plans and pricing for Prisma Postgres and Prisma platform features.",
+  },
+];
+
+export const llmsSections: LLMsSection[] = [
+  {
+    slug: "orm",
+    title: "Prisma ORM",
+    description: "Prisma ORM setup, schema modeling, Prisma Client, migrations, and references.",
+    prefixes: ["/orm", "/prisma-orm"],
+  },
+  {
+    slug: "postgres",
+    title: "Prisma Postgres",
+    description:
+      "Prisma Postgres setup, connection strings, local development, operations, and guides.",
+    prefixes: ["/postgres", "/prisma-postgres"],
+  },
+  {
+    slug: "mcp",
+    title: "Prisma MCP",
+    description: "MCP server setup for Prisma Postgres and Prisma CLI workflows.",
+    prefixes: ["/ai/tools/mcp-server", "/cli/mcp"],
+  },
+];
+
+function resolveLLMsHref(href: string, baseUrl: string) {
+  if (/^[a-z][a-z\d+.-]*:\/\//i.test(href)) return href;
+  return `${baseUrl}${withDocsBasePath(href)}`;
+}
+
+export function formatLLMsLink(link: LLMsLink, baseUrl: string) {
+  return `- [\`${link.title}\`](${resolveLLMsHref(link.href, baseUrl)}): ${link.description}`;
+}
+
+export function formatLLMsPageLink(
+  page: { data: { title: string; description?: string }; url: string },
+  baseUrl: string,
+) {
+  const title = page.data.title;
+  const description = page.data.description || "";
+  const path = `${baseUrl}${withDocsBasePath(page.url)}`;
+
+  return `- [\`${title}\`](${path}): ${description}`;
+}
+
+export function formatLLMsSectionLink(section: LLMsSection, baseUrl: string) {
+  const href = `${baseUrl}${withDocsBasePath(`/llms/${section.slug}.txt`)}`;
+
+  return `- [\`${section.title}\`](${href}): ${section.description}`;
+}
+
+export function getLLMsSection(slug: string) {
+  return llmsSections.find((section) => section.slug === slug);
+}
+
+export function filterPagesForLLMsSection<T extends { url: string }>(
+  pages: T[],
+  section: LLMsSection,
+) {
+  return pages.filter((page) =>
+    section.prefixes.some((prefix) => page.url === prefix || page.url.startsWith(`${prefix}/`)),
+  );
+}
+
+export function createLLMsFullResponse<TPage extends LLMsFullPage>(
+  description: string,
+  pages: TPage[],
+  renderPage: (page: TPage) => Promise<string>,
+) {
+  const encoder = new TextEncoder();
+  let pageIndex = -1;
+  const stream = new ReadableStream({
+    async pull(controller) {
+      if (pageIndex === -1) {
+        pageIndex = 0;
+        controller.enqueue(encoder.encode(description));
+        return;
+      }
+
+      const page = pages[pageIndex];
+      pageIndex += 1;
+
+      if (!page) {
+        controller.close();
+        return;
+      }
+
+      try {
+        controller.enqueue(encoder.encode(`${await renderPage(page)}\n\n`));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown error";
+        controller.enqueue(
+          encoder.encode(
+            `# ${page.data.title}\n\nThis page could not be rendered for the full documentation feed.\n\n${message}\n\n`,
+          ),
+        );
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/apps/docs/src/lib/llms.ts
+++ b/apps/docs/src/lib/llms.ts
@@ -6,6 +6,14 @@ type LLMsLink = {
   description: string;
 };
 
+type LLMsPage = {
+  data: {
+    title: string;
+    description?: string;
+  };
+  url: string;
+};
+
 type LLMsFullPage = {
   data: {
     title: string;
@@ -18,6 +26,27 @@ type LLMsSection = {
   description: string;
   prefixes: string[];
 };
+
+type LLMsExcludedProduct = {
+  prefixes: string[];
+  urlPatterns?: RegExp[];
+  titlePatterns?: RegExp[];
+  descriptionPatterns?: RegExp[];
+};
+
+const excludedLLMsProducts: LLMsExcludedProduct[] = [
+  {
+    prefixes: ["/accelerate"],
+    urlPatterns: [/(^|\/)accelerate($|[/-])/i],
+    titlePatterns: [/\bAccelerate\b/i],
+    descriptionPatterns: [/\bAccelerate\b/i],
+  },
+  {
+    prefixes: ["/optimize"],
+    titlePatterns: [/\bPrisma Optimize\b/i],
+    descriptionPatterns: [/\bPrisma Optimize\b/i],
+  },
+];
 
 export const commonQueries: LLMsLink[] = [
   {
@@ -52,6 +81,11 @@ export const commonQueries: LLMsLink[] = [
     title: "Deploy migrations safely",
     href: "/orm/prisma-client/deployment/deploy-database-changes-with-prisma-migrate",
     description: "Apply schema changes in production with Prisma Migrate.",
+  },
+  {
+    title: "Use Query Insights",
+    href: "/query-insights",
+    description: "Inspect slow queries, connect Prisma calls to SQL, and apply focused fixes.",
   },
   {
     title: "Set up the Prisma MCP server",
@@ -103,6 +137,16 @@ export const llmsSections: LLMsSection[] = [
     prefixes: ["/postgres", "/prisma-postgres"],
   },
   {
+    slug: "query-insights",
+    title: "Query Insights",
+    description: "Query performance analysis, slow query inspection, and Prisma SQL comment setup.",
+    prefixes: [
+      "/query-insights",
+      "/postgres/database/query-insights",
+      "/orm/prisma-client/queries/advanced/query-optimization-performance",
+    ],
+  },
+  {
     slug: "mcp",
     title: "Prisma MCP",
     description: "MCP server setup for Prisma Postgres and Prisma CLI workflows.",
@@ -115,14 +159,52 @@ function resolveLLMsHref(href: string, baseUrl: string) {
   return `${baseUrl}${withDocsBasePath(href)}`;
 }
 
+function normalizeInternalHref(href: string) {
+  if (/^[a-z][a-z\d+.-]*:\/\//i.test(href)) return undefined;
+
+  const pathname = href.split(/[?#]/, 1)[0];
+  if (pathname === "/docs") return "/";
+  if (pathname.startsWith("/docs/")) return pathname.slice("/docs".length);
+  return pathname;
+}
+
+function hasPageForHref(href: string, pages: LLMsPage[]) {
+  const pathname = normalizeInternalHref(href);
+  if (!pathname) return true;
+  return pages.some((page) => page.url === pathname);
+}
+
+function matchesLLMsPagePrefix(page: LLMsPage, prefixes: string[]) {
+  return prefixes.some((prefix) => page.url === prefix || page.url.startsWith(`${prefix}/`));
+}
+
+function matchesAnyPattern(value: string, patterns: RegExp[] | undefined) {
+  return patterns?.some((pattern) => pattern.test(value)) ?? false;
+}
+
+function isExcludedLLMsPage(page: LLMsPage) {
+  return excludedLLMsProducts.some(
+    (product) =>
+      matchesLLMsPagePrefix(page, product.prefixes) ||
+      matchesAnyPattern(page.url, product.urlPatterns) ||
+      matchesAnyPattern(page.data.title, product.titlePatterns) ||
+      matchesAnyPattern(page.data.description ?? "", product.descriptionPatterns),
+  );
+}
+
+export function filterPagesForLLMsIndex<T extends LLMsPage>(pages: T[]) {
+  return pages.filter((page) => !isExcludedLLMsPage(page));
+}
+
 export function formatLLMsLink(link: LLMsLink, baseUrl: string) {
   return `- [\`${link.title}\`](${resolveLLMsHref(link.href, baseUrl)}): ${link.description}`;
 }
 
-export function formatLLMsPageLink(
-  page: { data: { title: string; description?: string }; url: string },
-  baseUrl: string,
-) {
+export function filterAvailableLLMsLinks(links: LLMsLink[], pages: LLMsPage[]) {
+  return links.filter((link) => hasPageForHref(link.href, pages));
+}
+
+export function formatLLMsPageLink(page: LLMsPage, baseUrl: string) {
   const title = page.data.title;
   const description = page.data.description || "";
   const path = `${baseUrl}${withDocsBasePath(page.url)}`;
@@ -136,10 +218,6 @@ export function formatLLMsSectionLink(section: LLMsSection, baseUrl: string) {
   return `- [\`${section.title}\`](${href}): ${section.description}`;
 }
 
-export function getLLMsSection(slug: string) {
-  return llmsSections.find((section) => section.slug === slug);
-}
-
 export function filterPagesForLLMsSection<T extends { url: string }>(
   pages: T[],
   section: LLMsSection,
@@ -147,6 +225,15 @@ export function filterPagesForLLMsSection<T extends { url: string }>(
   return pages.filter((page) =>
     section.prefixes.some((prefix) => page.url === prefix || page.url.startsWith(`${prefix}/`)),
   );
+}
+
+export function filterAvailableLLMsSections(sections: LLMsSection[], pages: LLMsPage[]) {
+  return sections.filter((section) => filterPagesForLLMsSection(pages, section).length > 0);
+}
+
+export function getLLMsSection(slug: string, pages?: LLMsPage[]) {
+  const sections = pages ? filterAvailableLLMsSections(llmsSections, pages) : llmsSections;
+  return sections.find((section) => section.slug === slug);
 }
 
 export function createLLMsFullResponse<TPage extends LLMsFullPage>(
@@ -175,10 +262,13 @@ export function createLLMsFullResponse<TPage extends LLMsFullPage>(
       try {
         controller.enqueue(encoder.encode(`${await renderPage(page)}\n\n`));
       } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
+        console.error("docs:llms_full_page_render_error", {
+          title: page.data.title,
+          error,
+        });
         controller.enqueue(
           encoder.encode(
-            `# ${page.data.title}\n\nThis page could not be rendered for the full documentation feed.\n\n${message}\n\n`,
+            `# ${page.data.title}\n\nThis page could not be rendered for the full documentation feed.\n\nAn internal error occurred while rendering this page.\n\n`,
           ),
         );
       }

--- a/apps/docs/src/proxy.ts
+++ b/apps/docs/src/proxy.ts
@@ -1,0 +1,35 @@
+import { getAgentMarkdownRewritePathname, getAgentMarkdownSignal } from "@/lib/agent-markdown";
+import { NextResponse, type NextRequest } from "next/server";
+
+export function proxy(request: NextRequest) {
+  const signal = getAgentMarkdownSignal(request.headers);
+  if (!signal) return NextResponse.next();
+
+  const rewritePathname = getAgentMarkdownRewritePathname(request.nextUrl.pathname);
+  if (!rewritePathname) return NextResponse.next();
+
+  const url = request.nextUrl.clone();
+  url.pathname = rewritePathname;
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-prisma-agent-markdown", signal);
+  requestHeaders.set("x-prisma-agent-markdown-path", request.nextUrl.pathname);
+
+  console.info("docs:agent_markdown_rewrite", {
+    path: request.nextUrl.pathname,
+    signal,
+  });
+
+  const response = NextResponse.rewrite(url, {
+    request: {
+      headers: requestHeaders,
+    },
+  });
+  response.headers.set("x-prisma-agent-markdown", signal);
+
+  return response;
+}
+
+export const config = {
+  matcher: ["/((?!_next|monitoring).*)"],
+};

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,6 +30,7 @@
     "@tailwindcss/postcss": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "next": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -818,9 +818,6 @@ importers:
       lucide-react:
         specifier: 'catalog:'
         version: 0.575.0(react@19.2.4)
-      next:
-        specifier: 'catalog:'
-        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -846,6 +843,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
+      next:
+        specifier: 'catalog:'
+        version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.2.2


### PR DESCRIPTION
## Summary

Adds agent-friendly Markdown access patterns for Prisma docs, including transparent agent content negotiation, `.md` URL aliases, curated `llms.txt` sections, product-area sub-indexes, Markdown 404 recovery, and richer Markdown output with breadcrumbs and related pages.

The v7 `llms.txt` index now prioritizes current Prisma docs, includes Query Insights, and excludes deprecated/removed product surfaces such as Accelerate and Prisma Optimize from current agent-facing indexes. v6 remains available separately.

## Issues

Resolves DR-8317
Resolves DR-8318
Resolves DR-8319
Resolves DR-8320
Resolves DR-8321
Resolves DR-8322
Resolves DR-8324

## Verification

- Ran focused `oxlint` on the changed docs files.
- Ran `oxfmt --check` on the changed docs files.
- Ran `pnpm --filter docs exec next typegen`.
- Verified live routes on `localhost:3001` for:
  - agent User-Agent and `Accept: text/markdown` rewrites
  - browser HTML behavior
  - `.md` / `.mdx` parity
  - curated `llms.txt`
  - scoped product sub-indexes
  - Markdown 404 output
  - breadcrumbs and related pages
  - full Markdown feed output
  - Markdown discovery `Link` headers

`pnpm --filter docs exec tsc --noEmit` was attempted but is blocked by an existing unrelated `packages/ui` import resolution error for `next/navigation`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent-aware markdown routing and middleware to serve docs tailored to markdown-capable clients
  * New plain-text LLM section endpoints and precomputed section paths for static serving
  * Streamed "full LLMs" feed for complete docs export

* **Documentation**
  * Custom 404 pages with suggested similar topics and navigation links
  * Added "Common Queries" and "Product Area Indexes" to LLM feeds; improved breadcrumbs and related-pages in exported markdown

* **Chores**
  * Dev tooling dependency updated for docs UI build/runtime tools
<!-- end of auto-generated comment: release notes by coderabbit.ai -->