### PR TITLE
fix(docs): normalize latest ORM URLs

### DIFF
--- a/apps/docs/content/docs/orm/core-concepts/api-patterns.mdx
+++ b/apps/docs/content/docs/orm/core-concepts/api-patterns.mdx
@@ -1,7 +1,7 @@
 ---
 title: API patterns
 description: 'How to use Prisma ORM with REST APIs, GraphQL servers, and fullstack frameworks'
-url: /orm/latest/core-concepts/api-patterns
+url: /orm/core-concepts/api-patterns
 metaTitle: Building REST APIs with Prisma ORM
 metaDescription: This page gives an overview of the most important things when building REST APIs with Prisma. It shows practical examples and the supported libraries.
 ---

--- a/apps/docs/content/docs/orm/core-concepts/data-modeling.mdx
+++ b/apps/docs/content/docs/orm/core-concepts/data-modeling.mdx
@@ -1,7 +1,7 @@
 ---
 title: Data modeling
 description: Learn how data modeling with Prisma differs from data modeling with SQL or ORMs. Prisma uses a declarative data modeling language to describe a database schema
-url: /orm/latest/core-concepts/data-modeling
+url: /orm/core-concepts/data-modeling
 metaTitle: Data modeling with Prisma
 metaDescription: Learn how data modeling with Prisma differs from data modeling with SQL or ORMs. Prisma uses a declarative data modeling language to describe a database schema.
 ---

--- a/apps/docs/content/docs/orm/core-concepts/supported-databases/database-drivers.mdx
+++ b/apps/docs/content/docs/orm/core-concepts/supported-databases/database-drivers.mdx
@@ -1,7 +1,7 @@
 ---
 title: Database drivers
 description: Learn how Prisma connects to your database using driver adapters
-url: /orm/latest/core-concepts/supported-databases/database-drivers
+url: /orm/core-concepts/supported-databases/database-drivers
 metaTitle: Database drivers
 metaDescription: Learn how Prisma connects to your database using the built-in drivers and how you can use Prisma along with other JavaScript database drivers using driver adapters (Preview)
 ---

--- a/apps/docs/content/docs/orm/core-concepts/supported-databases/index.mdx
+++ b/apps/docs/content/docs/orm/core-concepts/supported-databases/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: 'Prisma ORM supports PostgreSQL, MySQL, SQLite, MongoDB, SQL Server, CockroachDB, and serverless databases'
-url: /orm/latest/core-concepts/supported-databases
+url: /orm/core-concepts/supported-databases
 metaTitle: Databases
 metaDescription: Prisma ORM supports PostgreSQL, MySQL, SQLite, MongoDB, SQL Server, CockroachDB, and serverless databases'
 ---

--- a/apps/docs/content/docs/orm/core-concepts/supported-databases/mongodb.mdx
+++ b/apps/docs/content/docs/orm/core-concepts/supported-databases/mongodb.mdx
@@ -2,7 +2,7 @@
 title: MongoDB
 description: How Prisma ORM connects to MongoDB databases
 codeStyle: false
-url: /orm/latest/core-concepts/supported-databases/mongodb
+url: /orm/core-concepts/supported-databases/mongodb
 metaTitle: MongoDB database connector
 metaDescription: How Prisma can connect to a MongoDB database using the MongoDB database connector.
 ---

--- a/apps/docs/content/docs/orm/core-concepts/supported-databases/mysql.mdx
+++ b/apps/docs/content/docs/orm/core-concepts/supported-databases/mysql.mdx
@@ -1,7 +1,7 @@
 ---
 title: MySQL
 description: Use Prisma ORM with MySQL databases including self-hosted MySQL/MariaDB and serverless PlanetScale
-url: /orm/latest/core-concepts/supported-databases/mysql
+url: /orm/core-concepts/supported-databases/mysql
 metaTitle: MySQL database connector
 metaDescription: This page explains how Prisma can connect to a MySQL or MariaDB database using the MySQL database connector.
 ---

--- a/apps/docs/content/docs/orm/core-concepts/supported-databases/postgresql.mdx
+++ b/apps/docs/content/docs/orm/core-concepts/supported-databases/postgresql.mdx
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL
 description: 'Use Prisma ORM with PostgreSQL databases including self-hosted, serverless (Neon, Supabase), and CockroachDB'
-url: /orm/latest/core-concepts/supported-databases/postgresql
+url: /orm/core-concepts/supported-databases/postgresql
 metaTitle: PostgreSQL database connector
 metaDescription: This page explains how Prisma can connect to a PostgreSQL database using the PostgreSQL database connector.
 ---

--- a/apps/docs/content/docs/orm/core-concepts/supported-databases/sql-server.mdx
+++ b/apps/docs/content/docs/orm/core-concepts/supported-databases/sql-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: SQL Server
 description: Use Prisma ORM with Microsoft SQL Server databases
-url: /orm/latest/core-concepts/supported-databases/sql-server
+url: /orm/core-concepts/supported-databases/sql-server
 metaTitle: Microsoft SQL Server
 metaDescription: This page explains how Prisma can connect to a Microsoft SQL Server database using the Microsoft SQL Server database connector.
 ---

--- a/apps/docs/content/docs/orm/core-concepts/supported-databases/sqlite.mdx
+++ b/apps/docs/content/docs/orm/core-concepts/supported-databases/sqlite.mdx
@@ -1,7 +1,7 @@
 ---
 title: SQLite
 description: 'Use Prisma ORM with SQLite databases including local SQLite, Turso (libSQL), and Cloudflare D1'
-url: /orm/latest/core-concepts/supported-databases/sqlite
+url: /orm/core-concepts/supported-databases/sqlite
 metaTitle: SQLite database connector
 metaDescription: This page explains how Prisma can connect to a SQLite database using the SQLite database connector.
 ---

--- a/apps/docs/content/docs/orm/index.mdx
+++ b/apps/docs/content/docs/orm/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Prisma ORM
 description: 'Prisma ORM is a next-generation Node.js and TypeScript ORM that provides type-safe database access, migrations, and a visual data editor.'
-url: /orm/latest
+url: /orm
 metaTitle: What is Prisma ORM? (Overview)
 metaDescription: This page gives a high-level overview of what Prisma ORM is and how it works. It's a great starting point for Prisma newcomers
 ---

--- a/apps/docs/content/docs/orm/more/best-practices.mdx
+++ b/apps/docs/content/docs/orm/more/best-practices.mdx
@@ -3,7 +3,7 @@ title: Best practices
 description: 'Learn production-ready patterns for schema design, query optimization, type safety, security, and deployment with Prisma ORM.'
 metaTitle: Best practices
 metaDescription: 'Learn production-ready patterns for schema design, query optimization, type safety, security, and deployment with Prisma ORM.'
-url: /orm/latest/more/best-practices
+url: /orm/more/best-practices
 ---
 
 ## Schema design and modeling

--- a/apps/docs/content/docs/orm/more/dev-environment/editor-setup.mdx
+++ b/apps/docs/content/docs/orm/more/dev-environment/editor-setup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Editor setup
 description: Learn how to configure your editor and IDEs for an optimal developer experience with Prisma ORM
-url: /orm/latest/more/dev-environment/editor-setup
+url: /orm/more/dev-environment/editor-setup
 metaTitle: Editor and IDE setup
 metaDescription: Learn how to configure your editor and IDEs for an optimal developer experience with Prisma ORM.
 ---

--- a/apps/docs/content/docs/orm/more/dev-environment/environment-variables.mdx
+++ b/apps/docs/content/docs/orm/more/dev-environment/environment-variables.mdx
@@ -1,7 +1,7 @@
 ---
 title: Environment variables
 description: Learn how to manage environment variables in your Prisma ORM project
-url: /orm/latest/more/dev-environment/environment-variables
+url: /orm/more/dev-environment/environment-variables
 metaTitle: Managing Prisma ORM environment variables and settings
 metaDescription: Learn how to manage the environment variables and settings in your Prisma ORM project
 ---

--- a/apps/docs/content/docs/orm/more/releases.mdx
+++ b/apps/docs/content/docs/orm/more/releases.mdx
@@ -1,7 +1,7 @@
 ---
 title: ORM releases and maturity levels
 description: 'Learn about the release process, versioning, and maturity of Prisma ORM components and how to deal with breaking changes that might happen throughout releases'
-url: /orm/latest/more/releases
+url: /orm/more/releases
 metaTitle: ORM releases and maturity levels
 metaDescription: 'Learn about the release process, versioning, and maturity of Prisma ORM components and how to deal with breaking changes that might happen throughout releases.'
 ---

--- a/apps/docs/content/docs/orm/more/troubleshooting/bundler-issues.mdx
+++ b/apps/docs/content/docs/orm/more/troubleshooting/bundler-issues.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bundler issues
 description: Solve ENOENT package error with vercel/pkg and other bundlers
-url: /orm/latest/more/troubleshooting/bundler-issues
+url: /orm/more/troubleshooting/bundler-issues
 metaTitle: Solve ENOENT package error with vercel/pkg
 metaDescription: Solve ENOENT package error with vercel/pkg
 ---

--- a/apps/docs/content/docs/orm/more/troubleshooting/check-constraints.mdx
+++ b/apps/docs/content/docs/orm/more/troubleshooting/check-constraints.mdx
@@ -1,7 +1,7 @@
 ---
 title: Check constraints
 description: Learn how to configure CHECK constraints for data validation with Prisma ORM and PostgreSQL
