### PR TITLE
feat(docs): add Netlify and Vercel Compute migration guides

### DIFF
--- a/apps/docs/content/docs/compute-internal/guides/meta.json
+++ b/apps/docs/content/docs/compute-internal/guides/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Migration guides",
+  "pages": ["vercel", "netlify"]
+}

--- a/apps/docs/content/docs/compute-internal/guides/netlify.mdx
+++ b/apps/docs/content/docs/compute-internal/guides/netlify.mdx
@@ -1,0 +1,184 @@
+---
+title: Netlify
+url: /compute-internal/guides/netlify
+metaTitle: "Migrate a Netlify deployment to Prisma Compute (Internal)"
+metaDescription: Internal testing guide for migrating a Netlify deployment to Prisma Compute with the preview CLI.
+---
+
+:::warning
+Internal team reference. Not for users. This version uses `@prisma/cli@preview` for internal testing. The final public guide lives at [/compute/guides/netlify](/compute/guides/netlify).
+:::
+
+Move the same app you deploy on Netlify to Prisma Compute. Keep the Netlify deployment running while you test, then switch traffic after the Compute deployment is healthy.
+
+## Prerequisites
+
+- Node.js 20 or later
+- A Prisma account
+- A local checkout of the repo and branch Netlify deploys
+- Access to the Netlify site's production environment variables
+
+## 1. Prepare the app
+
+Most frameworks need a small config change before Compute can run them. Expand your framework below.
+
+<Accordions type="single" defaultValue="Next.js">
+  <Accordion title="Next.js">
+    Enable the standalone build output:
+
+    ```typescript title="next.config.ts"
+    const nextConfig = { output: "standalone" };
+    export default nextConfig;
+    ```
+
+    If your existing config already exports other options, keep them and add `output: "standalone"`.
+  </Accordion>
+
+  <Accordion title="TanStack Start">
+    TanStack Start on Netlify uses the Netlify vite plugin. When deploying to Prisma Compute, swap it to `nitro` from `nitro/vite`:
+
+    ```typescript title="vite.config.ts"
+    import { defineConfig } from 'vite'
+    import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+    import viteReact from '@vitejs/plugin-react'
+    import tailwindcss from '@tailwindcss/vite'
+    import netlify from '@netlify/vite-plugin-tanstack-start' // [!code --]
+    import { nitro } from 'nitro/vite' // [!code ++]
+
+    const config = defineConfig({
+      resolve: { tsconfigPaths: true },
+      plugins: [
+        netlify(), // [!code --]
+        nitro({ rollupConfig: { external: [/^@sentry\//] } }), // [!code ++]
+        tailwindcss(),
+        tanstackStart(),
+        viteReact(),
+      ],
+    })
+
+    export default config
+    ```
+  </Accordion>
+
+  <Accordion title="Astro">
+    Use the Node adapter in standalone mode:
+
+    ```npm
+    npm install @astrojs/node
+    ```
+
+    ```typescript title="astro.config.mjs"
+    import { defineConfig } from "astro/config";
+    import node from "@astrojs/node";
+
+    export default defineConfig({
+      output: "server",
+      adapter: node({ mode: "standalone" }),
+    });
+    ```
+  </Accordion>
+
+  <Accordion title="Nuxt and Bun">
+    No framework-specific changes are needed. Nuxt and Bun apps build to a standard Node.js server process that Compute can run directly.
+  </Accordion>
+
+  <Accordion title="Netlify-specific behavior">
+    If your app depends on Netlify Functions, Netlify Edge Functions, Netlify build plugins, or `netlify.toml` routing behavior, move that behavior into your framework or server code before switching production traffic.
+  </Accordion>
+</Accordions>
+
+## 2. Build locally
+
+Run the same install and build commands Netlify uses:
+
+```npm
+npm install
+npm run build
+```
+
+Fix local build issues before deploying to Compute.
+
+## 3. Deploy to Compute
+
+Copy the runtime variables your app needs from **Netlify Site configuration > Environment variables**, then deploy from the same local checkout:
+
+```bash
+npx @prisma/cli@preview auth login
+npx @prisma/cli@preview app deploy \
+  --app my-app \
+  --http-port 3000 \
+  --env DATABASE_URL="postgresql://example" \
+  --env AUTH_SECRET="replace-me"
+```
+
+Use `--http-port 3000` for most Next.js, Nuxt, TanStack Start, and Bun apps. Use `--http-port 4321` for Astro unless your app serves on a different port.
+
+<Accordions type="single">
+  <Accordion title="TanStack Start: pass the server entrypoint">
+    TanStack Start's build outputs a Nitro server to `.output/server/index.mjs`. Pass that path with `--entry`:
+
+    ```bash
+    npx @prisma/cli@preview app deploy \
+      --app my-app \
+      --entry .output/server/index.mjs \
+      --http-port 3000 \
+      --env DATABASE_URL="postgresql://example" \
+      --env AUTH_SECRET="replace-me"
+    ```
+  </Accordion>
+
+  <Accordion title="Export Netlify environment variables with the CLI">
+    You can export production environment variables locally with the Netlify CLI:
+
+    ```bash
+    netlify env:list --context production --plain > .env.netlify
+    ```
+
+    Start with runtime values such as `DATABASE_URL`, auth secrets, API keys, and service endpoints. Do not copy Netlify-managed variables unless your app explicitly depends on them.
+  </Accordion>
+
+  <Accordion title="If Netlify masks a secret">
+    Netlify may hide raw values for environment variables marked as secret. If a required secret is masked, copy the production value from your secret manager or the Netlify UI.
+  </Accordion>
+
+  <Accordion title="Update environment variables after deploy">
+    You can add or change variables after the first deploy:
+
+    ```bash
+    npx @prisma/cli@preview app update-env --env AUTH_SECRET="replace-me"
+    npx @prisma/cli@preview app list-env
+    ```
+
+    See [Environment variables](/compute-internal/environment-variables) for the full internal workflow.
+  </Accordion>
+</Accordions>
+
+## 4. Verify and switch traffic
+
+Open the Compute deployment URL and test the pages, API routes, database reads and writes, auth callbacks, and webhooks that matter for production.
+
+Stream logs while testing:
+
+```bash
+npx @prisma/cli@preview app logs
+```
+
+<Accordions type="single">
+  <Accordion title="Inspect deployments">
+    Inspect a specific deployment if needed:
+
+    ```bash
+    npx @prisma/cli@preview app list-deploys
+    npx @prisma/cli@preview app show-deploy <deployment-id>
+    ```
+  </Accordion>
+</Accordions>
+
+Switch traffic only after the Compute deployment is healthy. Keep the Netlify deployment available as a rollback target until the Compute deployment is serving production traffic successfully.
+
+## Next steps
+
+- [Environment variables](/compute-internal/environment-variables): set secrets and configuration at deploy time or after.
+- [Logs](/compute-internal/logs): stream runtime logs.
+- [CLI reference](/compute-internal/cli): compare the current CLI surfaces.
+- [Limitations](/compute-internal/limitations): review known Compute caveats.

