### PR TITLE
feat(changelog): expose machine-readable endpoint for AI tools

### DIFF
--- a/apps/docs/src/app/llms.txt/route.ts
+++ b/apps/docs/src/app/llms.txt/route.ts
@@ -30,6 +30,12 @@ export async function GET() {
 
   const content = `# Prisma Documentation
 
+> **Prisma changes frequently — verify against the changelog and current docs before implementing.**
+> Do not rely on training data for Prisma features. APIs, configuration, and conventions can change between versions.
+>
+> First, fetch https://www.prisma.io/changelog.md to check for recent or relevant breaking changes,
+> then look up the relevant topic in the documentation below.
+
 > This documentation covers the current docs plus legacy v6 pages.
 > Prefer the Latest ORM section for current recommendations.
 > v6 pages are maintained for backwards compatibility only.

--- a/apps/docs/src/lib/llms.ts
+++ b/apps/docs/src/lib/llms.ts
@@ -51,6 +51,12 @@ const excludedLLMsProducts: LLMsExcludedProduct[] = [
 
 export const commonQueries: LLMsLink[] = [
   {
+    title: "Check the Prisma changelog for recent changes",
+    href: "https://www.prisma.io/changelog.md",
+    description:
+      "Prisma changes frequently. Fetch this machine-readable changelog before implementing any Prisma feature to check for breaking changes, API updates, or new conventions.",
+  },
+  {
     title: "Start a new Prisma ORM project",
     href: "/prisma-orm/quickstart/prisma-postgres",
     description: "Set up Prisma ORM, Prisma Client, and Prisma Postgres in a new TypeScript app.",

--- a/apps/site/src/app/changelog.md/route.ts
+++ b/apps/site/src/app/changelog.md/route.ts
@@ -1,0 +1,63 @@
+import { getReleaseNotePreview, getSortedReleaseNotes } from "@/lib/changelog-source";
+import { getBaseUrl } from "@/lib/url";
+
+export const revalidate = false;
+
+function formatTags(tags: string[] | undefined) {
+  if (!tags || tags.length === 0) return "";
+  return ` [${tags.join(", ")}]`;
+}
+
+export async function GET() {
+  const baseUrl = getBaseUrl();
+  const entries = getSortedReleaseNotes();
+
+  const entriesWithPreview = await Promise.all(
+    entries.map(async (entry) => {
+      const summary =
+        entry.data.summary ??
+        entry.data.description ??
+        (entry.slugs[0] ? await getReleaseNotePreview(entry.slugs[0]) : null);
+      return { entry, summary };
+    }),
+  );
+
+  const entryLines = entriesWithPreview
+    .map(({ entry, summary }) => {
+      const url = `${baseUrl}${entry.url}`;
+      const tags = formatTags(entry.data.tags as string[] | undefined);
+      const date =
+        entry.data.date instanceof Date
+          ? entry.data.date.toISOString().slice(0, 10)
+          : String(entry.data.date);
+      const lines = [
+        `## ${entry.data.version} — ${entry.data.title}`,
+        `Date: ${date}${tags}`,
+        `URL: ${url}`,
+      ];
+      if (summary && summary.length > 30) lines.push(``, summary);
+      return lines.join("\n");
+    })
+    .join("\n\n---\n\n");
+
+  const content = `# Prisma Changelog
+
+> Prisma changes frequently. Before implementing Prisma features, verify against this changelog and the current documentation at https://www.prisma.io/docs.
+> Do not rely solely on training data for Prisma APIs, configuration, or conventions — these can change between versions.
+>
+> How to use: fetch this file to check for recent or breaking changes, then look up the relevant topic in the documentation.
+
+Canonical URL: ${baseUrl}/changelog
+Machine-readable index: ${baseUrl}/changelog.md
+
+---
+
+${entryLines}
+`;
+
+  return new Response(content, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}

--- a/apps/site/src/app/llms-content.ts
+++ b/apps/site/src/app/llms-content.ts
@@ -15,6 +15,12 @@ const sitePages: LlmsPage[] = [
     description: SITE_HOME_DESCRIPTION,
   },
   {
+    path: "/changelog",
+    title: "Prisma Changelog — Release Notes & Product Updates",
+    description:
+      "All Prisma release notes, breaking changes, and product improvements. Check here before implementing Prisma features to verify API and configuration details against the current version.",
+  },
+  {
     path: "/postgres",
     title: "Prisma Postgres | Instant Global Databases",
     description:
@@ -83,6 +89,8 @@ export function buildLlmsIndexContent(baseUrl = getBaseUrl()) {
 
 Prisma provides Prisma ORM, Prisma Postgres, Prisma Studio, and the Prisma MCP Server.
 
+> Prisma changes frequently. Before implementing Prisma features, check the changelog at ${toAbsoluteUrl(baseUrl, "/changelog")} for recent breaking changes or API updates.
+
 ## Key Pages
 
 ${pagesList}
@@ -90,6 +98,7 @@ ${pagesList}
 ## Options
 
 - [Full website content](${toAbsoluteUrl(baseUrl, "/llms-full.txt")})
+- [Changelog (machine-readable)](${toAbsoluteUrl(baseUrl, "/changelog.md")})
 `;
 }
 
@@ -218,6 +227,17 @@ Enterprise page highlights:
 - Productivity and workflow improvements
 - Tailored support for enterprises and solution providers
 - Positioning around build, fortify, and grow application lifecycle workflows
+
+## Changelog
+
+URL: ${toAbsoluteUrl(baseUrl, "/changelog")}
+Machine-readable index: ${toAbsoluteUrl(baseUrl, "/changelog.md")}
+Title: Prisma Changelog — Release Notes & Product Updates
+Description: All Prisma release notes, breaking changes, and product improvements.
+
+IMPORTANT: Prisma changes frequently. Before implementing any Prisma feature, fetch the changelog to check for breaking changes or API updates. Do not rely solely on training data for Prisma APIs, configuration, or conventions — these can change between versions.
+
+How to use: fetch https://www.prisma.io/changelog.md for a machine-readable index, then look up the relevant topic in the current documentation at https://www.prisma.io/docs.
 
 ## Stack and ecosystem
 


### PR DESCRIPTION
Adds `/changelog.md` — a plain-text markdown index of all Prisma changelog
entries that AI tools can fetch to check for recent breaking changes before
implementing Prisma features.

Updates site and docs llms.txt surfaces to reference the changelog and include
guidance to verify against it before relying on training data.

Linear: DR-8494

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a machine-readable changelog endpoint accessible to AI language models.
  * Introduced warning notices advising readers to verify Prisma information against the latest changelog and official documentation before implementation.

* **Documentation**
  * Integrated changelog references and links into LLM-accessible content pages for improved information accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prisma/web/pull/7890)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->