### PR TITLE
enhance: add internal links to prisma next ea blog

### DIFF
--- a/apps/blog/content/blog/data-migrations-in-prisma-next/index.mdx
+++ b/apps/blog/content/blog/data-migrations-in-prisma-next/index.mdx
@@ -204,7 +204,7 @@ Same `check` and `run` callbacks. Same compilation to a JSON file. Same kind of 
 
 ## Try it yourself
 
-If you're as excited about this as we are, go ahead and try it out!
+If you're as excited about this as we are, go ahead and try it out! [Prisma Next is now in Early Access](https://www.prisma.io/blog/prisma-next-early-access-write-your-contract-prompt-your-agent-ship-your-app).
 
 ```bash
 pnpx prisma-next init

--- a/apps/blog/content/blog/prisma-next-call-for-extension-authors/index.mdx
+++ b/apps/blog/content/blog/prisma-next-call-for-extension-authors/index.mdx
@@ -16,7 +16,7 @@ tags:
   - "education"
 ---
 
-If you've ever wanted to integrate your tool, your database, or your library with Prisma, or you tried in Prisma 6 or 7 and gave up, this post is for you.
+If you've ever wanted to integrate your tool, your database, or your library with Prisma, or you tried in Prisma 6 or 7 and gave up, this post is for you. Read the [Prisma Next Early Access announcement](https://www.prisma.io/blog/prisma-next-early-access-write-your-contract-prompt-your-agent-ship-your-app) for the full launch story.
 
 Prisma Next has a deliberately tiny core that knows nothing about any specific database. Postgres support is an extension. Vector search is an extension. JSON-with-schema is an extension. Whatever Prisma Next can do, it does because someone wrote it using the same components that are available to you.
 

--- a/apps/blog/content/blog/prisma-next-roadmap-april-milestone/index.mdx
+++ b/apps/blog/content/blog/prisma-next-roadmap-april-milestone/index.mdx
@@ -70,7 +70,7 @@ For our upcoming Supabase support, we're adding realtime query subscriptions —
 
 ## May: making it easy to get started
 
-May's focus is the developer experience. We want your first hour with Prisma Next to feel smooth — from scaffolding a project to running your first query. When it's ready, we'll launch Prisma Next as Early Access for Postgres and MongoDB.
+May's focus is the developer experience. We want your first hour with Prisma Next to feel smooth, from scaffolding a project to running your first query. When it's ready, we'll launch [Prisma Next as Early Access](https://www.prisma.io/blog/prisma-next-early-access-write-your-contract-prompt-your-agent-ship-your-app) for Postgres and MongoDB.
 
 Three things to watch this month:
 

--- a/apps/blog/content/blog/prisma-next-roadmap/index.mdx
+++ b/apps/blog/content/blog/prisma-next-roadmap/index.mdx
@@ -54,7 +54,7 @@ As soon as it's ready, we'll put out a public announcement alongside getting sta
 
 By this point we expect the user-facing APIs to be stable for Postgres and one additional SQL database (SQLite is our top pick).
 
-> If you want to adopt Prisma Next early, May is the time to get started.
+> If you want to adopt Prisma Next early, May is the time to get started. [Prisma Next Early Access is now live](https://www.prisma.io/blog/prisma-next-early-access-write-your-contract-prompt-your-agent-ship-your-app).
 
 ### June - July: Postgres General Availability
 

--- a/apps/blog/content/blog/typescript-migrations-in-prisma-next/index.mdx
+++ b/apps/blog/content/blog/typescript-migrations-in-prisma-next/index.mdx
@@ -284,7 +284,7 @@ Most importantly, `migration.ts` combined with `ops.json` is _really_ easy to re
 
 ## Try it yourself
 
-Prisma Next is not production-ready yet. Prisma 7 is still the right choice for production today. When Prisma Next is ready for general use, it becomes Prisma 8.
+[Prisma Next is in Early Access](https://www.prisma.io/blog/prisma-next-early-access-write-your-contract-prompt-your-agent-ship-your-app) and not production-ready yet. Prisma 7 is still the right choice for production today. When Prisma Next is ready for general use, it becomes Prisma 8.
 
 But you can try it now:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated multiple blog posts with links and messaging directing readers to Prisma Next Early Access announcement
  * Added call-to-action references throughout blog content to the Early Access program

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prisma/web/pull/7923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->