-url: /orm/latest/more/troubleshooting/check-constraints
+url: /orm/more/troubleshooting/check-constraints
 metaTitle: Data validation with CHECK constraints (PostgreSQL)
 metaDescription: Learn how to configure CHECK constraints for data validation with Prisma ORM and PostgreSQL by following the step-by-step instructions in this practical guide.
 ---

--- a/apps/docs/content/docs/orm/more/troubleshooting/graphql-autocompletion.mdx
+++ b/apps/docs/content/docs/orm/more/troubleshooting/graphql-autocompletion.mdx
@@ -1,7 +1,7 @@
 ---
 title: GraphQL autocompletion
 description: Get autocompletion for Prisma Client queries in GraphQL resolvers with plain JavaScript
-url: /orm/latest/more/troubleshooting/graphql-autocompletion
+url: /orm/more/troubleshooting/graphql-autocompletion
 metaTitle: Autocompletion in GraphQL resolvers with JavaScript
 metaDescription: Learn how you can get autocompletion for Prisma Client queries in GraphQL resolvers with plain JavaScript
 ---

--- a/apps/docs/content/docs/orm/more/troubleshooting/many-to-many-relations.mdx
+++ b/apps/docs/content/docs/orm/more/troubleshooting/many-to-many-relations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Many-to-many relations
 description: 'Learn how to model, query, and convert many-to-many relations with Prisma ORM'
-url: /orm/latest/more/troubleshooting/many-to-many-relations
+url: /orm/more/troubleshooting/many-to-many-relations
 metaTitle: Modeling and querying many-to-many relations
 metaDescription: Learn how you can model and query implicit and explicit many-to-many relations with Prisma ORM
 ---

--- a/apps/docs/content/docs/orm/more/troubleshooting/nextjs.mdx
+++ b/apps/docs/content/docs/orm/more/troubleshooting/nextjs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Next.js
 description: Best practices and troubleshooting for using Prisma ORM with Next.js applications
-url: /orm/latest/more/troubleshooting/nextjs
+url: /orm/more/troubleshooting/nextjs
 metaDescription: 'Learn best practices, monorepo strategies, and dynamic usage techniques for Prisma ORM in Next.js applications.'
 metaTitle: Comprehensive Guide to Using Prisma ORM with Next.js
 ---

--- a/apps/docs/content/docs/orm/more/troubleshooting/nuxt.mdx
+++ b/apps/docs/content/docs/orm/more/troubleshooting/nuxt.mdx
@@ -1,7 +1,7 @@
 ---
 title: Nuxt
 description: Learn how to integrate Prisma ORM with your Nuxt application
-url: /orm/latest/more/troubleshooting/nuxt
+url: /orm/more/troubleshooting/nuxt
 metaTitle: Add Prisma ORM Easily to Your Nuxt Apps
 metaDescription: 'Learn how to easily add Prisma ORM to your Nuxt apps, use its features, and understand its limitations.'
 ---

--- a/apps/docs/content/docs/orm/more/troubleshooting/raw-sql-comparisons.mdx
+++ b/apps/docs/content/docs/orm/more/troubleshooting/raw-sql-comparisons.mdx
@@ -1,7 +1,7 @@
 ---
 title: Raw SQL comparisons
 description: Compare columns of the same table with raw queries in Prisma ORM
-url: /orm/latest/more/troubleshooting/raw-sql-comparisons
+url: /orm/more/troubleshooting/raw-sql-comparisons
 metaTitle: Compare columns of the same table with raw queries
 metaDescription: Compare columns with inbuilt raw query methods in Prisma
 ---

--- a/apps/docs/content/docs/orm/more/troubleshooting/typescript-performance.mdx
+++ b/apps/docs/content/docs/orm/more/troubleshooting/typescript-performance.mdx
@@ -1,7 +1,7 @@
 ---
 title: TypeScript performance
 description: Optimize TypeScript compilation performance when working with large Prisma schemas
-url: /orm/latest/more/troubleshooting/typescript-performance
+url: /orm/more/troubleshooting/typescript-performance
 metaTitle: Optimizing TypeScript performance with large Prisma schemas
 metaDescription: Learn how to dramatically improve TypeScript compilation performance when working with large Prisma schemas using type optimization strategies
 ---

--- a/apps/docs/content/docs/orm/prisma-client/client-extensions/client.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/client-extensions/client.mdx
@@ -1,7 +1,7 @@
 ---
 title: Add methods to Prisma Client
 description: 'Extend the functionality of Prisma Client, client component'
-url: /orm/latest/prisma-client/client-extensions/client
+url: /orm/prisma-client/client-extensions/client
 metaTitle: 'Prisma Client extensions: client component'
 metaDescription: 'Extend the functionality of Prisma Client, client component'
 ---

--- a/apps/docs/content/docs/orm/prisma-client/client-extensions/extension-examples.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/client-extensions/extension-examples.mdx
@@ -1,7 +1,7 @@
 ---
 title: Shared packages & examples
 description: Explore the Prisma Client extensions that have been built by Prisma and its community
-url: /orm/latest/prisma-client/client-extensions/extension-examples
+url: /orm/prisma-client/client-extensions/extension-examples
 metaTitle: Prisma Client extensions | Shared packages & examples
 metaDescription: Explore the Prisma Client extensions that have been built by Prisma and its community
 ---

--- a/apps/docs/content/docs/orm/prisma-client/client-extensions/index.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/client-extensions/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: What are Client Extensions
 description: Extend the functionality of Prisma Client
-url: /orm/latest/prisma-client/client-extensions
+url: /orm/prisma-client/client-extensions
 metaTitle: Prisma Client extensions
 metaDescription: Extend the functionality of Prisma Client
 ---

--- a/apps/docs/content/docs/orm/prisma-client/client-extensions/model.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/client-extensions/model.mdx
@@ -1,7 +1,7 @@
 ---
 title: Add custom methods to your models
 description: 'Extend the functionality of Prisma Client, model component'
-url: /orm/latest/prisma-client/client-extensions/model
+url: /orm/prisma-client/client-extensions/model
 metaTitle: 'Prisma Client extensions: model component'
 metaDescription: 'Extend the functionality of Prisma Client, model component'
 ---

--- a/apps/docs/content/docs/orm/prisma-client/client-extensions/query.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/client-extensions/query.mdx
@@ -1,7 +1,7 @@
 ---
 title: Create custom Prisma Client queries
 description: 'Extend the functionality of Prisma Client, query component'
-url: /orm/latest/prisma-client/client-extensions/query
+url: /orm/prisma-client/client-extensions/query
 metaTitle: 'Prisma Client extensions: query component'
 metaDescription: 'Extend the functionality of Prisma Client, query component'
 ---

--- a/apps/docs/content/docs/orm/prisma-client/client-extensions/result.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/client-extensions/result.mdx
@@ -1,7 +1,7 @@
 ---
 title: Add custom fields and methods to query results
 description: 'Extend the functionality of Prisma Client, result component'
-url: /orm/latest/prisma-client/client-extensions/result
+url: /orm/prisma-client/client-extensions/result
 metaTitle: 'Prisma Client extensions: result component'
 metaDescription: 'Extend the functionality of Prisma Client, result component'
 ---

--- a/apps/docs/content/docs/orm/prisma-client/client-extensions/shared-extensions/index.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/client-extensions/shared-extensions/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Shared Prisma Client extensions
 description: Share extensions or import shared extensions into your Prisma project
-url: /orm/latest/prisma-client/client-extensions/shared-extensions
+url: /orm/prisma-client/client-extensions/shared-extensions
 metaTitle: 'Shared Prisma Client extensions'
 metaDescription: 'Share extensions or import shared extensions into your Prisma project'
 

--- a/apps/docs/content/docs/orm/prisma-client/client-extensions/shared-extensions/permit-rbac.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/client-extensions/shared-extensions/permit-rbac.mdx
@@ -1,7 +1,7 @@
 ---
 title: Fine-Grained Authorization (Permit)
 description: 'Learn how to implement RBAC, ABAC, and ReBAC authorization in your Prisma applications'
-url: /orm/latest/prisma-client/client-extensions/shared-extensions/permit-rbac
+url: /orm/prisma-client/client-extensions/shared-extensions/permit-rbac
 metaDescription: 'Learn how to implement RBAC, ABAC, and ReBAC authorization in your Prisma applications'
 metaTitle: Fine-Grained Authorization (Permit)
 ---

--- a/apps/docs/content/docs/orm/prisma-client/client-extensions/type-utilities.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/client-extensions/type-utilities.mdx
@@ -1,7 +1,7 @@
 ---
 title: Type utilities
 description: 'Advanced type safety: improve type safety in your custom model methods'
-url: /orm/latest/prisma-client/client-extensions/type-utilities
+url: /orm/prisma-client/client-extensions/type-utilities
 metaTitle: 'Prisma Client Extensions: Type utilities'
 metaDescription: 'Advanced type safety: improve type safety in your custom model methods'
 ---

