### PR TITLE
fix(docs): refer wrong raw query methods in ORM > Using Raw SQL > TypeSQL

### DIFF
--- a/apps/docs/content/docs/orm/prisma-client/using-raw-sql/typedsql.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/using-raw-sql/typedsql.mdx
@@ -242,7 +242,7 @@ TypedSQL requires an active database connection to function properly. This means
 
 ### Dynamic SQL Queries with Dynamic Columns
 
-TypedSQL does not natively support constructing SQL queries with dynamically added columns. When you need to create a query where the columns are determined at runtime, you must use the `$queryRaw` and `$executeRaw` methods. These methods allow for the execution of raw SQL, which can include dynamic column selections.
+TypedSQL does not natively support constructing SQL queries with dynamically added columns. When you need to create a query where the columns are determined at runtime, you must use the `$queryRawUnsafe` and `$executeRawUnsafe` methods. These methods allow for the execution of raw SQL, which can include dynamic column selections.
 
 **Example of a query using dynamic column selection:**
 

--- a/apps/docs/content/docs/orm/v6/prisma-client/using-raw-sql/typedsql.mdx
+++ b/apps/docs/content/docs/orm/v6/prisma-client/using-raw-sql/typedsql.mdx
@@ -245,7 +245,7 @@ TypedSQL requires an active database connection to function properly. This means
 
 ### Dynamic SQL Queries with Dynamic Columns
 
-TypedSQL does not natively support constructing SQL queries with dynamically added columns. When you need to create a query where the columns are determined at runtime, you must use the `$queryRaw` and `$executeRaw` methods. These methods allow for the execution of raw SQL, which can include dynamic column selections.
+TypedSQL does not natively support constructing SQL queries with dynamically added columns. When you need to create a query where the columns are determined at runtime, you must use the `$queryRawUnsafe` and `$executeRawUnsafe` methods. These methods allow for the execution of raw SQL, which can include dynamic column selections.
 
 **Example of a query using dynamic column selection:**
 


### PR DESCRIPTION
## Summary

In [Dynamic SQL Queries with Dynamic Columns](https://www.prisma.io/docs/v6/orm/prisma-client/using-raw-sql/typedsql#dynamic-sql-queries-with-dynamic-columns) section, the doc clearly mentioned:
> When you need to create a query where the columns are determined at runtime, you must use the $queryRaw and $executeRaw methods.
But in the example, it uses:
```js
const columns = "name, email, age"; // Columns determined at runtime
const result = await prisma.$queryRawUnsafe(`SELECT ${columns} FROM Users WHERE active = true`);
```
It looks counterintuitive to me, so I do check on my own. The search results confirmed my assumptions: the doc might refer to the wrong methods. 

### Proofs:
Under [`$queryRaw` considerations> ](https://www.prisma.io/docs/orm/prisma-client/using-raw-sql/raw-queries#considerations)
<img width="711" height="309" alt="image" src="https://github.com/user-attachments/assets/1d3b3a67-92fb-4250-a2c1-bca4cdc4301b" />

Under [`$executeRaw` considerations> ](https://www.prisma.io/docs/orm/prisma-client/using-raw-sql/raw-queries#considerations-1)
<img width="715" height="306" alt="image" src="https://github.com/user-attachments/assets/36270183-4888-434e-809f-aff19df648e8" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for constructing SQL queries with dynamically determined columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->