### PR TITLE
fix(blog): replace unreadable mermaid diagram in custom domains post

### DIFF
--- a/apps/blog/content/blog/prisma-compute-custom-domains/SequenceDiagram.tsx
+++ b/apps/blog/content/blog/prisma-compute-custom-domains/SequenceDiagram.tsx
@@ -1,0 +1,155 @@
+const W = 750
+const BOX_W = 124
+const BOX_H = 34
+const BOX_R = 7
+const BOX_Y = 12
+const LIFE_Y0 = BOX_Y + BOX_H + 2
+const STEP_Y0 = LIFE_Y0 + 38
+const STEP_DY = 52
+const LOOP_W = 44
+
+const PARTICIPANTS = ["User", "DNS provider", "Prisma Compute", "Certificate authority"]
+const PX = [76, 249, 430, 618]
+
+type Step = { from: number; to: number; label: string; dashed?: boolean }
+
+const STEPS: Step[] = [
+  { from: 0, to: 2, label: "Add custom domain" },
+  { from: 2, to: 0, label: "Return CNAME target", dashed: true },
+  { from: 0, to: 1, label: "Create CNAME record" },
+  { from: 2, to: 3, label: "Request certificate" },
+  { from: 3, to: 2, label: "Return http-01 challenge", dashed: true },
+  { from: 3, to: 2, label: "Check HTTP challenge path" },
+  { from: 2, to: 3, label: "Serve challenge response", dashed: true },
+  { from: 3, to: 2, label: "Issue TLS certificate", dashed: true },
+  { from: 2, to: 2, label: "Encrypt and store certificate material" },
+]
+
+const H = STEP_Y0 + STEPS.length * STEP_DY + 24
+
+export function SequenceDiagram() {
+  return (
+    <figure className="seq-diagram not-prose">
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        width="100%"
+        aria-label="TLS certificate provisioning sequence diagram"
+        role="img"
+      >
+        <defs>
+          <marker
+            id="seq-arr"
+            viewBox="0 0 8 8"
+            refX="7"
+            refY="4"
+            markerWidth="5"
+            markerHeight="5"
+            orient="auto"
+          >
+            <path d="M0,0 L8,4 L0,8 Z" className="seq-arr-fill" />
+          </marker>
+          <marker
+            id="seq-arr-d"
+            viewBox="0 0 8 8"
+            refX="7"
+            refY="4"
+            markerWidth="5"
+            markerHeight="5"
+            orient="auto"
+          >
+            <path d="M0,0 L8,4 L0,8 Z" className="seq-arr-d-fill" />
+          </marker>
+        </defs>
+
+        {/* participant boxes */}
+        {PARTICIPANTS.map((name, i) => (
+          <g key={name}>
+            <rect
+              x={PX[i] - BOX_W / 2}
+              y={BOX_Y}
+              width={BOX_W}
+              height={BOX_H}
+              rx={BOX_R}
+              className="seq-box"
+            />
+            <text
+              x={PX[i]}
+              y={BOX_Y + BOX_H / 2}
+              textAnchor="middle"
+              dominantBaseline="central"
+              className="seq-box-text"
+            >
+              {name}
+            </text>
+          </g>
+        ))}
+
+        {/* lifelines */}
+        {PARTICIPANTS.map((_, i) => (
+          <line
+            key={i}
+            x1={PX[i]}
+            y1={LIFE_Y0}
+            x2={PX[i]}
+            y2={H - 8}
+            strokeDasharray="3 5"
+            className="seq-lifeline"
+          />
+        ))}
+
+        {/* steps */}
+        {STEPS.map((step, idx) => {
+          const y = STEP_Y0 + idx * STEP_DY
+          const isSelf = step.from === step.to
+          const mid = isSelf
+            ? PX[step.from] + LOOP_W + 8
+            : (PX[step.from] + PX[step.to]) / 2
+          const markerId = `url(#seq-arr${step.dashed ? "-d" : ""})`
+          const arrowClass = `seq-arrow${step.dashed ? " seq-arrow-dashed" : ""}`
+
+          return (
+            <g key={idx}>
+              <circle cx={16} cy={y} r={9} className="seq-num-bg" />
+              <text
+                x={16}
+                y={y}
+                textAnchor="middle"
+                dominantBaseline="central"
+                className="seq-num-text"
+              >
+                {idx + 1}
+              </text>
+
+              {isSelf ? (
+                <path
+                  d={`M${PX[step.from]},${y - 8} H${PX[step.from] + LOOP_W} V${y + 8} H${PX[step.from]}`}
+                  fill="none"
+                  markerEnd={markerId}
+                  className={arrowClass}
+                />
+              ) : (
+                <line
+                  x1={PX[step.from]}
+                  y1={y}
+                  x2={PX[step.to]}
+                  y2={y}
+                  markerEnd={markerId}
+                  className={arrowClass}
+                />
+              )}
+
+              <text
+                x={mid}
+                y={y - 11}
+                textAnchor={isSelf ? "start" : "middle"}
+                className="seq-label"
+              >
+                {step.label}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+    </figure>
+  )
+}

--- a/apps/blog/content/blog/prisma-compute-custom-domains/index.mdx
+++ b/apps/blog/content/blog/prisma-compute-custom-domains/index.mdx
@@ -53,23 +53,17 @@ The proof step is where things get interesting. ACME supports several challenge 
 
 That maps well to Compute's custom domain flow. Once the user creates the CNAME and DNS starts resolving to Compute, HTTP traffic for the domain reaches Prisma's routing layer. Even though we do not have the final certificate yet, we can serve the ACME challenge response for the certificate authority. The challenge is used only for certificate issuance; the user does not need to see it, configure it, or respond to it.
 
-```mermaid
-sequenceDiagram
-    participant User as User
-    participant DNS as DNS provider
-    participant Compute as Prisma Compute
-    participant ACME as Certificate authority
-
-    User->>Compute: Add custom domain
-    Compute-->>User: Return CNAME target
-    User->>DNS: Create CNAME record
-    Compute->>ACME: Request certificate
-    ACME-->>Compute: Return http-01 challenge
-    ACME->>Compute: Check HTTP challenge path
-    Compute-->>ACME: Serve challenge response
-    ACME-->>Compute: Issue TLS certificate
-    Compute->>Compute: Encrypt and store certificate material
-```
+| Step | From | To | Action |
+|------|------|----|--------|
+| 1 | User | Prisma Compute | Add custom domain |
+| 2 | Prisma Compute | User | Return CNAME target |
+| 3 | User | DNS provider | Create CNAME record |
+| 4 | Prisma Compute | Certificate authority | Request certificate |
+| 5 | Certificate authority | Prisma Compute | Return `http-01` challenge |
+| 6 | Certificate authority | Prisma Compute | Check HTTP challenge path |
+| 7 | Prisma Compute | Certificate authority | Serve challenge response |
+| 8 | Certificate authority | Prisma Compute | Issue TLS certificate |
+| 9 | Prisma Compute | — | Encrypt and store certificate material |
 
 In this flow, the user handles the domain assignment and DNS record. Compute handles the certificate request, challenge response, certificate retrieval, encryption, and storage. The user experience stays focused on the single DNS step, and automatic provisioning can complete quickly once DNS resolves.
 

--- a/apps/blog/content/blog/prisma-compute-custom-domains/index.mdx
+++ b/apps/blog/content/blog/prisma-compute-custom-domains/index.mdx
@@ -14,6 +14,8 @@ series: prisma-compute
 seriesIndex: 3
 ---
 
+import { SequenceDiagram } from "./SequenceDiagram"
+
 We launched Prisma Compute with custom domain support. You can add a domain to a Compute service, point one DNS record at Prisma, and let Prisma Compute handle certificate provisioning and routing behind the scenes.
 
 This is a small but incredibly important feature. Custom domains give you a stable, public URL that you own for sharing and integrating. In this post, we'll get into the behind-the-scenes work that handles DNS, certificate provisioning, certificate storage, and request routing correctly. Let's get into how we approached it.
@@ -53,17 +55,7 @@ The proof step is where things get interesting. ACME supports several challenge 
 
 That maps well to Compute's custom domain flow. Once the user creates the CNAME and DNS starts resolving to Compute, HTTP traffic for the domain reaches Prisma's routing layer. Even though we do not have the final certificate yet, we can serve the ACME challenge response for the certificate authority. The challenge is used only for certificate issuance; the user does not need to see it, configure it, or respond to it.
 
-| Step | From | To | Action |
-|------|------|----|--------|
-| 1 | User | Prisma Compute | Add custom domain |
-| 2 | Prisma Compute | User | Return CNAME target |
-| 3 | User | DNS provider | Create CNAME record |
-| 4 | Prisma Compute | Certificate authority | Request certificate |
-| 5 | Certificate authority | Prisma Compute | Return `http-01` challenge |
-| 6 | Certificate authority | Prisma Compute | Check HTTP challenge path |
-| 7 | Prisma Compute | Certificate authority | Serve challenge response |
-| 8 | Certificate authority | Prisma Compute | Issue TLS certificate |
-| 9 | Prisma Compute | — | Encrypt and store certificate material |
+<SequenceDiagram />
 
 In this flow, the user handles the domain assignment and DNS record. Compute handles the certificate request, challenge response, certificate retrieval, encryption, and storage. The user experience stays focused on the single DNS step, and automatic provisioning can complete quickly once DNS resolves.
 

--- a/apps/blog/src/app/global.css
+++ b/apps/blog/src/app/global.css
@@ -1640,3 +1640,70 @@
   font-size: 0.875rem;
   line-height: 1.1;
 }
+
+/* ── Sequence diagram ───────────────────────────────────────────────── */
+.seq-diagram {
+  --seq-accent: #5fb878;
+  --seq-accent-bg: color-mix(in srgb, #5fb878 15%, transparent);
+  margin: 1.75rem 0;
+  border: 1px solid var(--color-stroke-neutral);
+  border-radius: 10px;
+  background: var(--color-background-default);
+  padding: 12px 16px 16px;
+  overflow-x: auto;
+}
+
+.seq-box {
+  fill: color-mix(in srgb, var(--color-foreground-ppg) 6%, var(--color-background-default));
+  stroke: var(--color-stroke-neutral);
+  stroke-width: 1.5;
+}
+
+.seq-box-text {
+  fill: var(--color-foreground-neutral);
+  font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+  font-size: 11.5px;
+  font-weight: 600;
+}
+
+.seq-lifeline {
+  stroke: var(--color-stroke-neutral);
+  stroke-width: 1;
+}
+
+.seq-arrow {
+  stroke: var(--color-foreground-neutral);
+  stroke-width: 1.5;
+}
+
+.seq-arrow-dashed {
+  stroke: color-mix(in srgb, var(--color-foreground-neutral) 55%, transparent);
+  stroke-dasharray: 5 3;
+}
+
+.seq-arr-fill {
+  fill: var(--color-foreground-neutral);
+}
+
+.seq-arr-d-fill {
+  fill: color-mix(in srgb, var(--color-foreground-neutral) 55%, transparent);
+}
+
+.seq-label {
+  fill: var(--color-foreground-neutral);
+  font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
+  font-size: 11px;
+}
+
+.seq-num-bg {
+  fill: var(--seq-accent-bg);
+  stroke: var(--seq-accent);
+  stroke-width: 1;
+}
+
+.seq-num-text {
+  fill: var(--seq-accent);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 9px;
+  font-weight: 700;
+}


### PR DESCRIPTION
Replaces the mermaid sequence diagram in the Prisma Compute custom domains post with a plain table. The mermaid renderer outputs very faint/washed-out text that makes the diagram hard to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the custom domains blog post to use a clearer, step-by-step visual of the ACME certificate provisioning flow.
* **New Features**
  * Added a reusable sequence diagram component to render the TLS workflow illustration consistently.
* **Style**
  * Introduced dedicated styles for sequence diagrams (layout, lifelines, arrows, and step labels) to improve readability and visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->