--- a/apps/docs/content/docs/orm/prisma-client/debugging-and-troubleshooting/debugging.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/debugging-and-troubleshooting/debugging.mdx
@@ -1,7 +1,7 @@
 ---
 title: Debugging
 description: This page explains how to enable debugging output for Prisma Client by setting the `DEBUG` environment variable
-url: /orm/latest/prisma-client/debugging-and-troubleshooting/debugging
+url: /orm/prisma-client/debugging-and-troubleshooting/debugging
 metaTitle: Debugging (Reference)
 metaDescription: This page explains how to enable debugging output for Prisma Client by setting the `DEBUG` environment variable.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/debugging-and-troubleshooting/handling-exceptions-and-errors.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/debugging-and-troubleshooting/handling-exceptions-and-errors.mdx
@@ -1,7 +1,7 @@
 ---
 title: Handling exceptions and errors
 description: This page covers how to handle exceptions and errors
-url: /orm/latest/prisma-client/debugging-and-troubleshooting/handling-exceptions-and-errors
+url: /orm/prisma-client/debugging-and-troubleshooting/handling-exceptions-and-errors
 metaTitle: Handling exceptions and errors (Reference)
 metaDescription: This page covers how to handle exceptions and errors
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/caveats-when-deploying-to-aws-platforms.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/caveats-when-deploying-to-aws-platforms.mdx
@@ -1,7 +1,7 @@
 ---
 title: Caveats when deploying to AWS platforms
 description: Known caveats when deploying to an AWS platform
-url: /orm/latest/prisma-client/deployment/caveats-when-deploying-to-aws-platforms
+url: /orm/prisma-client/deployment/caveats-when-deploying-to-aws-platforms
 metaTitle: Caveats when deploying to AWS platforms
 metaDescription: Known caveats when deploying to an AWS platform
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/deploy-database-changes-with-prisma-migrate.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/deploy-database-changes-with-prisma-migrate.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploying database changes with Prisma Migrate
 description: Learn how to deploy database changes with Prisma Migrate
-url: /orm/latest/prisma-client/deployment/deploy-database-changes-with-prisma-migrate
+url: /orm/prisma-client/deployment/deploy-database-changes-with-prisma-migrate
 metaDescription: Learn how to deploy database changes with Prisma Migrate.
 metaTitle: Deploying database changes with Prisma Migrate
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/deploy-migrations-from-a-local-environment.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/deploy-migrations-from-a-local-environment.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy migrations from a local environment
 description: Learn how to deploy Node.js and TypeScript applications that are using Prisma Client locally
-url: /orm/latest/prisma-client/deployment/deploy-migrations-from-a-local-environment
+url: /orm/prisma-client/deployment/deploy-migrations-from-a-local-environment
 metaTitle: Deploy migrations from a local environment
 metaDescription: Learn how to deploy Node.js and TypeScript applications that are using Prisma Client locally.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/deploy-prisma.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/deploy-prisma.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy Prisma ORM
 description: Learn more about the different deployment paradigms for Node.js applications and how they affect deploying an application using Prisma Client
-url: /orm/latest/prisma-client/deployment/deploy-prisma
+url: /orm/prisma-client/deployment/deploy-prisma
 metaTitle: Deploying Prisma ORM-based projects
 metaDescription: Learn more about the different deployment paradigms for Node.js applications and how they affect deploying an application using Prisma Client.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/edge/deploy-to-cloudflare.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/edge/deploy-to-cloudflare.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy to Cloudflare Workers & Pages
 description: Learn the things you need to know in order to deploy an app that uses Prisma Client for talking to a database to a Cloudflare Worker or to Cloudflare Pages
-url: /orm/latest/prisma-client/deployment/edge/deploy-to-cloudflare
+url: /orm/prisma-client/deployment/edge/deploy-to-cloudflare
 metaTitle: Deploy to Cloudflare Workers & Pages
 metaDescription: Learn the things you need to know in order to deploy an app that uses Prisma Client for talking to a database to a Cloudflare Worker or to Cloudflare Pages.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/edge/deploy-to-deno-deploy.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/edge/deploy-to-deno-deploy.mdx
@@ -2,7 +2,7 @@
 title: Deploy to Deno Deploy
 metaTitle: Deploy to Deno Deploy
 metaDescription: Learn how to deploy a TypeScript application using Prisma ORM to Deno Deploy.
