### PR TITLE
fix(blog): make post title responsive on mobile

### DIFF
--- a/apps/blog/src/app/(blog)/[slug]/page.tsx
+++ b/apps/blog/src/app/(blog)/[slug]/page.tsx
@@ -188,7 +188,7 @@ export default async function Page(props: {
           >
             ← Back to Blog
           </Link>
-          <h1 className="mt-3 mb-8 type-title-5xl text-foreground-neutral">
+          <h1 className="mt-3 mb-8 type-title-3xl md:type-title-4xl lg:type-title-5xl text-foreground-neutral break-words hyphens-auto">
             {page.data.title}
           </h1>
           <div className="text-sm flex gap-2 items-center text-foreground-neutral mb-4">


### PR DESCRIPTION
## Summary
- Long blog post titles (e.g. the Prisma Next EA post) were breaking word-by-word on mobile because the `<h1>` used a fixed `type-title-5xl` (4rem / 64px) at every viewport.
- Scale the title down on smaller screens: `type-title-3xl` on mobile → `type-title-4xl` on `md` → `type-title-5xl` on `lg`, with `break-words hyphens-auto` as a safety net.

## Test plan
- [ ] Open the Prisma Next EA blog post on mobile width (~375px) and confirm the title wraps naturally instead of putting each word on its own line.
- [ ] Verify the title still renders at the original large size on desktop (≥1024px).
- [ ] Spot-check a few other blog posts to confirm no regression in title sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive typography for blog post titles across different screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prisma/web/pull/7915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->