--- a/apps/docs/content/docs/compute-internal/guides/netlify.mdx
+++ b/apps/docs/content/docs/compute-internal/guides/netlify.mdx
@@ -114,19 +114,6 @@ npx @prisma/cli@preview app deploy \
 Use `--http-port 3000` for most Next.js, Nuxt, TanStack Start, and Bun apps. Use `--http-port 4321` for Astro unless your app serves on a different port.
 
 <Accordions type="single">
-  <Accordion title="TanStack Start: pass the server entrypoint">
-    TanStack Start's build outputs a Nitro server to `.output/server/index.mjs`. Pass that path with `--entry`:
-
-    ```bash
-    npx @prisma/cli@preview app deploy \
-      --app my-app \
-      --entry .output/server/index.mjs \
-      --http-port 3000 \
-      --env DATABASE_URL="postgresql://example" \
-      --env AUTH_SECRET="replace-me"
-    ```
-  </Accordion>
-
   <Accordion title="Export Netlify environment variables with the CLI">
     You can export production environment variables locally with the Netlify CLI:
 

--- a/apps/docs/content/docs/compute-internal/guides/vercel.mdx
+++ b/apps/docs/content/docs/compute-internal/guides/vercel.mdx
@@ -110,19 +110,6 @@ npx @prisma/cli@preview app deploy \
 Use `--http-port 3000` for most Next.js, Nuxt, TanStack Start, and Bun apps. Use `--http-port 4321` for Astro unless your app serves on a different port.
 
 <Accordions type="single">
