### PR TITLE
Enhance documentation clarity for prisma-next repo

### DIFF
--- a/apps/blog/content/blog/prisma-next-call-for-extension-authors/index.mdx
+++ b/apps/blog/content/blog/prisma-next-call-for-extension-authors/index.mdx
@@ -127,6 +127,8 @@ Clone [`prisma/prisma-next`](https://pris.ly/pn-gh), point your coding agent at 
 
 The repo is dense with architecture docs, architecture decision record (ADRs), SPI READMEs, and reference extensions: enough context that an agent can absorb it in seconds and scaffold a working pack from your description alone, without you reading a line of it first.
 
+The repo is packed with architecture docs, architecture decision records (ADRs), SPI READMEs, and reference extensions. Together, they give agents enough context to understand the system in seconds and scaffold a working pack from your description alone, without you having to read through the docs first. You can also browse the docs yourself [here](https://github.com/prisma/prisma-next/tree/main/docs).
+
 The result is normal TypeScript you can read, edit, and iterate on like any other code, and it's dramatically faster than building one by hand from documentation.
 
 If you'd rather start from a known-good template yourself, pick the existing extension closest to what you want and copy it:


### PR DESCRIPTION
Clarified the description of the repo's contents and usage for agents, emphasizing the ease of scaffolding a working pack without prior reading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the "fastest way to start" section with clearer guidance on leveraging documentation resources and reference extensions to quickly scaffold extensions, including a direct link to the documentation directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->