### PR TITLE
fix(docs): make Management API Postman collection deterministic

### DIFF
--- a/apps/docs/public/prisma-management-api.postman_collection.json
+++ b/apps/docs/public/prisma-management-api.postman_collection.json
@@ -1,7 +1,6 @@
 {
   "item": [
     {
-      "id": "d7ec9221-a84b-4907-96c4-be74b76edf43",
       "name": "Projects",
       "description": {
         "content": "",
@@ -9,7 +8,6 @@
       },
       "item": [
         {
-          "id": "f6c2f680-54ab-4735-95f6-e2cb5141901b",
           "name": "Get list of projects",
           "request": {
             "name": "Get list of projects",
@@ -50,7 +48,6 @@
           },
           "response": [
             {
-              "id": "d43e8a8a-0a83-421e-8818-65aa5ebc6f01",
               "name": "Returns the list of projects.",
               "originalRequest": {
                 "url": {
@@ -103,7 +100,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "5eb63452-c41c-4b70-a03d-3102d50788f3",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -162,7 +158,6 @@
           }
         },
         {
-          "id": "1cbf0094-b61d-404b-9dfe-202d6c88d2e8",
           "name": "Create project with a postgres database",
           "request": {
             "name": "Create project with a postgres database",
@@ -205,7 +200,6 @@
           },
           "response": [
             {
-              "id": "fcaf6b65-3035-4616-936f-5e215a9c7f25",
               "name": "New project created.",
               "originalRequest": {
                 "url": {
@@ -257,7 +251,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "e2b91ffe-6c29-4fbc-bc64-2b15520fe0f5",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -315,7 +308,6 @@
           }
         },
         {
-          "id": "c3173a2e-cb95-449f-8c03-6047fb8549ee",
           "name": "Delete project",
           "request": {
             "name": "Delete project",
@@ -354,7 +346,6 @@
           },
           "response": [
             {
-              "id": "dc9f353b-6ded-4338-96d4-fd68e37688fe",
               "name": "Project deleted.",
               "originalRequest": {
                 "url": {
@@ -403,7 +394,6 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "d4b4c2c7-69c0-435a-9f31-5cbbe06fc398",
               "name": "Project cannot be deleted due to existing dependencies.",
               "originalRequest": {
                 "url": {
@@ -456,7 +446,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "7c1976c4-489f-4a17-ac35-6c2b193638ed",
               "name": "Unauthorized",
               "originalRequest": {
                 "url": {
@@ -509,7 +498,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "7b0b1806-e056-47ab-be1b-6e52eac9c205",
               "name": "Project with the specified ID was not found",
               "originalRequest": {
                 "url": {
@@ -568,7 +556,6 @@
           }
         },
         {
-          "id": "1cbbd530-09f4-444c-aae6-9f76a250a862",
           "name": "Get project",
           "request": {
             "name": "Get project",
@@ -607,7 +594,6 @@
           },
           "response": [
             {
-              "id": "48ab93e9-8417-43fb-83ee-375911430d93",
               "name": "Project retrieved.",
               "originalRequest": {
                 "url": {
@@ -660,7 +646,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "b0d010ae-10db-43d1-b906-ef28c6b1b47c",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -713,7 +698,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "4cc390c0-4607-4986-89cb-28f3e55823da",
               "name": "Project with the specified ID was not found.",
               "originalRequest": {
                 "url": {
@@ -772,7 +756,6 @@
           }
         },
         {
-          "id": "4e7c8ebf-4e4e-488f-abdb-d9334ef7a29d",
           "name": "Update project",
           "request": {
             "name": "Update project",
@@ -824,7 +807,6 @@
           },
           "response": [
             {
-              "id": "672f906a-a2c8-4f99-8ed7-5650a01330f4",
               "name": "Project updated.",
               "originalRequest": {
                 "url": {
@@ -885,7 +867,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "79701ebf-12be-45fd-8d06-d4333d8ade5e",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -946,7 +927,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "e47f0903-8db9-4e5c-8145-c1e443c80da5",
               "name": "Actor does not have access to the project.",
               "originalRequest": {
                 "url": {
@@ -1007,7 +987,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "eb0da0ae-5ae2-428a-b4c8-b549cb2a860c",
               "name": "Project with the specified ID was not found.",
               "originalRequest": {
                 "url": {
@@ -1068,7 +1047,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "b3bc24c4-abfe-4de4-81ff-28dc195bc5a8",
               "name": "Validation failed.",
               "originalRequest": {
                 "url": {
@@ -1135,7 +1113,6 @@
           }
         },
         {
-          "id": "afc1d303-77ae-4e80-93b8-0d77d96b6caa",
           "name": "Transfer project",
           "request": {
             "name": "Transfer project",
@@ -1188,7 +1165,6 @@
           },
           "response": [
             {
-              "id": "dc04e6f1-5586-40af-b065-856d250bd53b",
               "name": "Project transferred",
               "originalRequest": {
                 "url": {
@@ -1246,7 +1222,6 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0542bda5-e3ae-4e9f-85d1-dc478a03afc3",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -1308,7 +1283,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "394d8e92-2601-4cd9-85f1-c8438a03d2bf",
               "name": "Project with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -1379,7 +1353,6 @@
       "event": []
     },
     {
-      "id": "d8495499-dad5-4f68-abd2-02d9b7832334",
       "name": "Databases",
       "description": {
         "content": "",
@@ -1387,7 +1360,6 @@
       },
       "item": [
         {
-          "id": "dba63b25-4161-4e12-ba3c-68fcc4a0adb2",
           "name": "List databases",
           "request": {
             "name": "List databases",
@@ -1443,7 +1415,6 @@
           },
           "response": [
             {
-              "id": "27721ef5-2f72-4282-9460-737a29a3f4ce",
               "name": "Returns the list of databases.",
               "originalRequest": {
                 "url": {
@@ -1508,7 +1479,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "38f1cc3f-a8b5-4f7d-ad68-b2fc16e3eab6",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -1573,7 +1543,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "b251aac0-ac6a-4818-beca-6551ef9b1da5",
               "name": "Actor does not have access to the requested databases.",
               "originalRequest": {
                 "url": {
@@ -1644,7 +1613,6 @@
           }
         },
         {
-          "id": "ce8374c6-5cbb-41c5-8d32-c3f8615e8aac",
           "name": "Create database /v1/databases",
           "request": {
             "name": "Create database",
@@ -1687,7 +1655,6 @@
           },
           "response": [
             {
-              "id": "e3202644-4fbd-41df-af8a-93649b12b45f",
               "name": "Created a new database.",
               "originalRequest": {
                 "url": {
@@ -1739,7 +1706,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "dbb8a947-13bf-4a96-bccb-b853d8a46662",
               "name": "Invalid request parameters.",
               "originalRequest": {
                 "url": {
@@ -1791,7 +1757,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "a87a5371-c19c-420c-8495-883c7c36abf5",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -1843,7 +1808,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "52438cce-1486-4f0b-8a8e-74f239a3896e",
               "name": "Actor does not have access to the specified project.",
               "originalRequest": {
                 "url": {
@@ -1895,7 +1859,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "22f2de45-b872-4ebd-bc7e-8e0298ea5ef9",
               "name": "Project not found.",
               "originalRequest": {
                 "url": {
@@ -1953,7 +1916,6 @@
           }
         },
         {
-          "id": "5bbe97b7-b759-42bb-bdfc-fcb821938dd4",
           "name": "Get database",
           "request": {
             "name": "Get database",
@@ -1992,7 +1954,6 @@
           },
           "response": [
             {
-              "id": "5ef92672-f85b-4f06-81a1-fbaa0a68b5a7",
               "name": "Returned the database with the given ID.",
               "originalRequest": {
                 "url": {
@@ -2045,7 +2006,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "3c9b0ed7-87c1-48de-8a74-7db40ef24d80",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -2098,7 +2058,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "d27deaf2-646f-481d-8fd7-c4fe01de9507",
               "name": "Actor does not have access to the database.",
               "originalRequest": {
                 "url": {
@@ -2151,7 +2110,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "4714efdf-b581-4d47-90ff-24bf3fcb5627",
               "name": "Database with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -2210,7 +2168,6 @@
           }
         },
         {
-          "id": "483ca4dd-f9dd-4a60-8c5f-23a3d93975dd",
           "name": "Update database",
           "request": {
             "name": "Update database",
@@ -2262,7 +2219,6 @@
           },
           "response": [
             {
-              "id": "42f68609-e462-4eb1-bbde-b632c37fc7de",
               "name": "Updated the database.",
               "originalRequest": {
                 "url": {
@@ -2323,7 +2279,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "b4183f94-2b7b-44d9-9e9a-9c937a8e30ab",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -2384,7 +2339,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "c7c1a6f3-2013-4a9b-81d5-a6d84e67fe07",
               "name": "Actor does not have access to the database.",
               "originalRequest": {
                 "url": {
@@ -2445,7 +2399,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "391c1eaa-cbc8-4cdd-af36-d0057f873685",
               "name": "Database with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -2512,7 +2465,6 @@
           }
         },
         {
-          "id": "40c5db16-ad40-4e3b-87f1-3b094aa8047d",
           "name": "Delete database",
           "request": {
             "name": "Delete database",
@@ -2551,7 +2503,6 @@
           },
           "response": [
             {
-              "id": "92473f3f-e631-44e5-9bd1-5109ad343992",
               "name": "Deleted the database successfully.",
               "originalRequest": {
                 "url": {
@@ -2600,7 +2551,6 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "0fc6c081-10d1-4e5f-b25e-41114258ddfb",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -2653,7 +2603,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "07941526-e49f-41e5-b3fa-a5b6d60a4137",
               "name": "Cannot delete the default environment.",
               "originalRequest": {
                 "url": {
@@ -2706,7 +2655,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "5c7f6976-21af-4559-be10-13fa23302b30",
               "name": "Database with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -2765,7 +2713,6 @@
           }
         },
         {
-          "id": "d7b10051-90a2-4878-ae25-0d94213b9777",
           "name": "Restore database (destructive)",
           "request": {
             "name": "Restore database (destructive)",
@@ -2818,7 +2765,6 @@
           },
           "response": [
             {
-              "id": "f2e16fb0-5cce-4f68-bc17-241f0114a950",
               "name": "Database restore initiated. The database status will be \"recovering\" until the restore completes.",
               "originalRequest": {
                 "url": {
@@ -2880,7 +2826,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "29d8b549-1071-4e7c-ad5d-898d4870100f",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -2942,7 +2887,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "6c60aff2-696d-4d45-890c-9d0b2765577b",
               "name": "Target database, source database, or backup not found.",
               "originalRequest": {
                 "url": {
@@ -3004,7 +2948,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "71a1e398-ebfb-4348-bb54-c2076ba48693",
               "name": "Target database is currently provisioning or recovering and cannot be restored.",
               "originalRequest": {
                 "url": {
@@ -3066,7 +3009,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "12ee93dc-4175-4ea3-a2e6-d3353adc7e97",
               "name": "Invalid source type or backup not usable.",
               "originalRequest": {
                 "url": {
@@ -3134,7 +3076,6 @@
           }
         },
         {
-          "id": "03a8a778-ec6b-4cc8-9b56-d402660a6115",
           "name": "Get list of databases",
           "request": {
             "name": "Get list of databases",
@@ -3185,7 +3126,6 @@
           },
           "response": [
             {
-              "id": "4f4909e2-8b86-48fd-b67c-5f217ced82eb",
               "name": "Returned the databases for the given project ID.",
               "originalRequest": {
                 "url": {
@@ -3248,7 +3188,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "073f2efb-d38e-4f00-b795-8430587255ff",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -3311,7 +3250,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "02f2eaa5-4fbf-45dc-b498-6c86a3632649",
               "name": "Project with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -3380,7 +3318,6 @@
           }
         },
         {
-          "id": "64483ca9-c0e8-4432-a62c-8a7a84d564c1",
           "name": "Create database /v1/projects/{projectId}/databases",
           "request": {
             "name": "Create database",
@@ -3433,7 +3370,6 @@
           },
           "response": [
             {
-              "id": "e62ade0f-ac29-4c8b-b267-2ac5ba40fc24",
               "name": "Created a new database for the project.",
               "originalRequest": {
                 "url": {
@@ -3495,7 +3431,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "2e53e97c-a9f5-4a8e-b205-788b1253d4bb",
               "name": "The request is invalid due to missing or invalid parameters.",
               "originalRequest": {
                 "url": {
@@ -3557,7 +3492,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "de63c2ab-748f-40c9-b0d4-3583968cfc01",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -3619,7 +3553,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "a16ae526-bf50-45a0-91fb-7b6a2f5d2120",
               "name": "Project does not belong to the service token’s workspace.",
               "originalRequest": {
                 "url": {
@@ -3690,7 +3623,6 @@
       "event": []
     },
     {
-      "id": "f01d2c43-662d-4860-ab65-9c9e84ac69f0",
       "name": "Databases Connections",
       "description": {
         "content": "",
@@ -3698,7 +3630,6 @@
       },
       "item": [
         {
-          "id": "2edf9c99-ab89-46e2-9b9a-55bbedd03f80",
           "name": "Get list of database connections",
           "request": {
             "name": "Get list of database connections",
@@ -3749,7 +3680,6 @@
           },
           "response": [
             {
-              "id": "5e8d8bae-d0c3-47bf-b8d6-12dde6771e9f",
               "name": "Returned all connections for the given database.",
               "originalRequest": {
                 "url": {
@@ -3812,7 +3742,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "049f61bb-325b-4065-a66a-a4eb5d0d0316",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -3881,7 +3810,6 @@
           }
         },
         {
-          "id": "423cd467-77c5-4013-bad6-c35eb6fb19fe",
           "name": "Create database connection string",
           "request": {
             "name": "Create database connection string",
@@ -3934,7 +3862,6 @@
           },
           "response": [
             {
-              "id": "cdbcf3fa-fb16-4946-8753-5a1303b365cb",
               "name": "Created a new connection string for the database.",
               "originalRequest": {
                 "url": {
@@ -3996,7 +3923,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "630aa00b-e44d-42f4-9ed4-80c1c1a5ad87",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -4058,7 +3984,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "c06714b7-9675-4661-a5ed-fc257959209d",
               "name": "Database with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -4129,7 +4054,6 @@
       "event": []
     },
     {
-      "id": "ac9bb9bf-e203-4fd3-8ec2-d65dfb5b14d6",
       "name": "Database Backups",
       "description": {
         "content": "",
@@ -4137,7 +4061,6 @@
       },
       "item": [
         {
-          "id": "bbae2354-408d-4e1e-a1e8-9d532ed7b835",
           "name": "Get list of backups",
           "request": {
             "name": "Get list of backups",
@@ -4183,7 +4106,6 @@
           },
           "response": [
             {
-              "id": "90c925ad-0d7d-467b-ab67-205c16571791",
               "name": "Returned backups for the given database.",
               "originalRequest": {
                 "url": {
@@ -4242,7 +4164,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "2ad20872-98e8-4b9a-8c6e-61e4a420695a",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -4301,7 +4222,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "4ed06382-f89c-48f0-baeb-64024a7c2335",
               "name": "Database with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -4360,7 +4280,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "86a0bd19-012f-40a7-ab9d-b8d6abeac594",
               "name": "Remote database backups are not supported",
               "originalRequest": {
                 "url": {
@@ -4428,7 +4347,6 @@
       "event": []
     },
     {
-      "id": "b36a35f6-6b60-4bf0-a164-4b664a1ab950",
       "name": "Database Usage",
       "description": {
         "content": "",
@@ -4436,7 +4354,6 @@
       },
       "item": [
         {
-          "id": "058fb809-5772-46d2-bef1-d9e46ed89ffa",
           "name": "Get database usage metrics",
           "request": {
             "name": "Get database usage metrics",
@@ -4487,7 +4404,6 @@
           },
           "response": [
             {
-              "id": "17a79370-4d88-429e-a92b-90fb1d3a4ca6",
               "name": "Returned usage metrics for the given database.",
               "originalRequest": {
                 "url": {
@@ -4550,7 +4466,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "4bcfea60-beeb-4dd8-a940-44587b811e3a",
               "name": "Invalid request parameters",
               "originalRequest": {
                 "url": {
@@ -4613,7 +4528,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "6e3459f1-c8bc-4f4c-acb6-541dec61d4a4",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -4676,7 +4590,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "a53c6e18-4180-41bf-892d-619388e0e836",
               "name": "Database with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -4739,7 +4652,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "93595c92-ae3e-4a64-b282-cb3473b086ff",
               "name": "Error occurred while fetching metrics",
               "originalRequest": {
                 "url": {
@@ -4811,7 +4723,6 @@
       "event": []
     },
     {
-      "id": "90af62f4-d57d-45f9-8d89-947f41f907d1",
       "name": "Connections",
       "description": {
         "content": "",
@@ -4819,7 +4730,6 @@
       },
       "item": [
         {
-          "id": "ae521c6a-1f07-4089-863e-af0fa3c92883",
           "name": "List connections",
           "request": {
             "name": "List connections",
@@ -4865,7 +4775,6 @@
           },
           "response": [
             {
-              "id": "08bc348d-524b-43b8-96f0-06e7e94c4ab6",
               "name": "Returned list of connections.",
               "originalRequest": {
                 "url": {
@@ -4922,7 +4831,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "9e3b6909-803c-4c08-b863-f2b4a960b94e",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -4985,7 +4893,6 @@
           }
         },
         {
-          "id": "d8e2ff89-0d4a-4539-9fed-65d7e0d1ea38",
           "name": "Create connection",
           "request": {
             "name": "Create connection",
@@ -5028,7 +4935,6 @@
           },
           "response": [
             {
-              "id": "e22206e0-a4a0-4565-83a5-b9b2618d6856",
               "name": "Created a new connection.",
               "originalRequest": {
                 "url": {
@@ -5080,7 +4986,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "52149a9f-0b0d-448f-8ee7-b0762c996eec",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -5132,7 +5037,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "25d7992e-f8ac-424b-a416-c7a84d6809d1",
               "name": "Database with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -5190,7 +5094,6 @@
           }
         },
         {
-          "id": "547ec1a0-a866-4f43-851a-71e5b7df9765",
           "name": "Get connection",
           "request": {
             "name": "Get connection",
@@ -5229,7 +5132,6 @@
           },
           "response": [
             {
-              "id": "bd39114b-517d-4ff1-9e9d-1cc525b5ba56",
               "name": "Returned the connection.",
               "originalRequest": {
                 "url": {
@@ -5282,7 +5184,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "a66df0e9-e0b3-4e6e-8f4a-7d426fa5bd1c",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -5335,7 +5236,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "a883f517-2edf-42bd-95f5-09868f349ef0",
               "name": "Connection with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -5394,7 +5294,6 @@
           }
         },
         {
-          "id": "2841e852-16b2-4458-a2a8-16d0418a2df2",
           "name": "Delete connection",
           "request": {
             "name": "Delete connection",
@@ -5433,7 +5332,6 @@
           },
           "response": [
             {
-              "id": "5493d5e8-d49a-4fed-94f0-e07f1d22befb",
               "name": "Deleted the connection.",
               "originalRequest": {
                 "url": {
@@ -5482,7 +5380,6 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "265dfa55-37cf-471f-93aa-9951838c75ca",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -5535,7 +5432,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "7b48709a-40d0-447e-8d91-85869981150d",
               "name": "Connection with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -5594,7 +5490,6 @@
           }
         },
         {
-          "id": "dd61d161-2ade-4a3a-9019-b93e5b3acf2f",
           "name": "Rotate connection credentials",
           "request": {
             "name": "Rotate connection credentials",
@@ -5634,7 +5529,6 @@
           },
           "response": [
             {
-              "id": "d31083db-8b70-46fe-a717-b32809498920",
               "name": "Rotated connection credentials.",
               "originalRequest": {
                 "url": {
@@ -5688,7 +5582,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "744554b8-5881-4a87-b100-dbc430a7e81d",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -5742,7 +5635,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "3f183bad-f9af-4574-8e70-23f94241a541",
               "name": "Connection with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -5805,7 +5697,6 @@
       "event": []
     },
     {
-      "id": "7d16c20c-285e-41de-8a26-11a6fdb4ccee",
       "name": "Integrations",
       "description": {
         "content": "",
@@ -5813,7 +5704,6 @@
       },
       "item": [
         {
-          "id": "ace8191e-69ce-41ed-97a8-0c18bc6d35b9",
           "name": "Get list of integrations /v1/integrations",
           "request": {
             "name": "Get list of integrations",
@@ -5860,7 +5750,6 @@
           },
           "response": [
             {
-              "id": "22d4abf6-99e6-46c9-8df4-cfebea62db26",
               "name": "Returned the integrations for the given workspace.",
               "originalRequest": {
                 "url": {
@@ -5917,7 +5806,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "306ec83d-5f63-4033-80de-7a8c80d32006",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -5980,7 +5868,6 @@
           }
         },
         {
-          "id": "44fd2231-a826-46fc-bc84-7e59bb2873f5",
           "name": "Get integration by ID",
           "request": {
             "name": "Get integration by ID",
@@ -6019,7 +5906,6 @@
           },
           "response": [
             {
-              "id": "7f3e1829-d9d8-43d2-b478-ccde747c4784",
               "name": "Returned the integration.",
               "originalRequest": {
                 "url": {
@@ -6072,7 +5958,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "98e70a51-7f36-45ff-9827-d33da081695d",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -6125,7 +6010,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "7192ce5b-85ce-4e11-a6f3-dde80a1f0a78",
               "name": "Integration with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -6184,7 +6068,6 @@
           }
         },
         {
-          "id": "5f8ec7a6-75be-4d15-8b95-f6b99f6a9e66",
           "name": "Delete integration",
           "request": {
             "name": "Delete integration",
@@ -6223,7 +6106,6 @@
           },
           "response": [
             {
-              "id": "0e120a38-b7c9-43e4-ad44-acccdd0cd386",
               "name": "Revoked the integration tokens.",
               "originalRequest": {
                 "url": {
@@ -6272,7 +6154,6 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "00423a8b-5662-4a28-b60b-2b7b77a1cc68",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -6325,7 +6206,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "497b7e60-1feb-4118-b33c-63318243cc35",
               "name": "Integration with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -6384,7 +6264,6 @@
           }
         },
         {
-          "id": "70e6dab2-2077-4295-9aeb-716bf804eb12",
           "name": "Get list of integrations /v1/workspaces/{workspaceId}/integrations",
           "request": {
             "name": "Get list of integrations",
@@ -6435,7 +6314,6 @@
           },
           "response": [
             {
-              "id": "eaefb721-f9fd-42eb-8f1f-256e2d857e69",
               "name": "Returned the integrations for the given workspace ID.",
               "originalRequest": {
                 "url": {
@@ -6498,7 +6376,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "f76a086d-f06d-42df-bdae-d7efcd0e1fbc",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -6561,7 +6438,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "8ccfc1d1-6530-4b67-9cac-8201717bfb3f",
               "name": "Workspace with the given ID was not found.",
               "originalRequest": {
                 "url": {
@@ -6630,7 +6506,6 @@
           }
         },
         {
-          "id": "fd9cb02a-bbe0-4ad1-a605-8b5ec998f7dd",
           "name": "Revoke integration tokens",
           "request": {
             "name": "Revoke integration tokens",
@@ -6678,7 +6553,6 @@
           },
           "response": [
             {
-              "id": "f81d338b-e720-4cec-b2f3-57663835debf",
               "name": "Revoked the integration tokens.",
               "originalRequest": {
                 "url": {
@@ -6736,7 +6610,6 @@
               "_postman_previewlanguage": "text"
             },
             {
-              "id": "2fcb6f28-a224-400d-8394-cc140265f291",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -6798,7 +6671,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "45f63a48-bf3e-42c7-9361-fc66f500cf95",
               "name": "Integration with the given client ID was not found.",
               "originalRequest": {
                 "url": {
@@ -6869,7 +6741,6 @@
       "event": []
     },
     {
-      "id": "83ebca80-366a-43c7-8eed-3424e73d62c8",
       "name": "Workspaces",
       "description": {
         "content": "",
@@ -6877,7 +6748,6 @@
       },
       "item": [
         {
-          "id": "062ade0c-cfd0-4ce0-836d-3387c24fae4c",
           "name": "Get list of workspaces",
           "request": {
             "name": "Get list of workspaces",
@@ -6918,7 +6788,6 @@
           },
           "response": [
             {
-              "id": "60eeaaeb-3ede-47d9-a028-9c7d5080ce78",
               "name": "Returns the list of workspaces the current token can access.",
               "originalRequest": {
                 "url": {
@@ -6971,7 +6840,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "59f7ffd7-f748-4014-adaa-9761fc9cadb7",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -7030,7 +6898,6 @@
           }
         },
         {
-          "id": "e5b33285-0511-4561-b930-ca053f3259a8",
           "name": "Get workspace",
           "request": {
             "name": "Get workspace",
@@ -7069,7 +6936,6 @@
           },
           "response": [
             {
-              "id": "4cc21e4c-824c-4c44-adff-336eab124d2f",
               "name": "Workspace retrieved.",
               "originalRequest": {
                 "url": {
@@ -7122,7 +6988,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "5d12354a-a037-4387-b835-8c3cb17428b5",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -7175,7 +7040,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "f629a5f9-57b1-4b79-8bc5-863282306464",
               "name": "Workspace with the specified ID was not found.",
               "originalRequest": {
                 "url": {
@@ -7237,7 +7101,6 @@
       "event": []
     },
     {
-      "id": "3ea5fee8-32c7-47bc-bcfc-5c6fb01d86e8",
       "name": "Regions",
       "description": {
         "content": "",
@@ -7245,7 +7108,6 @@
       },
       "item": [
         {
-          "id": "c2c54fa3-bc57-48c9-88ce-7a94d9fb183e",
           "name": "Get all regions",
           "request": {
             "name": "Get all regions",
@@ -7281,7 +7143,6 @@
           },
           "response": [
             {
-              "id": "d4255a0b-084c-46a1-b2ce-cd05527a5dc8",
               "name": "Returns all available regions.",
               "originalRequest": {
                 "url": {
@@ -7330,7 +7191,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "3ee85456-53c3-433a-bd00-85352e27353f",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -7388,7 +7248,6 @@
       "event": []
     },
     {
-      "id": "06b82020-be55-43b8-8c14-e209add9838c",
       "name": "Misc",
       "description": {
         "content": "",
@@ -7396,7 +7255,6 @@
       },
       "item": [
         {
-          "id": "df02e032-3083-445c-becf-bae656a2fef4",
           "name": "Get Prisma Postgres regions",
           "request": {
             "name": "Get Prisma Postgres regions",
@@ -7427,7 +7285,6 @@
           },
           "response": [
             {
-              "id": "b60821bf-8897-48fe-8a0c-d6db1cbce029",
               "name": "Returns all available regions for Prisma Postgres.",
               "originalRequest": {
                 "url": {
@@ -7472,7 +7329,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "180830be-3118-4b47-80f2-3fc9a51dec8f",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -7523,7 +7379,6 @@
           }
         },
         {
-          "id": "afe24089-2635-4b3c-bc92-3b9e3a3ce07a",
           "name": "Get Prisma Accelerate regions",
           "request": {
             "name": "Get Prisma Accelerate regions",
@@ -7554,7 +7409,6 @@
           },
           "response": [
             {
-              "id": "0764b83a-05dd-4734-af67-3f2e804112c9",
               "name": "Returns all available regions for Prisma Accelerate.",
               "originalRequest": {
                 "url": {
@@ -7599,7 +7453,6 @@
               "_postman_previewlanguage": "json"
             },
             {
-              "id": "20376c94-0ec5-40bf-8ba9-a9028ed56569",
               "name": "Missing or invalid authorization token.",
               "originalRequest": {
                 "url": {
@@ -7687,7 +7540,6 @@
     ]
   },
   "info": {
-    "_postman_id": "ad5a5d42-0640-4de4-96cb-0f1a14fc1da0",
     "name": "Prisma Postgres Management API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "description": {

--- a/apps/docs/scripts/generate-postman-collection.ts
+++ b/apps/docs/scripts/generate-postman-collection.ts
@@ -2,6 +2,9 @@ import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createRequire } from "node:module";
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SYNTHETIC_KEY_RE = /^key_\d+$/;
+
 // openapi-to-postmanv2 is a CommonJS package; load it via createRequire in this ESM context
 // @ts-ignore
 const require = createRequire(import.meta.url);
@@ -11,9 +14,81 @@ const Converter = require("openapi-to-postmanv2") as {
   convert: (
     input: { type: "json"; data: unknown },
     options: Record<string, unknown>,
-    cb: (err: Error | null, result: { result: boolean; reason?: string; output: Array<{ data: Record<string, unknown> }> }) => void,
+    cb: (
+      err: Error | null,
+      result: {
+        result: boolean;
+        reason?: string;
+        output: Array<{ data: Record<string, unknown> }>;
+      },
+    ) => void,
   ) => void;
 };
+
+function normalizeSyntheticSampleObjects(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeSyntheticSampleObjects);
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+
+  const entries = Object.entries(value);
+  if (entries.length > 1 && entries.every(([key]) => SYNTHETIC_KEY_RE.test(key))) {
+    const keyZero = entries.find(([key]) => key === "key_0") ?? entries[0];
+    return { key_0: normalizeSyntheticSampleObjects(keyZero[1]) };
+  }
+
+  return Object.fromEntries(
+    entries.map(([key, nestedValue]) => [key, normalizeSyntheticSampleObjects(nestedValue)]),
+  );
+}
+
+function normalizeJsonSampleString(value: string): string {
+  const trimmed = value.trimStart();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    return value;
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    const normalized = normalizeSyntheticSampleObjects(parsed);
+    const formatted = JSON.stringify(normalized, null, 2);
+    return formatted === value ? value : formatted;
+  } catch {
+    return value;
+  }
+}
+
+function normalizeGeneratedCollection(value: unknown, key?: string): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeGeneratedCollection(item));
+  }
+
+  if (typeof value === "string" && (key === "raw" || key === "body")) {
+    return normalizeJsonSampleString(value);
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+
+  const normalized: Record<string, unknown> = {};
+  for (const [objectKey, nestedValue] of Object.entries(value)) {
+    if (objectKey === "_postman_id") {
+      continue;
+    }
+
+    if (objectKey === "id" && typeof nestedValue === "string" && UUID_RE.test(nestedValue)) {
+      continue;
+    }
+
+    normalized[objectKey] = normalizeGeneratedCollection(nestedValue, objectKey);
+  }
+
+  return normalized;
+}
 
 async function main() {
   const cwd = process.cwd();
@@ -72,7 +147,8 @@ async function main() {
       for (const r of item.item) {
         if (!r.name || (nameCounts.get(r.name) ?? 0) <= 1) continue;
         const path = r.request?.url?.path ?? [];
-        const pathStr = "/" + path.map((s) => (s.startsWith(":") ? `{${s.slice(1)}}` : s)).join("/");
+        const pathStr =
+          "/" + path.map((s) => (s.startsWith(":") ? `{${s.slice(1)}}` : s)).join("/");
         r.name = `${r.name} ${pathStr}`;
       }
     }
@@ -103,8 +179,10 @@ async function main() {
     ],
   };
 
+  const normalizedCollection = normalizeGeneratedCollection(collection);
+
   const outputPath = join(cwd, "public/prisma-management-api.postman_collection.json");
-  await writeFile(outputPath, JSON.stringify(collection, null, 2), "utf-8");
+  await writeFile(outputPath, JSON.stringify(normalizedCollection, null, 2), "utf-8");
   console.log(`Generated Postman collection: ${outputPath}`);
 }
 


### PR DESCRIPTION
## Summary

Make the generated Management API Postman collection deterministic so the docs sync workflow stops committing meaningless churn.

This change:

- strips volatile Postman-generated UUID fields (`id` and `_postman_id`) before writing the collection
- normalizes synthetic sample object keys generated from `additionalProperties`
- keeps the committed collection content stable unless the API surface actually changes

## Context

PR #7888 added the Postman collection to the Management API docs sync. The converter emits fresh IDs on every run, and some generated sample bodies can flip between `key_0`, `key_1`, etc. That caused repeated `chore(docs): sync management API documentation` commits on `main` even when there was no meaningful documentation change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Postman collection for the Prisma Postgres Management API with cleaner structure, simplified authorization configuration at the collection level, and standardized request/response examples across all endpoints.

* **Chores**
  * Improved collection generation process with enhanced normalization and standardization of generated API documentation artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prisma/web/pull/7900)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->