-  <Accordion title="TanStack Start: pass the server entrypoint">
-    TanStack Start's build outputs a Nitro server to `.output/server/index.mjs`. Pass that path with `--entry`:
-
-    ```bash
-    npx @prisma/cli@preview app deploy \
-      --app my-app \
-      --entry .output/server/index.mjs \
-      --http-port 3000 \
-      --env DATABASE_URL="postgresql://example" \
-      --env AUTH_SECRET="replace-me"
-    ```
-  </Accordion>
-
   <Accordion title="Pull Vercel environment variables with the CLI">
     You can pull production environment variables locally with the Vercel CLI:
 

--- a/apps/docs/content/docs/compute-internal/guides/vercel.mdx
+++ b/apps/docs/content/docs/compute-internal/guides/vercel.mdx
@@ -1,0 +1,176 @@
+---
+title: Vercel
+url: /compute-internal/guides/vercel
+metaTitle: "Migrate a Vercel deployment to Prisma Compute (Internal)"
+metaDescription: Internal testing guide for migrating a Vercel deployment to Prisma Compute with the preview CLI.
+---
+
+:::warning
+Internal team reference. Not for users. This version uses `@prisma/cli@preview` for internal testing. The final public guide lives at [/compute/guides/vercel](/compute/guides/vercel).
+:::
+
+Move the same app you deploy on Vercel to Prisma Compute. Keep the Vercel deployment running while you test, then switch traffic after the Compute deployment is healthy.
+
+## Prerequisites
+
+- Node.js 20 or later
+- A Prisma account
+- A local checkout of the repo and branch Vercel deploys
+- Access to the Vercel project's production environment variables
+
+## 1. Prepare the app
+
+Most frameworks need a small config change before Compute can run them. Expand your framework below.
+
+<Accordions type="single" defaultValue="Next.js">
+  <Accordion title="Next.js">
+    Enable the standalone build output:
+
+    ```typescript title="next.config.ts"
+    const nextConfig = { output: "standalone" };
+    export default nextConfig;
+    ```
+
+    If your existing config already exports other options, keep them and add `output: "standalone"`.
+  </Accordion>
+
+  <Accordion title="TanStack Start">
+    TanStack Start on Vercel already uses the Nitro vite plugin, which is the same plugin Prisma Compute expects. No changes to `vite.config.ts` are needed.
+  </Accordion>
+
+  <Accordion title="Astro">
+    Use the Node adapter in standalone mode:
+
+    ```npm
+    npm install @astrojs/node
+    ```
+
+    ```typescript title="astro.config.mjs"
+    import { defineConfig } from "astro/config";
+    import node from "@astrojs/node";
+
+    export default defineConfig({
+      output: "server",
+      adapter: node({ mode: "standalone" }),
+    });
+    ```
+  </Accordion>
+
+  <Accordion title="Nuxt and Bun">
+    No framework-specific changes are needed. Nuxt and Bun apps build to a standard Node.js server process that Compute can run directly.
+  </Accordion>
+
+  <Accordion title="Vercel-specific behavior">
+    If your app depends on Vercel Functions, Vercel Edge Functions, or `vercel.json` routing behavior, move that behavior into your framework or server code before switching production traffic.
+  </Accordion>
+</Accordions>
+
+## 2. Build locally
+
+Run the same install and build commands Vercel uses:
+
+```npm
+npm install
+npm run build
+```
+
+Fix local build issues before deploying to Compute.
+
+<Accordions type="single">
+  <Accordion title="Next.js with pnpm">
+    A fresh Vercel-deployed Next.js app worked after adding `output: "standalone"` and deploying.
+
+    If deploy fails with symlink errors, check whether Next.js printed a workspace root warning. A stray lockfile outside the repo can make Next.js choose the wrong root and produce a bad standalone output.
+
+    If the warning points at an accidental `~/package-lock.json`, clean and rebuild:
+
+    ```bash
+    rm -rf .next node_modules ~/package-lock.json
+    pnpm install
+    pnpm build
+    ```
+
+    Then deploy again.
+  </Accordion>
+</Accordions>
+
+## 3. Deploy to Compute
+
+Copy the runtime variables your app needs from **Vercel Project Settings > Environment Variables**, then deploy from the same local checkout:
+
+```bash
+npx @prisma/cli@preview auth login
+npx @prisma/cli@preview app deploy \
+  --app my-app \
+  --http-port 3000 \
+  --env DATABASE_URL="postgresql://example" \
+  --env AUTH_SECRET="replace-me"
+```
+
+Use `--http-port 3000` for most Next.js, Nuxt, TanStack Start, and Bun apps. Use `--http-port 4321` for Astro unless your app serves on a different port.
+
+<Accordions type="single">
+  <Accordion title="TanStack Start: pass the server entrypoint">
+    TanStack Start's build outputs a Nitro server to `.output/server/index.mjs`. Pass that path with `--entry`:
+
+    ```bash
+    npx @prisma/cli@preview app deploy \
+      --app my-app \
+      --entry .output/server/index.mjs \
+      --http-port 3000 \
+      --env DATABASE_URL="postgresql://example" \
+      --env AUTH_SECRET="replace-me"
+    ```
+  </Accordion>
+
+  <Accordion title="Pull Vercel environment variables with the CLI">
+    You can pull production environment variables locally with the Vercel CLI:
+
+    ```bash
+    vercel env pull .env.vercel --environment=production
+    ```
+
+    Start with runtime values such as `DATABASE_URL`, auth secrets, API keys, and service endpoints. Do not copy Vercel-managed variables unless your app explicitly depends on them.
+  </Accordion>
+
+  <Accordion title="Update environment variables after deploy">
+    You can add or change variables after the first deploy:
+
+    ```bash
+    npx @prisma/cli@preview app update-env --env AUTH_SECRET="replace-me"
+    npx @prisma/cli@preview app list-env
+    ```
+
+    See [Environment variables](/compute-internal/environment-variables) for the full internal workflow.
+  </Accordion>
+</Accordions>
+
+## 4. Verify and switch traffic
+
+Open the Compute deployment URL and test the pages, API routes, database reads and writes, auth callbacks, and webhooks that matter for production.
+
+Stream logs while testing:
+
+```bash
+npx @prisma/cli@preview app logs
+```
+
+<Accordions type="single">
+  <Accordion title="Inspect deployments">
+    Inspect a specific deployment if needed:
+
+    ```bash
+    npx @prisma/cli@preview app list-deploys
+    npx @prisma/cli@preview app show-deploy <deployment-id>
+    ```
+  </Accordion>
+</Accordions>
+
+Switch traffic only after the Compute deployment is healthy. Keep the Vercel deployment available as a rollback target until the Compute deployment is serving production traffic successfully.
+
+## Next steps
+
+- [Environment variables](/compute-internal/environment-variables): set secrets and configuration at deploy time or after.
+- [Logs](/compute-internal/logs): stream runtime logs.
+- [CLI reference](/compute-internal/cli): compare the current CLI surfaces.
+- [Limitations](/compute-internal/limitations): review known Compute caveats.