-url: /orm/latest/prisma-client/deployment/edge/deploy-to-deno-deploy
+url: /orm/prisma-client/deployment/edge/deploy-to-deno-deploy
 ---
 
 With this guide, you can learn how to build and deploy a REST API to [Deno Deploy](https://deno.com/deploy). The application uses Prisma ORM to manage tasks in a [Prisma Postgres](/postgres) database.

--- a/apps/docs/content/docs/orm/prisma-client/deployment/edge/deploy-to-vercel.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/edge/deploy-to-vercel.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy to Vercel Edge Functions & Middleware
 description: Learn the things you need to know in order to deploy an Edge function that uses Prisma Client for talking to a database
-url: /orm/latest/prisma-client/deployment/edge/deploy-to-vercel
+url: /orm/prisma-client/deployment/edge/deploy-to-vercel
 metaTitle: Deploy to Vercel Edge Functions & Middleware
 metaDescription: Learn the things you need to know in order to deploy an Edge function that uses Prisma Client for talking to a database.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/edge/overview.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/edge/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploying edge functions with Prisma ORM
 description: Learn how to deploy your Prisma-backed apps to edge functions like Cloudflare Workers or Vercel Edge Functions
-url: /orm/latest/prisma-client/deployment/edge/overview
+url: /orm/prisma-client/deployment/edge/overview
 metaTitle: 'Overview: Deploy Prisma ORM at the Edge'
 metaDescription: Learn how to deploy your Prisma-backed apps to edge functions like Cloudflare Workers or Vercel Edge Functions
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/serverless/deploy-to-aws-lambda.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/serverless/deploy-to-aws-lambda.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy to AWS Lambda
 description: 'Learn how to deploy your Prisma ORM-backed applications to AWS Lambda with AWS SAM, Serverless Framework, or SST'
-url: /orm/latest/prisma-client/deployment/serverless/deploy-to-aws-lambda
+url: /orm/prisma-client/deployment/serverless/deploy-to-aws-lambda
 metaTitle: Deploy your application using Prisma ORM to AWS Lambda
 metaDescription: 'Learn how to deploy your Prisma ORM-backed applications to AWS Lambda with AWS SAM, Serverless Framework, or SST'
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/serverless/deploy-to-azure-functions.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/serverless/deploy-to-azure-functions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy to Azure Functions
 description: Learn how to deploy a Prisma Client based REST API to Azure Functions and connect to an Azure SQL database
-url: /orm/latest/prisma-client/deployment/serverless/deploy-to-azure-functions
+url: /orm/prisma-client/deployment/serverless/deploy-to-azure-functions
 metaTitle: How to deploy an app using Prisma ORM to Azure Functions
 metaDescription: Learn how to deploy a Prisma Client based REST API to Azure Functions and connect to an Azure SQL database
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/serverless/deploy-to-netlify.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/serverless/deploy-to-netlify.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy to Netlify
 description: Learn how to deploy Node.js and TypeScript applications that are using Prisma Client to Netlify
-url: /orm/latest/prisma-client/deployment/serverless/deploy-to-netlify
+url: /orm/prisma-client/deployment/serverless/deploy-to-netlify
 metaTitle: Deploy to Netlify
 metaDescription: Learn how to deploy Node.js and TypeScript applications that are using Prisma Client to Netlify.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/serverless/deploy-to-vercel.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/serverless/deploy-to-vercel.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy to Vercel
 description: Learn how to deploy a Next.js application based on Prisma Client to Vercel
-url: /orm/latest/prisma-client/deployment/serverless/deploy-to-vercel
+url: /orm/prisma-client/deployment/serverless/deploy-to-vercel
 metaTitle: Deploy to Vercel
 metaDescription: Learn how to deploy a Next.js application based on Prisma Client to Vercel.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/traditional/deploy-to-flyio.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/traditional/deploy-to-flyio.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy to Fly.io
 description: Learn how to deploy a Node.js server that uses Prisma ORM to Fly.io
-url: /orm/latest/prisma-client/deployment/traditional/deploy-to-flyio
+url: /orm/prisma-client/deployment/traditional/deploy-to-flyio
 metaTitle: Deploy a Prisma app to Fly.io
 metaDescription: Learn how to deploy a Node.js server that uses Prisma ORM to Fly.io.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/traditional/deploy-to-heroku.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/traditional/deploy-to-heroku.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy to Heroku
 description: Learn how to deploy a Node.js server that uses Prisma ORM to Heroku
-url: /orm/latest/prisma-client/deployment/traditional/deploy-to-heroku
+url: /orm/prisma-client/deployment/traditional/deploy-to-heroku
 metaTitle: Deploy a Prisma app to Heroku
 metaDescription: Learn how to deploy a Node.js server that uses Prisma ORM to Heroku.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/traditional/deploy-to-koyeb.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/traditional/deploy-to-koyeb.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy to Koyeb
 description: Learn how to deploy a Node.js server that uses Prisma ORM to Koyeb Serverless Platform
-url: /orm/latest/prisma-client/deployment/traditional/deploy-to-koyeb
+url: /orm/prisma-client/deployment/traditional/deploy-to-koyeb
 metaTitle: Deploy a Prisma ORM app to Koyeb
 metaDescription: Learn how to deploy a Node.js server that uses Prisma ORM to Koyeb Serverless Platform.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/traditional/deploy-to-railway.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/traditional/deploy-to-railway.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy to Railway
 description: Learn how to deploy an app that uses Prisma ORM and Prisma Postgres to Railway
-url: /orm/latest/prisma-client/deployment/traditional/deploy-to-railway
+url: /orm/prisma-client/deployment/traditional/deploy-to-railway
 metaTitle: Deploy a Prisma app to Railway
 metaDescription: Learn how to deploy an app that uses Prisma ORM and Prisma Postgres to Railway.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/traditional/deploy-to-render.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/traditional/deploy-to-render.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy to Render
 description: Learn how to deploy a Node.js server that uses Prisma ORM to Render
-url: /orm/latest/prisma-client/deployment/traditional/deploy-to-render
+url: /orm/prisma-client/deployment/traditional/deploy-to-render
 metaTitle: Deploy a Prisma app to Render
 metaDescription: Learn how to deploy a Node.js server that uses Prisma ORM to Render.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/deployment/traditional/deploy-to-sevalla.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/deployment/traditional/deploy-to-sevalla.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploy to Sevalla
 description: Learn how to deploy a Node.js server that uses Prisma ORM to Sevalla
-url: /orm/latest/prisma-client/deployment/traditional/deploy-to-sevalla
+url: /orm/prisma-client/deployment/traditional/deploy-to-sevalla
 metaTitle: Deploy a Prisma app to Sevalla
 metaDescription: Learn how to deploy a Node.js server that uses Prisma ORM to Sevalla.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/observability-and-logging/logging.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/observability-and-logging/logging.mdx
@@ -1,7 +1,7 @@
 ---
 title: Logging
 description: Learn how to configure Prisma Client to log the raw SQL queries it sends to the database and other information
-url: /orm/latest/prisma-client/observability-and-logging/logging
+url: /orm/prisma-client/observability-and-logging/logging
 metaTitle: Logging
 metaDescription: Learn how to configure Prisma Client to log the raw SQL queries it sends to the database and other information.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/observability-and-logging/opentelemetry-tracing.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/observability-and-logging/opentelemetry-tracing.mdx
@@ -1,7 +1,7 @@
 ---
 title: OpenTelemetry tracing
 description: Diagnose application performance with detailed traces of each query
-url: /orm/latest/prisma-client/observability-and-logging/opentelemetry-tracing
+url: /orm/prisma-client/observability-and-logging/opentelemetry-tracing
 metaTitle: OpenTelemetry tracing
 metaDescription: Diagnose application performance with detailed traces of each query.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/observability-and-logging/sql-comments.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/observability-and-logging/sql-comments.mdx
@@ -1,7 +1,7 @@
 ---
 title: SQL comments
 description: 'Add metadata to your SQL queries as comments for improved observability, debugging, and tracing'
-url: /orm/latest/prisma-client/observability-and-logging/sql-comments
+url: /orm/prisma-client/observability-and-logging/sql-comments
 metaTitle: SQL comments
 metaDescription: 'Add metadata to your SQL queries as comments for improved observability, debugging, and tracing.'
 ---

--- a/apps/docs/content/docs/orm/prisma-client/queries/advanced/query-optimization-performance.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/queries/advanced/query-optimization-performance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Query optimization
 description: How to identify and optimize query performance with Prisma
-url: /orm/latest/prisma-client/queries/advanced/query-optimization-performance
+url: /orm/prisma-client/queries/advanced/query-optimization-performance
 metaTitle: Query optimization
 metaDescription: How to identify and optimize query performance with Prisma
 ---

--- a/apps/docs/content/docs/orm/prisma-client/queries/aggregation-grouping-summarizing.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/queries/aggregation-grouping-summarizing.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Aggregation, grouping, and summarizing'
 description: 'Use Prisma Client to aggregate, group by, count, and select distinct.'
-url: /orm/latest/prisma-client/queries/aggregation-grouping-summarizing
+url: /orm/prisma-client/queries/aggregation-grouping-summarizing
 metaTitle: 'Aggregation, grouping, and summarizing (Concepts)'
 metaDescription: 'Use Prisma Client to aggregate, group by, count, and select distinct.'
 ---

--- a/apps/docs/content/docs/orm/prisma-client/queries/relation-queries.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/queries/relation-queries.mdx
@@ -1,7 +1,7 @@
 ---
 title: Relation queries
 description: 'Prisma Client provides convenient queries for working with relations, such as a fluent API, nested writes (transactions), nested reads and relation filters'
-url: /orm/latest/prisma-client/queries/relation-queries
+url: /orm/prisma-client/queries/relation-queries
 metaTitle: Relation queries (Concepts)
 metaDescription: 'Prisma Client provides convenient queries for working with relations, such as a fluent API, nested writes (transactions), nested reads and relation filters.'
 ---

--- a/apps/docs/content/docs/orm/prisma-client/queries/transactions.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/queries/transactions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Transactions and batch queries
 description: This page explains the transactions API of Prisma Client
-url: /orm/latest/prisma-client/queries/transactions
+url: /orm/prisma-client/queries/transactions
 metaTitle: Transactions and batch queries (Reference)
 metaDescription: This page explains the transactions API of Prisma Client.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/custom-model-and-field-names.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/custom-model-and-field-names.mdx
@@ -1,7 +1,7 @@
 ---
 title: Custom model and field names
 description: Learn how you can decouple the naming of Prisma models from database tables to improve the ergonomics of the generated Prisma Client API
-url: /orm/latest/prisma-client/setup-and-configuration/custom-model-and-field-names
+url: /orm/prisma-client/setup-and-configuration/custom-model-and-field-names
 metaTitle: Custom model and field names
 metaDescription: Learn how you can decouple the naming of Prisma models from database tables to improve the ergonomics of the generated Prisma Client API.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/database-polyfills.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/database-polyfills.mdx
@@ -1,7 +1,7 @@
 ---
 title: Database polyfills
 description: Prisma Client provides features that are not achievable with relational databases. These features are referred to as "polyfills" and explained on this page.
-url: /orm/latest/prisma-client/setup-and-configuration/database-polyfills
+url: /orm/prisma-client/setup-and-configuration/database-polyfills
 metaTitle: Database polyfills (Concepts)
 metaDescription: Prisma Client provides features that are not achievable with relational databases. These features are referred to as "polyfills" and explained on this page.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/databases-connections/connection-management.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/databases-connections/connection-management.mdx
@@ -1,7 +1,7 @@
 ---
 title: Connection management
 description: This page explains how database connections are handled with Prisma Client and how to manually connect and disconnect your database
-url: /orm/latest/prisma-client/setup-and-configuration/databases-connections/connection-management
+url: /orm/prisma-client/setup-and-configuration/databases-connections/connection-management
 metaTitle: Connection management
 metaDescription: This page explains how database connections are handled with Prisma Client and how to manually connect and disconnect your database.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool.mdx
@@ -1,7 +1,7 @@
 ---
 title: Connection pool
 description: Prisma Client uses a connection pool (from the database driver or driver adapter) to store and manage database connections.
-url: /orm/latest/prisma-client/setup-and-configuration/databases-connections/connection-pool
+url: /orm/prisma-client/setup-and-configuration/databases-connections/connection-pool
 metaDescription: Prisma ORM's query engine creates a connection pool to store and manage database connections.
 metaTitle: Connection pool
 ---

--- a/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/databases-connections/index.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/databases-connections/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Database connections
 description: Learn how to manage database connections and configure connection pools
-url: /orm/latest/prisma-client/setup-and-configuration/databases-connections
+url: /orm/prisma-client/setup-and-configuration/databases-connections
 metaTitle: Database connections
 metaDescription: Databases connections
 ---

--- a/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/databases-connections/pgbouncer.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/databases-connections/pgbouncer.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure Prisma Client with PgBouncer
 description: 'Configure Prisma Client with PgBouncer and other poolers: when to use pgbouncer=true, required transaction mode, prepared statements, and Prisma Migrate workarounds'
-url: /orm/latest/prisma-client/setup-and-configuration/databases-connections/pgbouncer
+url: /orm/prisma-client/setup-and-configuration/databases-connections/pgbouncer
 metaTitle: Configure Prisma Client with PgBouncer
 metaDescription: 'Configure Prisma Client with PgBouncer and other poolers: when to use pgbouncer=true, required transaction mode, prepared statements, and Prisma Migrate workarounds.'
 ---

--- a/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/error-formatting.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/error-formatting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuring error formatting
 description: This page explains how to configure the formatting of errors when using Prisma Client
-url: /orm/latest/prisma-client/setup-and-configuration/error-formatting
+url: /orm/prisma-client/setup-and-configuration/error-formatting
 metaTitle: Configuring error formatting (Concepts)
 metaDescription: This page explains how to configure the formatting of errors when using Prisma Client.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/introduction.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: Introduction to Prisma Client
 description: Learn how to set up and configure Prisma Client in your project
-url: /orm/latest/prisma-client/setup-and-configuration/introduction
+url: /orm/prisma-client/setup-and-configuration/introduction
 metaTitle: Introduction to Prisma Client
 metaDescription: Learn how to set up Prisma Client.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/read-replicas.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/setup-and-configuration/read-replicas.mdx
@@ -1,7 +1,7 @@
 ---
 title: Read replicas
 description: Learn how to set up and use read replicas with Prisma Client
-url: /orm/latest/prisma-client/setup-and-configuration/read-replicas
+url: /orm/prisma-client/setup-and-configuration/read-replicas
 metaTitle: Read replicas
 metaDescription: Learn how to set up and use read replicas with Prisma Client
 ---

--- a/apps/docs/content/docs/orm/prisma-client/special-fields-and-types/composite-types.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/special-fields-and-types/composite-types.mdx
@@ -1,7 +1,7 @@
 ---
 title: Composite types
 description: Work with composite types and embedded documents in MongoDB
-url: /orm/latest/prisma-client/special-fields-and-types/composite-types
+url: /orm/prisma-client/special-fields-and-types/composite-types
 metaTitle: Composite types
 metaDescription: Composite types
 ---

--- a/apps/docs/content/docs/orm/prisma-client/special-fields-and-types/index.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/special-fields-and-types/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Fields & types
 description: Learn how to use about special fields and types with Prisma Client
-url: /orm/latest/prisma-client/special-fields-and-types
+url: /orm/prisma-client/special-fields-and-types
 metaTitle: Fields & types
 metaDescription: Learn how to use about special fields and types with Prisma Client.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/special-fields-and-types/null-and-undefined.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/special-fields-and-types/null-and-undefined.mdx
@@ -2,7 +2,7 @@
 title: Null and undefined
 description: How Prisma Client handles null and undefined
 preview: false
-url: /orm/latest/prisma-client/special-fields-and-types/null-and-undefined
+url: /orm/prisma-client/special-fields-and-types/null-and-undefined
 metaTitle: Null and undefined in Prisma Client (Reference)
 metaDescription: How Prisma Client handles null and undefined
 ---

--- a/apps/docs/content/docs/orm/prisma-client/special-fields-and-types/working-with-composite-ids-and-constraints.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/special-fields-and-types/working-with-composite-ids-and-constraints.mdx
@@ -1,7 +1,7 @@
 ---
 title: Working with compound IDs and unique constraints
 description: 'How to read, write, and filter by compound IDs and unique constraints'
-url: /orm/latest/prisma-client/special-fields-and-types/working-with-composite-ids-and-constraints
+url: /orm/prisma-client/special-fields-and-types/working-with-composite-ids-and-constraints
 metaTitle: Working with compound IDs and unique constraints (Concepts)
 metaDescription: 'How to read, write, and filter by compound IDs and unique constraints.'
 ---

--- a/apps/docs/content/docs/orm/prisma-client/special-fields-and-types/working-with-json-fields.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/special-fields-and-types/working-with-json-fields.mdx
@@ -1,7 +1,7 @@
 ---
 title: Working with Json fields
 description: 'How to read, write, and filter by Json fields'
-url: /orm/latest/prisma-client/special-fields-and-types/working-with-json-fields
+url: /orm/prisma-client/special-fields-and-types/working-with-json-fields
 metaTitle: Working with Json fields (Concepts)
 metaDescription: 'How to read, write, and filter by Json fields.'
 ---

--- a/apps/docs/content/docs/orm/prisma-client/special-fields-and-types/working-with-scalar-lists-arrays.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/special-fields-and-types/working-with-scalar-lists-arrays.mdx
@@ -1,7 +1,7 @@
 ---
 title: Working with scalar lists
 description: 'How to read, write, and filter by scalar lists / arrays'
-url: /orm/latest/prisma-client/special-fields-and-types/working-with-scalar-lists-arrays
+url: /orm/prisma-client/special-fields-and-types/working-with-scalar-lists-arrays
 metaTitle: Working with scalar lists/arrays (Concepts)
 metaDescription: 'How to read, write, and filter by scalar lists / arrays.'
 ---

--- a/apps/docs/content/docs/orm/prisma-client/testing/integration-testing.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/testing/integration-testing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integration testing
 description: Learn how to setup and run integration tests with Prisma and Docker
-url: /orm/latest/prisma-client/testing/integration-testing
+url: /orm/prisma-client/testing/integration-testing
 metaTitle: Integration testing with Prisma
 metaDescription: Learn how to setup and run integration tests with Prisma and Docker
 ---

--- a/apps/docs/content/docs/orm/prisma-client/testing/unit-testing.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/testing/unit-testing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Unit testing
 description: Learn how to setup and run unit tests with Prisma Client
-url: /orm/latest/prisma-client/testing/unit-testing
+url: /orm/prisma-client/testing/unit-testing
 metaTitle: Unit testing with Prisma ORM
 metaDescription: Learn how to setup and run unit tests with Prisma Client
 ---

--- a/apps/docs/content/docs/orm/prisma-client/type-safety/index.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/type-safety/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Type safety Overview
 description: 'Prisma Client provides full type safety for queries, even for partial queries or included relations. This page explains how to leverage the generated types and utilities'
-url: /orm/latest/prisma-client/type-safety
+url: /orm/prisma-client/type-safety
 metaTitle: 'Type safety'
 metaDescription: 'Prisma Client provides full type safety for queries, even for partial queries or included relations. This page explains how to leverage the generated types and utilities.'
 

--- a/apps/docs/content/docs/orm/prisma-client/type-safety/prisma-type-system.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/type-safety/prisma-type-system.mdx
@@ -1,7 +1,7 @@
 ---
 title: How to use Prisma ORM's type system
 description: How to use Prisma ORM's type system
-url: /orm/latest/prisma-client/type-safety/prisma-type-system
+url: /orm/prisma-client/type-safety/prisma-type-system
 metaDescription: How to use Prisma ORM's type system
 metaTitle: How to use Prisma ORM's type system
 ---

--- a/apps/docs/content/docs/orm/prisma-client/using-raw-sql/index.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/using-raw-sql/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Write your own SQL
 description: Learn how to use raw SQL queries in Prisma Client
-url: /orm/latest/prisma-client/using-raw-sql
+url: /orm/prisma-client/using-raw-sql
 metaTitle: Write Your Own SQL in Prisma Client
 metaDescription: Learn how to use raw SQL queries in Prisma Client.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/using-raw-sql/raw-queries.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/using-raw-sql/raw-queries.mdx
@@ -1,7 +1,7 @@
 ---
 title: Raw queries
 description: Learn how you can send raw SQL and MongoDB queries to your database using the raw() methods from the Prisma Client API
-url: /orm/latest/prisma-client/using-raw-sql/raw-queries
+url: /orm/prisma-client/using-raw-sql/raw-queries
 metaTitle: Raw queries
 metaDescription: Learn how you can send raw SQL and MongoDB queries to your database using the raw() methods from the Prisma Client API.
 ---

--- a/apps/docs/content/docs/orm/prisma-client/using-raw-sql/safeql.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/using-raw-sql/safeql.mdx
@@ -1,7 +1,7 @@
 ---
 title: SafeQL & Prisma Client
 description: 'Learn how to use SafeQL and Prisma Client extensions to work around features not natively supported by Prisma, such as PostGIS'
-url: /orm/latest/prisma-client/using-raw-sql/safeql
+url: /orm/prisma-client/using-raw-sql/safeql
 metaTitle: Integrate SafeQL with Prisma Client
 metaDescription: 'Learn how to use SafeQL and Prisma Client extensions to work around features not natively supported by Prisma, such as PostGIS.'
 ---

--- a/apps/docs/content/docs/orm/prisma-client/using-raw-sql/typedsql.mdx
+++ b/apps/docs/content/docs/orm/prisma-client/using-raw-sql/typedsql.mdx
@@ -2,7 +2,7 @@
 title: TypedSQL
 description: Learn how to use TypedSQL to write fully type-safe SQL queries that are compatible with any SQL console and Prisma Client
 badge: preview
-url: /orm/latest/prisma-client/using-raw-sql/typedsql
+url: /orm/prisma-client/using-raw-sql/typedsql
 metaTitle: Writing Type-safe SQL with TypedSQL and Prisma Client
 metaDescription: Learn how to use TypedSQL to write fully type-safe SQL queries that are compatible with any SQL console and Prisma Client.
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/getting-started.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting started with Prisma Migrate
 description: Learn how to migrate your schema in a development environment using Prisma Migrate
-url: /orm/latest/prisma-migrate/getting-started
+url: /orm/prisma-migrate/getting-started
 metaTitle: Getting started with Prisma Migrate
 metaDescription: Learn how to migrate your schema in a development environment using Prisma Migrate.
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/index.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview of Prisma Migrate
 description: Learn everything you need to know about Prisma Migrate
-url: /orm/latest/prisma-migrate
+url: /orm/prisma-migrate
 metaTitle: 'Prisma Migrate: Database, Schema, SQL Migration Tool'
 metaDescription: Prisma Migrate is a database migration tool available via the Prisma CLI that integrates with Prisma schema for data modeling.
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/understanding-prisma-migrate/limitations-and-known-issues.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/understanding-prisma-migrate/limitations-and-known-issues.mdx
@@ -1,6 +1,6 @@
 ---
 title: Limitations and known issues
-url: /orm/latest/prisma-migrate/understanding-prisma-migrate/limitations-and-known-issues
+url: /orm/prisma-migrate/understanding-prisma-migrate/limitations-and-known-issues
 metaDescriptions: Limitations and known issues
 metaTitle: Limitations and known issues
 metaDescription: Limitations and known issues

--- a/apps/docs/content/docs/orm/prisma-migrate/understanding-prisma-migrate/mental-model.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/understanding-prisma-migrate/mental-model.mdx
@@ -1,7 +1,7 @@
 ---
 title: Understanding Migrations
 description: A mental model guide for working with Prisma Migrate in your project
-url: /orm/latest/prisma-migrate/understanding-prisma-migrate/mental-model
+url: /orm/prisma-migrate/understanding-prisma-migrate/mental-model
 metaTitle: A mental model for Prisma Migrate
 metaDescription: A mental model guide for working with Prisma Migrate in your project
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/understanding-prisma-migrate/migration-histories.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/understanding-prisma-migrate/migration-histories.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migration histories
 description: How Prisma ORM uses migration histories to track changes to your schema
-url: /orm/latest/prisma-migrate/understanding-prisma-migrate/migration-histories
+url: /orm/prisma-migrate/understanding-prisma-migrate/migration-histories
 metaTitle: About migration histories
 metaDescription: About migration histories
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/understanding-prisma-migrate/shadow-database.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/understanding-prisma-migrate/shadow-database.mdx
@@ -1,7 +1,7 @@
 ---
 title: About the shadow database
 description: Learn how Prisma Migrate uses shadow databases to detect schema drift
-url: /orm/latest/prisma-migrate/understanding-prisma-migrate/shadow-database
+url: /orm/prisma-migrate/understanding-prisma-migrate/shadow-database
 metaTitle: About the shadow database
 metaDescription: About the shadow database
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/workflows/baselining.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/workflows/baselining.mdx
@@ -1,7 +1,7 @@
 ---
 title: Baselining a database
 description: How to initialize a migration history for an existing database that contains important data.
-url: /orm/latest/prisma-migrate/workflows/baselining
+url: /orm/prisma-migrate/workflows/baselining
 metaDescription: How to initialize a migration history for an existing database that contains important data.
 metaTitle: Baselining a database
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/workflows/customizing-migrations.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/workflows/customizing-migrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Customizing migrations
 description: How to edit a migration file before applying it to avoid data loss in production.
-url: /orm/latest/prisma-migrate/workflows/customizing-migrations
+url: /orm/prisma-migrate/workflows/customizing-migrations
 metaTitle: Customizing migrations
 metaDescription: How to edit a migration file before applying it to avoid data loss in production.
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/workflows/development-and-production.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/workflows/development-and-production.mdx
@@ -1,7 +1,7 @@
 ---
 title: Development and production
 description: How to use Prisma Migrate commands in development and production environments
-url: /orm/latest/prisma-migrate/workflows/development-and-production
+url: /orm/prisma-migrate/workflows/development-and-production
 metaTitle: Development and production
 metaDescription: Development and production
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/workflows/generating-down-migrations.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/workflows/generating-down-migrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Generating down migrations
 description: How to generate a down migration SQL file that reverses a given migration file
-url: /orm/latest/prisma-migrate/workflows/generating-down-migrations
+url: /orm/prisma-migrate/workflows/generating-down-migrations
 metaTitle: Generating down migrations
 metaDescription: How to generate down migrations
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/workflows/native-database-functions.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/workflows/native-database-functions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Native database functions
 description: How to enable PostgreSQL native database functions for projects that use Prisma Migrate.
-url: /orm/latest/prisma-migrate/workflows/native-database-functions
+url: /orm/prisma-migrate/workflows/native-database-functions
 metaTitle: Native database functions
 metaDescription: How to enable PostgreSQL native database functions for projects that use Prisma Migrate.
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/workflows/native-database-types.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/workflows/native-database-types.mdx
@@ -1,7 +1,7 @@
 ---
 title: Native database types
 description: Native database types
-url: /orm/latest/prisma-migrate/workflows/native-database-types
+url: /orm/prisma-migrate/workflows/native-database-types
 metaTitle: Native database types
 metaDescription: Native database types
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/workflows/patching-and-hotfixing.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/workflows/patching-and-hotfixing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Patching & hotfixing
 description: How to reconcile the migration history after applying a hotfix or patch to a production environment.
-url: /orm/latest/prisma-migrate/workflows/patching-and-hotfixing
+url: /orm/prisma-migrate/workflows/patching-and-hotfixing
 metaDescription: How to reconcile the migration history after applying a hotfix or patch to a production environment.
 metaTitle: Patching & hotfixing
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/workflows/prototyping-your-schema.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/workflows/prototyping-your-schema.mdx
@@ -1,7 +1,7 @@
 ---
 title: Prototyping your schema
 description: Rapidly prototype your Prisma schema using db push without migrations
-url: /orm/latest/prisma-migrate/workflows/prototyping-your-schema
+url: /orm/prisma-migrate/workflows/prototyping-your-schema
 metaTitle: Prototyping your schema
 metaDescription: Prototyping your schema
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/workflows/seeding.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/workflows/seeding.mdx
@@ -1,7 +1,7 @@
 ---
 title: Seeding
 description: Learn how to seed your database using Prisma ORM's integrated seeding functionality and Prisma Client
-url: /orm/latest/prisma-migrate/workflows/seeding
+url: /orm/prisma-migrate/workflows/seeding
 metaTitle: Seeding
 metaDescription: Learn how to seed your database using Prisma ORM's integrated seeding functionality and Prisma Client
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/workflows/squashing-migrations.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/workflows/squashing-migrations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Squashing migrations
 description: How to squash multiple migration files into a single migration
-url: /orm/latest/prisma-migrate/workflows/squashing-migrations
+url: /orm/prisma-migrate/workflows/squashing-migrations
 metaTitle: Squashing migrations
 metaDescription: How to squash multiple migration files into a single migration
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/workflows/troubleshooting.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/workflows/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 description: Troubleshooting issues with Prisma Migrate in a development environment.
-url: /orm/latest/prisma-migrate/workflows/troubleshooting
+url: /orm/prisma-migrate/workflows/troubleshooting
 metaTitle: Troubleshooting
 metaDescription: Troubleshooting issues with Prisma Migrate in a development environment.
 ---

--- a/apps/docs/content/docs/orm/prisma-migrate/workflows/unsupported-database-features.mdx
+++ b/apps/docs/content/docs/orm/prisma-migrate/workflows/unsupported-database-features.mdx
@@ -1,7 +1,7 @@
 ---
 title: Unsupported database features (Prisma Migrate)
 description: How to include unsupported database features for projects that use Prisma Migrate
-url: /orm/latest/prisma-migrate/workflows/unsupported-database-features
+url: /orm/prisma-migrate/workflows/unsupported-database-features
 metaTitle: 'Prisma Migrate: Unsupported database features'
 metaDescription: How to include unsupported database features for projects that use Prisma Migrate.
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/database-mapping.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/database-mapping.mdx
@@ -1,7 +1,7 @@
 ---
 title: Database mapping
 description: Learn how to map model and field names to database tables and columns
-url: /orm/latest/prisma-schema/data-model/database-mapping
+url: /orm/prisma-schema/data-model/database-mapping
 metaTitle: Database mapping
 metaDescription: Database mapping in Prisma schema
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/externally-managed-tables.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/externally-managed-tables.mdx
@@ -2,7 +2,7 @@
 title: External tables
 description: How to declare and use externally managed tables in Prisma ORM
 badge: preview
-url: /orm/latest/prisma-schema/data-model/externally-managed-tables
+url: /orm/prisma-schema/data-model/externally-managed-tables
 metaTitle: Externally managed tables
 metaDescription: How to declare and use externally managed tables in Prisma ORM
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/indexes.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/indexes.mdx
@@ -1,7 +1,7 @@
 ---
 title: Indexes
 description: How to configure index functionality and add full text indexes
-url: /orm/latest/prisma-schema/data-model/indexes
+url: /orm/prisma-schema/data-model/indexes
 metaDescription: How to configure index functionality and add full text indexes
 metaTitle: Indexes
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/models.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/models.mdx
@@ -1,7 +1,7 @@
 ---
 title: Models
 description: 'Learn about the concepts for building your data model with Prisma: Models, scalar types, enums, attributes, functions, IDs, default values and more'
-url: /orm/latest/prisma-schema/data-model/models
+url: /orm/prisma-schema/data-model/models
 metaTitle: Models
 metaDescription: 'Learn about the concepts for building your data model with Prisma: Models, scalar types, enums, attributes, functions, IDs, default values and more.'
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/multi-schema.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/multi-schema.mdx
@@ -1,7 +1,7 @@
 ---
 title: Multi-schema
 description: How to use Prisma ORM with multiple database schemas
-url: /orm/latest/prisma-schema/data-model/multi-schema
+url: /orm/prisma-schema/data-model/multi-schema
 metaTitle: How to use Prisma ORM with multiple database schemas
 metaDescription: How to use Prisma ORM with multiple database schemas
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/relations/index.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/relations/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Relations
 description: 'A relation is a connection between two models in the Prisma schema. This page explains how you can define one-to-one, one-to-many and many-to-many relations in Prisma'
-url: /orm/latest/prisma-schema/data-model/relations
+url: /orm/prisma-schema/data-model/relations
 metaTitle: Relations
 metaDescription: 'A relation is a connection between two models in the Prisma schema. This page explains how you can define one-to-one, one-to-many and many-to-many relations in Prisma.'
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/relations/many-to-many-relations.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/relations/many-to-many-relations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Many-to-many relations
 description: How to define and work with many-to-many relations in Prisma.
-url: /orm/latest/prisma-schema/data-model/relations/many-to-many-relations
+url: /orm/prisma-schema/data-model/relations/many-to-many-relations
 metaDescription: How to define and work with many-to-many relations in Prisma.
 metaTitle: Many-to-many relations
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/relations/one-to-many-relations.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/relations/one-to-many-relations.mdx
@@ -1,7 +1,7 @@
 ---
 title: One-to-many relations
 description: How to define and work with one-to-many relations in Prisma.
-url: /orm/latest/prisma-schema/data-model/relations/one-to-many-relations
+url: /orm/prisma-schema/data-model/relations/one-to-many-relations
 metaDescription: How to define and work with one-to-many relations in Prisma.
 metaTitle: One-to-many relations
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/relations/one-to-one-relations.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/relations/one-to-one-relations.mdx
@@ -1,7 +1,7 @@
 ---
 title: One-to-one relations
 description: How to define and work with one-to-one relations in Prisma.
-url: /orm/latest/prisma-schema/data-model/relations/one-to-one-relations
+url: /orm/prisma-schema/data-model/relations/one-to-one-relations
 metaDescription: How to define and work with one-to-one relations in Prisma.
 metaTitle: One-to-one relations
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/relations/referential-actions.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/relations/referential-actions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Referential actions
 description: Referential actions let you define the update and delete behavior of related models on the database level
-url: /orm/latest/prisma-schema/data-model/relations/referential-actions
+url: /orm/prisma-schema/data-model/relations/referential-actions
 metaTitle: Special rules for referential actions in SQL Server and MongoDB
 metaDescription: 'Circular references or multiple cascade paths can cause validation errors on Microsoft SQL Server and MongoDB. Since the database does not handle these situations out of the box, learn how to solve this problem.'
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/relations/relation-mode.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/relations/relation-mode.mdx
@@ -1,7 +1,7 @@
 ---
 title: Relation mode
 description: Manage relations between records with relation modes in Prisma
-url: /orm/latest/prisma-schema/data-model/relations/relation-mode
+url: /orm/prisma-schema/data-model/relations/relation-mode
 metaTitle: Manage relations between records with relation modes in Prisma
 metaDescription: Manage relations between records with relation modes in Prisma
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/relations/self-relations.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/relations/self-relations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Self-relations
 description: How to define and work with self-relations in Prisma.
-url: /orm/latest/prisma-schema/data-model/relations/self-relations
+url: /orm/prisma-schema/data-model/relations/self-relations
 metaDescription: How to define and work with self-relations in Prisma.
 metaTitle: Self-relations
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/relations/troubleshooting-relations.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/relations/troubleshooting-relations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting relations
 metaDescriptions: Common problems and solutions when defining relations in the Prisma schema.
-url: /orm/latest/prisma-schema/data-model/relations/troubleshooting-relations
+url: /orm/prisma-schema/data-model/relations/troubleshooting-relations
 metaDescription: Common problems and solutions when defining relations in the Prisma schema.
 metaTitle: Troubleshooting relations
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/table-inheritance.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/table-inheritance.mdx
@@ -1,7 +1,7 @@
 ---
 title: Table inheritance
 description: Learn about the use cases and patterns for table inheritance in Prisma ORM that enable usage of union types or polymorphic structures in your application.
-url: /orm/latest/prisma-schema/data-model/table-inheritance
+url: /orm/prisma-schema/data-model/table-inheritance
 metaTitle: Table inheritance
 metaDescription: Learn about the use cases and patterns for table inheritance in Prisma ORM that enable usage of union types or polymorphic structures in your application.
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/unsupported-database-features.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/unsupported-database-features.mdx
@@ -1,7 +1,7 @@
 ---
 title: Unsupported database features (Prisma Schema)
 description: How to support database features that do not have an equivalent syntax in Prisma Schema Language
-url: /orm/latest/prisma-schema/data-model/unsupported-database-features
+url: /orm/prisma-schema/data-model/unsupported-database-features
 metaTitle: 'Prisma schema: Unsupported database features'
 metaDescription: How to support database features that do not have an equivalent syntax in Prisma Schema Language.
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/data-model/views.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/data-model/views.mdx
@@ -2,7 +2,7 @@
 title: Views
 description: How to include views in your Prisma schema
 badge: preview
-url: /orm/latest/prisma-schema/data-model/views
+url: /orm/prisma-schema/data-model/views
 metaTitle: How to include views in your Prisma schema
 metaDescription: How to include views in your Prisma schema
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/introspection.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/introspection.mdx
@@ -1,7 +1,7 @@
 ---
 title: What is introspection?
 description: Learn how you can introspect your database to generate a data model into your Prisma schema
-url: /orm/latest/prisma-schema/introspection
+url: /orm/prisma-schema/introspection
 metaTitle: What is introspection? (Reference)
 metaDescription: Learn how you can introspect your database to generate a data model into your Prisma schema.
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/overview/data-sources.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/overview/data-sources.mdx
@@ -1,7 +1,7 @@
 ---
 title: Data sources
 description: Data sources enable Prisma to connect to your database. This page explains how to configure data sources in your Prisma schema
-url: /orm/latest/prisma-schema/overview/data-sources
+url: /orm/prisma-schema/overview/data-sources
 metaTitle: Data sources (Reference)
 metaDescription: Data sources enable Prisma to connect to your database. This page explains how to configure data sources in your Prisma schema.
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/overview/generators.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/overview/generators.mdx
@@ -1,7 +1,7 @@
 ---
 title: Generators
 description: Generators in your Prisma schema specify what assets are generated when the `prisma generate` command is invoked. This page explains how to configure generators
-url: /orm/latest/prisma-schema/overview/generators
+url: /orm/prisma-schema/overview/generators
 metaTitle: Generators (Reference)
 metaDescription: Generators in your Prisma schema specify what assets are generated when the `prisma generate` command is invoked. This page explains how to configure generators.
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/overview/index.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/overview/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview of Prisma Schema
 description: The Prisma schema is the main method of configuration when using Prisma. It is typically called schema.prisma and contains your database connection and data model
-url: /orm/latest/prisma-schema/overview
+url: /orm/prisma-schema/overview
 metaTitle: Prisma schema
 metaDescription: Learn everything you need to know about the Prisma schema.
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/overview/location.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/overview/location.mdx
@@ -1,7 +1,7 @@
 ---
 title: Schema location
 description: Documentation regarding proper location of Prisma Schema including default naming and multiple files.
-url: /orm/latest/prisma-schema/overview/location
+url: /orm/prisma-schema/overview/location
 metaTitle: Prisma Schema Location and Configuration
 metaDescription: Documentation regarding proper location of Prisma Schema including default naming and multiple files.
 ---

--- a/apps/docs/content/docs/orm/prisma-schema/postgresql-extensions.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/postgresql-extensions.mdx
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL extensions
 description: "How to install and manage PostgreSQL extensions with Prisma ORM using customized migrations, and how to use them in Prisma Client"
-url: /orm/latest/prisma-schema/postgresql-extensions
+url: /orm/prisma-schema/postgresql-extensions
 metaTitle: How to use PostgreSQL extensions with Prisma ORM
 metaDescription: "How to install and manage PostgreSQL extensions with Prisma ORM using customized migrations, and how to use them in Prisma Client."
 ---

--- a/apps/docs/content/docs/orm/reference/connection-urls.mdx
+++ b/apps/docs/content/docs/orm/reference/connection-urls.mdx
@@ -1,7 +1,7 @@
 ---
 title: Connection URLs
 description: 'Learn about the format and syntax Prisma ORM uses for defining database connection URLs for PostgreSQL, MySQL and SQLite'
-url: /orm/latest/reference/connection-urls
+url: /orm/reference/connection-urls
 metaTitle: Connection URLs (Reference)
 metaDescription: 'Learn about the format and syntax Prisma ORM uses for defining database connection URLs for PostgreSQL, MySQL and SQLite.'
 ---

--- a/apps/docs/content/docs/orm/reference/database-features.mdx
+++ b/apps/docs/content/docs/orm/reference/database-features.mdx
@@ -2,7 +2,7 @@
 title: Database Features
 description: Database features supported in Prisma ORM
 wide: true
-url: /orm/latest/reference/database-features
+url: /orm/reference/database-features
 metaTitle: Database features matrix
 metaDescription: Learn which database features are supported in Prisma ORM and how they map to the different Prisma ORM tools.
 ---

--- a/apps/docs/content/docs/orm/reference/environment-variables-reference.mdx
+++ b/apps/docs/content/docs/orm/reference/environment-variables-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: Environment Variables
 description: Reference for Prisma environment variables
-url: /orm/latest/reference/environment-variables-reference
+url: /orm/reference/environment-variables-reference
 metaTitle: Prisma environment variables
 metaDescription: This page gives an overview of all environment variables available for use.
 ---

--- a/apps/docs/content/docs/orm/reference/error-reference.mdx
+++ b/apps/docs/content/docs/orm/reference/error-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: Error Reference
 description: 'Prisma Client, Migrate, and Introspection error codes'
-url: /orm/latest/reference/error-reference
+url: /orm/reference/error-reference
 metaTitle: Errors
 metaDescription: 'Prisma Client, Migrate, Introspection error message reference'
 ---

--- a/apps/docs/content/docs/orm/reference/errors/index.mdx
+++ b/apps/docs/content/docs/orm/reference/errors/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Prisma Error Reference
 description: Common Prisma ORM errors and how to troubleshoot them
-url: /orm/latest/reference/errors
+url: /orm/reference/errors
 metaTitle: Errors
 metaDescription: 'Prisma Client, Migrate, Introspection error message reference'
 ---

--- a/apps/docs/content/docs/orm/reference/preview-features/cli-preview-features.mdx
+++ b/apps/docs/content/docs/orm/reference/preview-features/cli-preview-features.mdx
@@ -1,7 +1,7 @@
 ---
 title: Prisma CLI Preview features
 description: Prisma CLI features that are currently in Preview.
-url: /orm/latest/reference/preview-features/cli-preview-features
+url: /orm/reference/preview-features/cli-preview-features
 metaTitle: Prisma CLI Preview features
 metaDescription: Prisma CLI features that are currently in Preview.
 ---

--- a/apps/docs/content/docs/orm/reference/preview-features/client-preview-features.mdx
+++ b/apps/docs/content/docs/orm/reference/preview-features/client-preview-features.mdx
@@ -1,7 +1,7 @@
 ---
 title: Prisma Client & Prisma schema
 description: Prisma Client and Prisma schema features that are currently in Preview
-url: /orm/latest/reference/preview-features/client-preview-features
+url: /orm/reference/preview-features/client-preview-features
 metaTitle: Prisma Client & Prisma schema
 metaDescription: Prisma Client and Prisma schema features that are currently in Preview.
 ---

--- a/apps/docs/content/docs/orm/reference/prisma-cli-reference.mdx
+++ b/apps/docs/content/docs/orm/reference/prisma-cli-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: Prisma CLI reference
 description: 'This page gives an overview of all available Prisma CLI commands, explains their options and shows numerous usage examples'
-url: /orm/latest/reference/prisma-cli-reference
+url: /orm/reference/prisma-cli-reference
 metaTitle: Prisma CLI reference
 metaDescription: 'This page gives an overview of all available Prisma CLI commands, explains their options and shows numerous usage examples.'
 ---

--- a/apps/docs/content/docs/orm/reference/prisma-config-reference.mdx
+++ b/apps/docs/content/docs/orm/reference/prisma-config-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: Config API
 description: Complete reference for prisma.config.ts configuration options
-url: /orm/latest/reference/prisma-config-reference
+url: /orm/reference/prisma-config-reference
 metaTitle: Reference documentation for the prisma config file
 metaDescription: This page gives an overview of all Prisma config options available for use.
 ---

--- a/apps/docs/content/docs/orm/reference/prisma-schema-reference.mdx
+++ b/apps/docs/content/docs/orm/reference/prisma-schema-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: Schema API
 description: Reference for Prisma Schema Language (PSL)
-url: /orm/latest/reference/prisma-schema-reference
+url: /orm/reference/prisma-schema-reference
 metaTitle: Prisma Schema API
 metaDescription: API reference documentation for the Prisma Schema Language (PSL).
 ---

--- a/apps/docs/content/docs/orm/reference/supported-databases.mdx
+++ b/apps/docs/content/docs/orm/reference/supported-databases.mdx
@@ -1,7 +1,7 @@
 ---
 title: Supported databases
 description: This page lists all the databases and their versions that are supported by Prisma ORM
-url: /orm/latest/reference/supported-databases
+url: /orm/reference/supported-databases
 metaTitle: Databases supported by Prisma ORM
 metaDescription: This page lists all the databases and their versions that are supported by Prisma ORM.
 ---

--- a/apps/docs/content/docs/orm/reference/system-requirements.mdx
+++ b/apps/docs/content/docs/orm/reference/system-requirements.mdx
@@ -1,7 +1,7 @@
 ---
 title: System requirements
 description: System requirements for running Prisma ORM
-url: /orm/latest/reference/system-requirements
+url: /orm/reference/system-requirements
 metaTitle: System requirements (Reference)
 metaDescription: System requirements for running Prisma ORM
 ---

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -238,16 +238,16 @@ const config = {
         permanent: true,
         basePath: false,
       },
-      // {
-      //   source: "/orm/latest",
-      //   destination: "/orm",
-      //   permanent: true,
-      // },
-      // {
-      //   source: "/orm/latest/:path*",
-      //   destination: "/orm/:path*",
-      //   permanent: true,
-      // },
+      {
+        source: "/orm/latest",
+        destination: "/orm",
+        permanent: true,
+      },
+      {
+        source: "/orm/latest/:path*",
+        destination: "/orm/:path*",
+        permanent: true,
+      },
       {
         source: "/v6/orm",
         destination: "/orm/v6",

--- a/apps/docs/src/app/api/search/route.ts
+++ b/apps/docs/src/app/api/search/route.ts
@@ -3,6 +3,7 @@ import Mixedbread from "@mixedbread/sdk";
 import { SortedResult } from "fumadocs-core/search";
 import { formatSlugDisplayName } from "@/lib/breadcrumb-utils";
 import { isVersionSegment } from "@/lib/version";
+import { normalizeLatestOrmPath } from "@/lib/urls";
 
 export const dynamic = "force-dynamic";
 
@@ -79,7 +80,7 @@ export const { GET } = createMixedbreadSearchAPI({
     return results.flatMap((item) => {
       const { url = "#", title = "Untitled" } = item.generated_metadata ?? {};
 
-      const formattedUrl = url.startsWith("/docs") ? url.slice(5) : url;
+      const formattedUrl = normalizeLatestOrmPath(url.startsWith("/docs") ? url.slice(5) : url);
       const base = `${item.file_id}-${item.chunk_index}`;
       const breadcrumbs = getBreadcrumbsFromUrl(formattedUrl);
       const chunkResults: SortedResult[] = [

--- a/apps/docs/src/lib/urls.ts
+++ b/apps/docs/src/lib/urls.ts
@@ -15,6 +15,13 @@ export function normalize(urlOrPath: string) {
   return urlOrPath;
 }
 
+export function normalizeLatestOrmPath(urlOrPath: string): string {
+  return urlOrPath.replace(
+    /^(https?:\/\/[^/?#]+)?(\/docs)?\/orm\/latest(?=\/|$|[?#])/,
+    "$1$2/orm",
+  );
+}
+
 export const DOCS_PREFIX = "/docs";
 
 export function withDocsBasePath(path: string): string {

--- a/apps/site/src/app/api/search/route.ts
+++ b/apps/site/src/app/api/search/route.ts
@@ -44,6 +44,10 @@ function withBaseAndPrefixedPath(path: string | undefined, prefix: string): stri
   return prefixedPath === "#" ? prefixedPath : new URL(prefixedPath, websiteBaseUrl).toString();
 }
 
+function normalizeLatestOrmPath(path: string | undefined): string | undefined {
+  return path?.replace(/^(\/docs)?\/orm\/latest(?=\/|$|[?#])/, "$1/orm");
+}
+
 function normalizeBlogUrl(slug?: string): string {
   return withBaseAndPrefixedPath(slug, blogPrefix);
 }
@@ -56,7 +60,7 @@ function normalizeBlogImagePath(imagePath?: string): string {
 }
 
 function normalizeDocsUrl(url?: string): string {
-  return withBaseAndPrefixedPath(url, docsPrefix);
+  return withBaseAndPrefixedPath(normalizeLatestOrmPath(url), docsPrefix);
 }
 
 function getDocsImagePath(normalizedDocsUrl: string): string {


### PR DESCRIPTION
## Summary
- normalize current ORM docs frontmatter URLs from `/orm/latest/...` to `/orm/...`
- redirect legacy `/orm/latest` docs paths back to the canonical ORM docs routes
- defensively normalize stale `/orm/latest` metadata in docs and site search responses

## Root cause
Some current ORM docs pages still declared `/orm/latest/...` in frontmatter. Mixedbread used that metadata for search results, so docs search could surface links that 404 under the current routing.

## Validation
- `rg -n "^url: /orm/latest(/|$)|/docs/orm/latest|\(/orm/latest" apps/docs/content/docs apps/docs/src apps/site/src apps/blog/src packages -g "!apps/docs/.next/**" -S || true`
- `pnpm --filter docs exec oxlint next.config.mjs src/lib/urls.ts src/app/api/search/route.ts`
- `pnpm --filter site exec oxlint src/app/api/search/route.ts`
- `pnpm --filter docs exec tsc --noEmit`
- `pnpm --filter site exec tsc --noEmit`
- `pnpm --filter docs run audit:redirects:strict`
- `node --check apps/docs/next.config.mjs`
- `git diff --check`

Fixes #7908


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ORM documentation URL paths to remove the `/latest` segment for cleaner, simplified routing.
  * Added automatic redirects to ensure existing links and bookmarks continue to work seamlessly.
  * Enhanced search functionality to properly index and resolve documentation under the new URL structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prisma/web/pull/7910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->