### PR TITLE
docs(docs): align quickstart prisma.config.ts with actual prisma init output

### DIFF
--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/cockroachdb.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/cockroachdb.mdx
@@ -98,7 +98,7 @@ The generated `prisma.config.ts` file looks like this:
 
 ```typescript title="prisma.config.ts"
 import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -106,7 +106,7 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env["DATABASE_URL"],
   },
 });
 ```

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/mysql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/mysql.mdx
@@ -102,7 +102,7 @@ The generated `prisma.config.ts` file looks like this:
 
 ```typescript title="prisma.config.ts"
 import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -110,7 +110,7 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env["DATABASE_URL"],
   },
 });
 ```

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/planetscale.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/planetscale.mdx
@@ -108,7 +108,7 @@ The generated `prisma.config.ts` file looks like this:
 
 ```typescript title="prisma.config.ts"
 import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -116,7 +116,7 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env["DATABASE_URL"],
   },
 });
 ```

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/postgresql.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/postgresql.mdx
@@ -104,7 +104,7 @@ The generated `prisma.config.ts` file looks like this:
 
 ```typescript title="prisma.config.ts"
 import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -112,7 +112,7 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env["DATABASE_URL"],
   },
 });
 ```

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/prisma-postgres.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/prisma-postgres.mdx
@@ -94,7 +94,7 @@ The generated `prisma.config.ts` file looks like this:
 
 ```typescript title="prisma.config.ts"
 import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -102,7 +102,7 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env["DATABASE_URL"],
   },
 });
 ```

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/sql-server.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/sql-server.mdx
@@ -98,7 +98,7 @@ The generated `prisma.config.ts` file looks like this:
 
 ```typescript title="prisma.config.ts"
 import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -106,7 +106,7 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env["DATABASE_URL"],
   },
 });
 ```

--- a/apps/docs/content/docs/(index)/prisma-orm/quickstart/sqlite.mdx
+++ b/apps/docs/content/docs/(index)/prisma-orm/quickstart/sqlite.mdx
@@ -102,7 +102,7 @@ The generated `prisma.config.ts` file looks like this:
 
 ```typescript title="prisma.config.ts"
 import "dotenv/config";
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -110,7 +110,7 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env["DATABASE_URL"],
   },
 });
 ```


### PR DESCRIPTION
## What

The quickstart guides show the generated `prisma.config.ts` as:

    import "dotenv/config";
    import { defineConfig, env } from "prisma/config";
    ...
      datasource: { url: env("DATABASE_URL") }

But `prisma init` (standard npm/pnpm/yarn, i.e. the non-Bun runtime) actually
generates:

    import "dotenv/config";
    import { defineConfig } from "prisma/config";
    ...
      datasource: { url: process.env["DATABASE_URL"] }

The `env()` import/accessor is only emitted on the Bun runtime branch. In
`packages/cli/src/Init.ts`, `defaultConfig` picks the template with
`runtime: isBun ? 'bun' : 'other'`, and the `'other'` branch uses
`import { defineConfig }` + `process.env["DATABASE_URL"]`. The datasource
provider and `--db` flag don't change this. So the docs were incorrect for the
standard flow every quickstart describes (they all install via npm + dotenv).

Reported in #7818.

## Change

Update the `prisma.config.ts` example to match the actual non-Bun output on the
7 single-block quickstarts: postgresql, prisma-postgres, mysql, sqlite,
sql-server, cockroachdb, planetscale.

`mongodb` is intentionally left out — it presents a different two-step
"generated, then add dotenv" narrative with `engine: "classic"`, and should be
reviewed separately.

## Testing

- `pnpm run lint:spellcheck` — passes.
- Verified the replacement against `prisma/prisma` `packages/cli/src/Init.ts`
  (`defaultConfig`, `runtime: 'other'` branch).

Closes #7818


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Prisma quickstart guides across all supported databases: example config snippets now read DATABASE_URL directly from environment variables (removing a helper import) to simplify connection setup and make environment configuration clearer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->