--- a/apps/docs/content/docs/compute-internal/limitations.mdx
+++ b/apps/docs/content/docs/compute-internal/limitations.mdx
@@ -18,7 +18,9 @@ First-class support: **Next.js**, **Astro**, **Nuxt**, **TanStack Start**, and *
 Framework-specific requirements:
 
 - **Next.js**: must use `output: "standalone"` in `next.config.ts`.
+- **Next.js with pnpm**: if deploy fails with standalone symlink errors, check Next.js workspace root detection. A stray lockfile outside the repo, such as an accidental `~/package-lock.json`, can make Next.js infer the wrong root. Clean `.next` and `node_modules`, remove the accidental lockfile, reinstall, and rebuild before deploying again.
 - **Astro**: needs `@astrojs/node` in standalone mode via the adapter.
+- **TanStack Start**: the current internal CLIs need the Nitro server entry explicitly during deploy: `--entry .output/server/index.mjs` for `@looma/prisma-cli` or `--entrypoint .output/server/index.mjs` for `@prisma/compute-cli`.
 
 ## Environment updates
 

--- a/apps/docs/content/docs/compute-internal/meta.json
+++ b/apps/docs/content/docs/compute-internal/meta.json
@@ -7,6 +7,8 @@
     "index",
     "---Quickstart---",
     "...quickstart",
+    "---Migration guides---",
+    "...guides",
     "---Reference---",
     "environment-variables",
     "logs",

