### PR TITLE
Remove duplicate "adapter" from docs

### DIFF
--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/prisma-postgres.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/prisma-postgres.mdx
@@ -175,7 +175,7 @@ npx prisma generate
 
 ## 7. Instantiate Prisma Client
 
-Now that you have all the dependencies installed, you can instantiate Prisma Client. You need to pass an instance of the Prisma ORM driver adapter adapter to the `PrismaClient` constructor:
+Now that you have all the dependencies installed, you can instantiate Prisma Client. You need to pass an instance of the Prisma ORM driver adapter to the `PrismaClient` constructor:
 
 ```typescript title="lib/prisma.ts"
 import "dotenv/config";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in the Prisma ORM quickstart guide by removing duplicate text in the client instantiation section for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->