### PR TITLE
docs(mcp): document search_prisma_documentation tool

### DIFF
--- a/apps/docs/content/docs/ai/tools/mcp-server.mdx
+++ b/apps/docs/content/docs/ai/tools/mcp-server.mdx
@@ -27,8 +27,15 @@ Prisma provides an MCP server that lets AI tools manage Prisma Postgres database
 - `ListDatabasesTool`: Fetch a list of available Prisma Postgres Databases for user's workspace.
 - `ExecuteSqlQueryTool`: Execute a SQL query on a Prisma Postgres database with the given id.
 - `IntrospectSchemaTool`: Introspect the schema of a Prisma Postgres database with the given id.
+- `search_prisma_documentation`: Answer a natural-language question about Prisma using the official Prisma documentation, returning a cited answer with links back to the docs.
 
 Once you're connected to the Prisma MCP server, you can also always prompt your AI agent to "List the Prisma tools" to get a full overview of the latest supported tools.
+
+### Searching the Prisma documentation
+
+The `search_prisma_documentation` tool lets your AI agent answer questions about Prisma Postgres, Prisma ORM, Accelerate, Optimize, Prisma Compute, schema design, migrations, and more, grounded in the official documentation, without leaving your editor or terminal.
+
+Because it's read-only and exposed by the Prisma MCP server you're already connected to, there's no extra setup or second integration to install. When you ask your agent a Prisma question, it picks up the tool automatically and returns an answer with citations linking back to the relevant pages on [prisma.io/docs](https://www.prisma.io/docs). This keeps the agent's answers current and accurate instead of relying on whatever it happened to learn during training.
 
 ## Usage
 
@@ -51,6 +58,7 @@ The Prisma MCP server follows the standard JSON-based configuration for MCP serv
 - "Seed my database with real-looking data but create a backup beforehand."
 - "Show me all available backups of my database."
 - "Show me all customers and run an analysis over their orders."
+- "Search the Prisma docs and explain how connection pooling works on Prisma Postgres."
 
 ## Integrating in AI tools
 

--- a/apps/docs/content/docs/ai/tools/mcp-server.mdx
+++ b/apps/docs/content/docs/ai/tools/mcp-server.mdx
@@ -33,9 +33,9 @@ Once you're connected to the Prisma MCP server, you can also always prompt your 
 
 ### Searching the Prisma documentation
 
-The `search_prisma_documentation` tool lets your AI agent answer questions about Prisma Postgres, Prisma ORM, Accelerate, Optimize, Prisma Compute, schema design, migrations, and more, grounded in the official documentation, without leaving your editor or terminal.
+The `search_prisma_documentation` tool lets your AI agent answer questions about Prisma ORM, Prisma Postgres, Prisma Compute, schema design, migrations, and more, grounded in the official documentation, without leaving your editor or terminal.
 
-Because it's read-only and exposed by the Prisma MCP server you're already connected to, there's no extra setup or second integration to install. When you ask your agent a Prisma question, it picks up the tool automatically and returns an answer with citations linking back to the relevant pages on [prisma.io/docs](https://www.prisma.io/docs). This keeps the agent's answers current and accurate instead of relying on whatever it happened to learn during training.
+Because it's read-only and exposed by the Prisma MCP server you're already connected to, there's no extra setup or second integration to install. When you ask your agent a Prisma question, it picks up the tool automatically and returns an answer with citations linking back to the relevant pages in the [Prisma documentation](/). This keeps the agent's answers current and accurate instead of relying on whatever it happened to learn during training.
 
 ## Usage
 

--- a/apps/docs/content/docs/ai/tools/mcp-server.mdx
+++ b/apps/docs/content/docs/ai/tools/mcp-server.mdx
@@ -58,7 +58,7 @@ The Prisma MCP server follows the standard JSON-based configuration for MCP serv
 - "Seed my database with real-looking data but create a backup beforehand."
 - "Show me all available backups of my database."
 - "Show me all customers and run an analysis over their orders."
-- "Search the Prisma docs and explain how connection pooling works on Prisma Postgres."
+- "Search the Prisma docs and explain how to deploy a project to Prisma Compute."
 
 ## Integrating in AI tools
 


### PR DESCRIPTION
## Purpose of change

Documents the new `search_prisma_documentation` tool added to the hosted Prisma MCP server in [pdp-control-plane#4069](https://github.com/prisma/pdp-control-plane/pull/4069).

## What's changed

In `apps/docs/content/docs/ai/tools/mcp-server.mdx`:

- Added `search_prisma_documentation` to the **Tools** list.
- Added a **Searching the Prisma documentation** subsection explaining what the tool does and how it's helpful: it answers natural-language Prisma questions grounded in the official docs and returns cited answers, with no extra setup since it's exposed by the MCP server you're already connected to.
- Added a sample prompt demonstrating it.

Only public-facing, user-relevant behavior is documented. Internal implementation details (backend provider, env vars/secrets, infra/service names) are intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the MCP server Tools documentation with a new “search Prisma documentation” tool
  * Added guidance on how the tool answers using Prisma docs with citations/links
  * Included an example prompt for searching Prisma docs for deploying to Prisma Compute
<!-- end of auto-generated comment: release notes by coderabbit.ai -->