### PR TITLE
docs(docs): use package-manager-agnostic wording for Prisma CLI in quickstarts

### DIFF
--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/cockroachdb.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/cockroachdb.mdx
@@ -76,7 +76,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/mongodb.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/mongodb.mdx
@@ -94,7 +94,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/mysql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/mysql.mdx
@@ -80,7 +80,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/planetscale.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/planetscale.mdx
@@ -78,7 +78,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/postgresql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/postgresql.mdx
@@ -82,7 +82,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/prisma-postgres.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/prisma-postgres.mdx
@@ -70,7 +70,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/sql-server.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/sql-server.mdx
@@ -76,7 +76,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/sqlite.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/sqlite.mdx
@@ -80,7 +80,7 @@ Update `package.json` to enable ESM:
 
 ## 4. Initialize Prisma ORM
 
-You can now invoke the Prisma CLI by prefixing it with `npx`:
+You can now run Prisma CLI commands using your package manager:
 
 ```npm
 npx prisma


### PR DESCRIPTION
## What

The "Initialize Prisma ORM" step in the quickstart guides says:

> You can now invoke the Prisma CLI by prefixing it with `npx`:

…directly above a code block that renders package-manager tabs (npm / pnpm /
yarn / bun). For the non-npm tabs the rendered command is `pnpm dlx prisma`,
`yarn dlx prisma`, and `bunx --bun prisma`, so the "prefix it with `npx`"
wording is npm-specific and incorrect for 3 of the 4 tabs.

The tabs come from `apps/docs/source.config.ts` (`remarkNpmOptions`), which runs
every npm code block through `npm-to-yarn`.

## Change

Reword the intro sentence to be package-manager-neutral on all 8 quickstart
pages that have it:

> You can now run Prisma CLI commands using your package manager:

The tabbed code block already adapts the command per package manager, so the
prose no longer needs to name `npx`.

Pages updated: postgresql, prisma-postgres, mysql, sqlite, sql-server,
cockroachdb, planetscale, mongodb.

## Testing

- `pnpm run lint:spellcheck` — passes (prose-only change, all words valid).
- Prose-only edit; no MDX structure, code fences, or links changed.

Closes #7913


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated quickstart guides for all supported databases (CockroachDB, MongoDB, MySQL, PlanetScale, PostgreSQL, Prisma Postgres, SQL Server, SQLite). Wording for running the Prisma CLI clarified: users can invoke Prisma commands via their project’s package manager instead of the previously prescribed approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->