### PR TITLE
docs: default package manager tabs to bun

### DIFF
--- a/apps/blog/source.config.ts
+++ b/apps/blog/source.config.ts
@@ -59,11 +59,14 @@ export default defineConfig({
     remarkCodeTabOptions: { parseMdx: true },
     remarkNpmOptions: {
       persist: { id: "package-manager" },
-      // Custom package managers to add --bun flag for bunx commands
       packageManagers: [
         {
-          command: (cmd: string) => convert(cmd.replace(/^npm init -y$/, "npm init"), "npm"),
-          name: "npm",
+          command: (cmd: string) => {
+            const converted = convert(cmd.replace(/^npm init -y$/, "npm init"), "bun");
+            if (!converted) return undefined;
+            return converted.replace(/^bun x /, "bunx --bun ");
+          },
+          name: "bun",
         },
         {
           command: (cmd: string) => convert(cmd.replace(/^npm init -y$/, "npm init"), "pnpm"),
@@ -74,12 +77,8 @@ export default defineConfig({
           name: "yarn",
         },
         {
-          command: (cmd: string) => {
-            const converted = convert(cmd.replace(/^npm init -y$/, "npm init"), "bun");
-            if (!converted) return undefined;
-            return converted.replace(/^bun x /, "bunx --bun ");
-          },
-          name: "bun",
+          command: (cmd: string) => convert(cmd.replace(/^npm init -y$/, "npm init"), "npm"),
+          name: "npm",
         },
       ],
     },

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -91,9 +91,6 @@ export default defineConfig({
         id: "package-manager",
       },
       packageManagers: [
-        { command: (cmd: string) => convertLine(cmd, "npm"), name: "npm" },
-        { command: (cmd: string) => convertLine(cmd, "pnpm"), name: "pnpm" },
-        { command: (cmd: string) => convertLine(cmd, "yarn"), name: "yarn" },
         {
           command: (cmd: string) => {
             const converted = convertLine(cmd, "bun");
@@ -102,6 +99,9 @@ export default defineConfig({
           },
           name: "bun",
         },
+        { command: (cmd: string) => convertLine(cmd, "pnpm"), name: "pnpm" },
+        { command: (cmd: string) => convertLine(cmd, "yarn"), name: "yarn" },
+        { command: (cmd: string) => convertLine(cmd, "npm"), name: "npm" },
       ],
     },
   },

--- a/apps/eclipse/source.config.ts
+++ b/apps/eclipse/source.config.ts
@@ -31,11 +31,14 @@ export default defineConfig({
       persist: {
         id: "package-manager",
       },
-      // Custom package managers to add --bun flag for bunx commands
       packageManagers: [
         {
-          command: (cmd: string) => convert(cmd.replace(/^npm init -y$/, "npm init"), "npm"),
-          name: "npm",
+          command: (cmd: string) => {
+            const converted = convert(cmd.replace(/^npm init -y$/, "npm init"), "bun");
+            if (!converted) return undefined;
+            return converted.replace(/^bun x /, "bunx --bun ");
+          },
+          name: "bun",
         },
         {
           command: (cmd: string) => convert(cmd.replace(/^npm init -y$/, "npm init"), "pnpm"),
@@ -46,12 +49,8 @@ export default defineConfig({
           name: "yarn",
         },
         {
-          command: (cmd: string) => {
-            const converted = convert(cmd.replace(/^npm init -y$/, "npm init"), "bun");
-            if (!converted) return undefined;
-            return converted.replace(/^bun x /, "bunx --bun ");
-          },
-          name: "bun",
+          command: (cmd: string) => convert(cmd.replace(/^npm init -y$/, "npm init"), "npm"),
+          name: "npm",
         },
       ],
     },

--- a/apps/site/source.config.ts
+++ b/apps/site/source.config.ts
@@ -3,6 +3,7 @@ import { remarkDirectiveAdmonition, remarkImage, remarkMdxFiles } from "fumadocs
 import { defineCollections, defineConfig, frontmatterSchema } from "fumadocs-mdx/config";
 import lastModified from "fumadocs-mdx/plugins/last-modified";
 import { z } from "zod";
+import convert from "npm-to-yarn";
 
 export const releaseNotes = defineCollections({
   type: "doc",
@@ -31,5 +32,30 @@ export default defineConfig({
       remarkMdxFiles,
     ],
     remarkCodeTabOptions: { parseMdx: true },
+    remarkNpmOptions: {
+      persist: { id: "package-manager" },
+      packageManagers: [
+        {
+          command: (cmd: string) => {
+            const converted = convert(cmd.replace(/^npm init -y$/, "npm init"), "bun");
+            if (!converted) return undefined;
+            return converted.replace(/^bun x /, "bunx --bun ");
+          },
+          name: "bun",
+        },
+        {
+          command: (cmd: string) => convert(cmd.replace(/^npm init -y$/, "npm init"), "pnpm"),
+          name: "pnpm",
+        },
+        {
+          command: (cmd: string) => convert(cmd.replace(/^npm init -y$/, "npm init"), "yarn"),
+          name: "yarn",
+        },
+        {
+          command: (cmd: string) => convert(cmd.replace(/^npm init -y$/, "npm init"), "npm"),
+          name: "npm",
+        },
+      ],
+    },
   },
 });


### PR DESCRIPTION
## Summary

- Make Bun the first/default package-manager tab for generated npm code blocks.
- Reorder package-manager tabs to `bun`, `pnpm`, `yarn`, `npm` across docs, blog, Eclipse docs, and site changelog MDX config.
- Add matching `remarkNpmOptions` to the site changelog collection so its npm fences use the same order instead of Fumadocs defaults.

## Validation

- `pnpm --filter docs exec fumadocs-mdx`
- `pnpm --filter blog exec fumadocs-mdx`
- `pnpm --filter eclipse exec fumadocs-mdx`
- `pnpm --filter site exec fumadocs-mdx`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated package manager configurations across multiple applications to ensure consistent and improved command handling for Bun, npm, pnpm, and yarn.
  * Reorganized settings to better support package manager command suggestions in documentation and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->