--- a/apps/docs/content/docs/compute-internal/quickstart/tanstack-start.mdx
+++ b/apps/docs/content/docs/compute-internal/quickstart/tanstack-start.mdx
@@ -49,7 +49,10 @@ export default defineConfig({
 
 ```bash
 npx @looma/prisma-cli auth login
-npx @looma/prisma-cli app deploy --app my-app --http-port 3000
+npx @looma/prisma-cli app deploy \
+  --app my-app \
+  --entry .output/server/index.mjs \
+  --http-port 3000
 ```
 
   </CodeBlockTab>
@@ -57,11 +60,16 @@ npx @looma/prisma-cli app deploy --app my-app --http-port 3000
 
 ```bash
 bunx @prisma/compute-cli login
-bunx @prisma/compute-cli deploy --service-name my-app --http-port 3000
+bunx @prisma/compute-cli deploy \
+  --service-name my-app \
+  --entrypoint .output/server/index.mjs \
+  --http-port 3000
 ```
 
   </CodeBlockTab>
 </CodeBlockTabs>
+
+The current internal CLIs need TanStack Start's Nitro server entry explicitly. The entry file is produced during the build at `.output/server/index.mjs`.
 
 The first deploy bootstraps project context. Re-deploys reuse the saved selection, so `app deploy` (or `deploy`) is enough.
 

--- a/apps/docs/content/docs/compute/guides/meta.json
+++ b/apps/docs/content/docs/compute/guides/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Migration guides",
+  "pages": ["vercel", "netlify"]
+}

--- a/apps/docs/content/docs/compute/guides/netlify.mdx
+++ b/apps/docs/content/docs/compute/guides/netlify.mdx
@@ -111,19 +111,6 @@ prisma app deploy \
 Use `--http-port 3000` for most Next.js, Nuxt, TanStack Start, and Bun apps. Use `--http-port 4321` for Astro unless your app serves on a different port.
 
 <Accordions type="single">
-  <Accordion title="TanStack Start: pass the server entrypoint">
-    TanStack Start's build outputs a Nitro server to `.output/server/index.mjs`. Pass that path with `--entry`:
-
-    ```bash
-    prisma app deploy \
-      --app my-app \
-      --entry .output/server/index.mjs \
-      --http-port 3000 \
-      --env DATABASE_URL="postgresql://example" \
-      --env AUTH_SECRET="replace-me"
-    ```
-  </Accordion>
-
   <Accordion title="Export Netlify environment variables with the CLI">
     You can export production environment variables locally with the Netlify CLI:
 

--- a/apps/docs/content/docs/compute/guides/netlify.mdx
+++ b/apps/docs/content/docs/compute/guides/netlify.mdx
@@ -1,0 +1,181 @@
+---
+title: Netlify
+description: Move an existing Netlify deployment to Prisma Compute.
+url: /compute/guides/netlify
+metaTitle: "Migrate a Netlify deployment to Prisma Compute"
+metaDescription: Move an existing Netlify deployment to Prisma Compute, including local build preparation, environment variables, deployment, and verification.
+---
+
+Move the same app you deploy on Netlify to Prisma Compute. Keep the Netlify deployment running while you test, then switch traffic after the Compute deployment is healthy.
+
+## Prerequisites
+
+- Node.js 20 or later
+- A Prisma account
+- A local checkout of the repo and branch Netlify deploys
+- Access to the Netlify site's production environment variables
+
+## 1. Prepare the app
+
+Most frameworks need a small config change before Compute can run them. Expand your framework below.
+
+<Accordions type="single" defaultValue="Next.js">
+  <Accordion title="Next.js">
+    Enable the standalone build output:
+
+    ```typescript title="next.config.ts"
+    const nextConfig = { output: "standalone" };
+    export default nextConfig;
+    ```
+
+    If your existing config already exports other options, keep them and add `output: "standalone"`.
+  </Accordion>
+
+  <Accordion title="TanStack Start">
+    TanStack Start on Netlify uses the Netlify vite plugin. When deploying to Prisma Compute, swap it to `nitro` from `nitro/vite`:
+
+    ```typescript title="vite.config.ts"
+    import { defineConfig } from 'vite'
+    import { tanstackStart } from '@tanstack/react-start/plugin/vite'
+    import viteReact from '@vitejs/plugin-react'
+    import tailwindcss from '@tailwindcss/vite'
+    import netlify from '@netlify/vite-plugin-tanstack-start' // [!code --]
+    import { nitro } from 'nitro/vite' // [!code ++]
+
+    const config = defineConfig({
+      resolve: { tsconfigPaths: true },
+      plugins: [
+        netlify(), // [!code --]
+        nitro({ rollupConfig: { external: [/^@sentry\//] } }), // [!code ++]
+        tailwindcss(),
+        tanstackStart(),
+        viteReact(),
+      ],
+    })
+
+    export default config
+    ```
+  </Accordion>
+
+  <Accordion title="Astro">
+    Use the Node adapter in standalone mode:
+
+    ```npm
+    npm install @astrojs/node
+    ```
+
+    ```typescript title="astro.config.mjs"
+    import { defineConfig } from "astro/config";
+    import node from "@astrojs/node";
+
+    export default defineConfig({
+      output: "server",
+      adapter: node({ mode: "standalone" }),
+    });
+    ```
+  </Accordion>
+
+  <Accordion title="Nuxt and Bun">
+    No framework-specific changes are needed. Nuxt and Bun apps build to a standard Node.js server process that Compute can run directly.
+  </Accordion>
+
+  <Accordion title="Netlify-specific behavior">
+    If your app depends on Netlify Functions, Netlify Edge Functions, Netlify build plugins, or `netlify.toml` routing behavior, move that behavior into your framework or server code before switching production traffic.
+  </Accordion>
+</Accordions>
+
+## 2. Build locally
+
+Run the same install and build commands Netlify uses:
+
+```npm
+npm install
+npm run build
+```
+
+Fix local build issues before deploying to Compute.
+
+## 3. Deploy to Compute
+
+Copy the runtime variables your app needs from **Netlify Site configuration > Environment variables**, then deploy from the same local checkout:
+
+```bash
+prisma auth login
+prisma app deploy \
+  --app my-app \
+  --http-port 3000 \
+  --env DATABASE_URL="postgresql://example" \
+  --env AUTH_SECRET="replace-me"
+```
+
+Use `--http-port 3000` for most Next.js, Nuxt, TanStack Start, and Bun apps. Use `--http-port 4321` for Astro unless your app serves on a different port.
+
+<Accordions type="single">
+  <Accordion title="TanStack Start: pass the server entrypoint">
+    TanStack Start's build outputs a Nitro server to `.output/server/index.mjs`. Pass that path with `--entry`:
+
+    ```bash
+    prisma app deploy \
+      --app my-app \
+      --entry .output/server/index.mjs \
+      --http-port 3000 \
+      --env DATABASE_URL="postgresql://example" \
+      --env AUTH_SECRET="replace-me"
+    ```
+  </Accordion>
+
+  <Accordion title="Export Netlify environment variables with the CLI">
+    You can export production environment variables locally with the Netlify CLI:
+
+    ```bash
+    netlify env:list --context production --plain > .env.netlify
+    ```
+
+    Start with runtime values such as `DATABASE_URL`, auth secrets, API keys, and service endpoints. Do not copy Netlify-managed variables unless your app explicitly depends on them.
+  </Accordion>
+
+  <Accordion title="If Netlify masks a secret">
+    Netlify may hide raw values for environment variables marked as secret. If a required secret is masked, copy the production value from your secret manager or the Netlify UI.
+  </Accordion>
+
+  <Accordion title="Update environment variables after deploy">
+    You can add or change variables after the first deploy:
+
+    ```bash
+    prisma app update-env --env AUTH_SECRET="replace-me"
+    prisma app list-env
+    ```
+
+    See [Environment variables](/compute/environment-variables) for the full workflow.
+  </Accordion>
+</Accordions>
+
+## 4. Verify and switch traffic
+
+Open the Compute deployment URL and test the pages, API routes, database reads and writes, auth callbacks, and webhooks that matter for production.
+
+Stream logs while testing:
+
+```bash
+prisma app logs
+```
+
+<Accordions type="single">
+  <Accordion title="Inspect deployments">
+    Inspect a specific deployment if needed:
+
+    ```bash
+    prisma app list-deploys
+    prisma app show-deploy <deployment-id>
+    ```
+  </Accordion>
+</Accordions>
+
+Switch traffic only after the Compute deployment is healthy. Keep the Netlify deployment available as a rollback target until the Compute deployment is serving production traffic successfully.
+
+## Next steps
+
+- [Environment variables](/compute/environment-variables): set secrets and configuration at deploy time or after.
+- [Logs](/compute/logs): stream runtime logs.
+- [Limitations](/compute/limitations): review known Compute caveats.
+- [Next.js quickstart](/compute/quickstart/nextjs): compare your migration against a fresh Next.js Compute deployment.

--- a/apps/docs/content/docs/compute/guides/vercel.mdx
+++ b/apps/docs/content/docs/compute/guides/vercel.mdx
@@ -1,0 +1,171 @@
+---
+title: Vercel
+description: Move an existing Vercel deployment to Prisma Compute.
+url: /compute/guides/vercel
+metaTitle: "Migrate a Vercel deployment to Prisma Compute"
+metaDescription: Move an existing Vercel deployment to Prisma Compute, including local build preparation, environment variables, deployment, and verification.
+---
+
+Move the same app you deploy on Vercel to Prisma Compute. Keep the Vercel deployment running while you test, then switch traffic after the Compute deployment is healthy.
+
+## Prerequisites
+
+- Node.js 20 or later
+- A Prisma account
+- A local checkout of the repo and branch Vercel deploys
+- Access to the Vercel project's production environment variables
+
+## 1. Prepare the app
+
+Most frameworks need a small config change before Compute can run them. Expand your framework below.
+
+<Accordions type="single" defaultValue="Next.js">
+  <Accordion title="Next.js">
+    Enable the standalone build output:
+
+    ```typescript title="next.config.ts"
+    const nextConfig = { output: "standalone" };
+    export default nextConfig;
+    ```
+
+    If your existing config already exports other options, keep them and add `output: "standalone"`.
+  </Accordion>
+
+  <Accordion title="TanStack Start">
+    TanStack Start on Vercel already uses the Nitro vite plugin, which is the same plugin Prisma Compute expects. No changes to `vite.config.ts` are needed.
+  </Accordion>
+
+  <Accordion title="Astro">
+    Use the Node adapter in standalone mode:
+
+    ```npm
+    npm install @astrojs/node
+    ```
+
+    ```typescript title="astro.config.mjs"
+    import { defineConfig } from "astro/config";
+    import node from "@astrojs/node";
+
+    export default defineConfig({
+      output: "server",
+      adapter: node({ mode: "standalone" }),
+    });
+    ```
+  </Accordion>
+
+  <Accordion title="Nuxt and Bun">
+    No framework-specific changes are needed. Nuxt and Bun apps build to a standard Node.js server process that Compute can run directly.
+  </Accordion>
+
+  <Accordion title="Vercel-specific behavior">
+    If your app depends on Vercel Functions, Vercel Edge Functions, or `vercel.json` routing behavior, move that behavior into your framework or server code before switching production traffic.
+  </Accordion>
+</Accordions>
+
+## 2. Build locally
+
+Run the same install and build commands Vercel uses:
+
+```npm
+npm install
+npm run build
+```
+
+Fix local build issues before deploying to Compute.
+
+<Accordions type="single">
+  <Accordion title="Next.js with pnpm">
+    If a standalone build fails with symlink errors, check whether Next.js printed a workspace root warning. A stray lockfile outside the repo can make Next.js choose the wrong root and produce a bad standalone output.
+
+    If the warning points at an accidental `~/package-lock.json`, clean and rebuild:
+
+    ```bash
+    rm -rf .next node_modules ~/package-lock.json
+    pnpm install
+    pnpm build
+    ```
+
+    Then deploy again.
+  </Accordion>
+</Accordions>
+
+## 3. Deploy to Compute
+
+Copy the runtime variables your app needs from **Vercel Project Settings > Environment Variables**, then deploy from the same local checkout:
+
+```bash
+prisma auth login
+prisma app deploy \
+  --app my-app \
+  --http-port 3000 \
+  --env DATABASE_URL="postgresql://example" \
+  --env AUTH_SECRET="replace-me"
+```
+
+Use `--http-port 3000` for most Next.js, Nuxt, TanStack Start, and Bun apps. Use `--http-port 4321` for Astro unless your app serves on a different port.
+
+<Accordions type="single">
+  <Accordion title="TanStack Start: pass the server entrypoint">
+    TanStack Start's build outputs a Nitro server to `.output/server/index.mjs`. Pass that path with `--entry`:
+
+    ```bash
+    prisma app deploy \
+      --app my-app \
+      --entry .output/server/index.mjs \
+      --http-port 3000 \
+      --env DATABASE_URL="postgresql://example" \
+      --env AUTH_SECRET="replace-me"
+    ```
+  </Accordion>
+
+  <Accordion title="Pull Vercel environment variables with the CLI">
+    You can pull production environment variables locally with the Vercel CLI:
+
+    ```bash
+    vercel env pull .env.vercel --environment=production
+    ```
+
+    Start with runtime values such as `DATABASE_URL`, auth secrets, API keys, and service endpoints. Do not copy Vercel-managed variables unless your app explicitly depends on them.
+  </Accordion>
+
+  <Accordion title="Update environment variables after deploy">
+    You can add or change variables after the first deploy:
+
+    ```bash
+    prisma app update-env --env AUTH_SECRET="replace-me"
+    prisma app list-env
+    ```
+
+    See [Environment variables](/compute/environment-variables) for the full workflow.
+  </Accordion>
+</Accordions>
+
+## 4. Verify and switch traffic
+
+Open the Compute deployment URL and test the pages, API routes, database reads and writes, auth callbacks, and webhooks that matter for production.
+
+Stream logs while testing:
+
+```bash
+prisma app logs
+```
+
+<Accordions type="single">
+  <Accordion title="Inspect deployments">
+    Inspect a specific deployment if needed:
+
+    ```bash
+    prisma app list-deploys
+    prisma app show-deploy <deployment-id>
+    ```
+  </Accordion>
+</Accordions>
+
+Switch traffic only after the Compute deployment is healthy. Keep the Vercel deployment available as a rollback target until the Compute deployment is serving production traffic successfully.
+
+## Next steps
+
+- [Environment variables](/compute/environment-variables): set secrets and configuration at deploy time or after.
+- [Logs](/compute/logs): stream runtime logs.
+- [Limitations](/compute/limitations): review known Compute caveats.
+- [Next.js quickstart](/compute/quickstart/nextjs): compare your migration against a fresh Next.js Compute deployment.

--- a/apps/docs/content/docs/compute/guides/vercel.mdx
+++ b/apps/docs/content/docs/compute/guides/vercel.mdx
@@ -105,19 +105,6 @@ prisma app deploy \
 Use `--http-port 3000` for most Next.js, Nuxt, TanStack Start, and Bun apps. Use `--http-port 4321` for Astro unless your app serves on a different port.
 
 <Accordions type="single">
-  <Accordion title="TanStack Start: pass the server entrypoint">
-    TanStack Start's build outputs a Nitro server to `.output/server/index.mjs`. Pass that path with `--entry`:
-
-    ```bash
-    prisma app deploy \
-      --app my-app \
-      --entry .output/server/index.mjs \
-      --http-port 3000 \
-      --env DATABASE_URL="postgresql://example" \
-      --env AUTH_SECRET="replace-me"
-    ```
-  </Accordion>
-
   <Accordion title="Pull Vercel environment variables with the CLI">
     You can pull production environment variables locally with the Vercel CLI:
 

--- a/apps/docs/content/docs/compute/meta.json
+++ b/apps/docs/content/docs/compute/meta.json
@@ -7,6 +7,8 @@
     "index",
     "---Quickstart---",
     "...quickstart",
+    "---Migration guides---",
+    "...guides",
     "---Reference---",
     "environment-variables",
     "logs",


### PR DESCRIPTION
## Summary

Adds migration guides for moving existing Netlify and Vercel deployments to Prisma Compute, in both the public and internal docs.

- `compute/guides/netlify.mdx`, `compute/guides/vercel.mdx` — public migration guides
- `compute-internal/guides/netlify.mdx`, `compute-internal/guides/vercel.mdx` — internal versions using `@prisma/cli@preview`

Each guide covers prerequisites, framework prep (Next.js, TanStack Start, Astro, Nuxt, Bun), local build, deploy, and traffic cutover. Framework prep is in expand-by-default accordions so users can jump straight to their stack.

TanStack Start specifics:
- Netlify guide shows the `vite.config.ts` swap from `@netlify/vite-plugin-tanstack-start` → `nitro/vite` (diff-highlighted)
- Vercel guide notes no `vite.config.ts` change is needed since Vercel already uses Nitro
- Both guides surface the `--entry .output/server/index.mjs` flag in the deploy step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Migration guides section with step-by-step Vercel and Netlify migration guides for Prisma Compute
  * Updated TanStack Start quickstart with explicit multi-line deploy commands and required entry-point configuration
  * Expanded limitations and framework support docs with Next.js (pnpm) troubleshooting, Astro notes, and Nitro/TanStack deployment guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->