### PR TITLE
docs(compute): prisma.compute.ts configuration reference + Nuxt/Astro framework lists

### DIFF
--- a/apps/docs/content/docs/(index)/prisma-compute/deploy.mdx
+++ b/apps/docs/content/docs/(index)/prisma-compute/deploy.mdx
@@ -21,7 +21,7 @@ Before you start, make sure you have:
 
 - **A JavaScript runtime.** Node.js 22.12 or newer for `npx`/`pnpm dlx`, or Bun for `bunx`.
 - **A [Prisma Data Platform account](https://pris.ly/pdp).** Free to create, and it holds your workspace.
-- **An app, if you are bringing your own.** Compute deploys **Next.js**, **Hono**, **TanStack Start**, and plain **Bun** servers today, including **Elysia** (which runs on Bun). Skip this if you are scaffolding a new app below.
+- **An app, if you are bringing your own.** Compute deploys **Next.js**, **Nuxt**, **Astro**, **Hono**, **TanStack Start**, and plain **Bun** servers today, including **Elysia** (which runs on Bun). Skip this if you are scaffolding a new app below.
 
 :::info
 
@@ -87,7 +87,7 @@ npx @prisma/cli@latest app deploy
 
 In one pass, the CLI:
 
-1. **Detects your framework** from your project files, whether that is Next.js, Hono, TanStack Start, or a plain Bun server. To choose it yourself, pass `--framework` (use `--framework bun` for a Bun or Elysia server).
+1. **Detects your framework** from your project files, whether that is Next.js, Nuxt, Astro, Hono, TanStack Start, or a plain Bun server. To choose it yourself, pass `--framework` (use `--framework bun` for a Bun or Elysia server).
 2. **Sets up a project** the first time you deploy from this directory, then writes [`.prisma/local.json`](/compute/getting-started#link-an-existing-project) to pin the directory to that project. That file is a gitignored local cache, not committed config. If your team already has a project, [link it first](/compute/getting-started#link-an-existing-project).
 3. **Resolves the target branch.** Inside a Git repository, the CLI uses your current Git branch name; otherwise it falls back to `main`. Pass `--branch <name>` to choose explicitly. Because each branch is its own isolated environment, this decides where the deploy lands.
 4. **Builds and uploads your app**, provisions it, and prints a live URL.

--- a/apps/docs/content/docs/compute/branching.mdx
+++ b/apps/docs/content/docs/compute/branching.mdx
@@ -39,16 +39,9 @@ Inspect platform branches:
 
 ```npm
 npx @prisma/cli@latest branch list
-npx @prisma/cli@latest branch show
 ```
 
-`branch use` changes which branch your later commands target, without creating anything remote:
-
-```npm
-npx @prisma/cli@latest branch use feature/search
-```
-
-Listing a branch doesn't expand the apps and databases inside it. Use the `app` commands to inspect those.
+Listing branches doesn't expand the apps and databases inside them. Use the `app` commands to inspect those.
 
 ## Creating branches
 

--- a/apps/docs/content/docs/compute/cli-reference.mdx
+++ b/apps/docs/content/docs/compute/cli-reference.mdx
@@ -54,7 +54,7 @@ Manage apps and deployments for a project.
 | `--project <id-or-name>`  | Target a specific project                                                    |
 | `--create-project <name>` | Create and link a new project before deploying                               |
 | `--branch <name>`         | Deploy to a specific branch; otherwise your active Git branch, then `main`   |
-| `--framework <name>`      | One of `nextjs`, `hono`, `tanstack-start`, `bun`                             |
+| `--framework <name>`      | One of `nextjs`, `nuxt`, `astro`, `hono`, `tanstack-start`, `bun`            |
 | `--entry <path>`          | Entry point, required for `bun` and useful when detection needs a hand       |
 | `--http-port <port>`      | HTTP port your app listens on                                                |
 | `--env <KEY=value>`       | Set a one-off variable for this deployment (repeatable)                      |

--- a/apps/docs/content/docs/compute/cli-reference.mdx
+++ b/apps/docs/content/docs/compute/cli-reference.mdx
@@ -14,7 +14,7 @@ The package installs an executable called `prisma-cli`. Run it without installin
 npx @prisma/cli@latest <command>
 ```
 
-Requires Node.js 22.12 or newer for `npx` and `pnpm`; `bunx` also works. The command groups are `auth`, `project`, `project env`, `git`, `branch`, `app`, and `version`. There is no `init`, `schema`, `database`, or `migrate` command in the beta.
+Requires Node.js 22.12 or newer for `npx` and `pnpm`; `bunx` also works. The command groups are `auth`, `project`, `project env`, `git`, `branch`, `database`, `app`, and `version`. There is no `init`, `schema`, or `migrate` command in the beta.
 
 ## `auth`
 
@@ -121,13 +121,11 @@ Values are write-only: encrypted at rest and never returned by any surface. They
 
 ## `branch`
 
-Inspect platform branches for the resolved project. These commands don't create remote state. To learn more, see the [Branching docs](/compute/branching).
+Inspect platform branches for the resolved project without creating remote state. To learn more, see the [Branching docs](/compute/branching).
 
-| Command            | Description                                              |
-| ------------------ | --------------------------------------------------------- |
-| `branch list`      | List platform branches for the resolved project            |
-| `branch show`      | Show the platform branch matching your current Git branch  |
-| `branch use [name]`| Switch your local branch context without creating anything |
+| Command       | Description                                      |
+| ------------- | ------------------------------------------------- |
+| `branch list` | List platform branches for the resolved project    |
 
 ## `git`
 

--- a/apps/docs/content/docs/compute/cli-reference.mdx
+++ b/apps/docs/content/docs/compute/cli-reference.mdx
@@ -171,7 +171,7 @@ Branch on `error.code`, not the message text: codes are a stable contract, while
 
 An agent skill teaches a coding agent the Compute deploy workflow. Install it into a repo with:
 
-```bash
+```npm
 npx skills add prisma/skills --skill prisma-compute
 ```
 

--- a/apps/docs/content/docs/compute/cli-reference.mdx
+++ b/apps/docs/content/docs/compute/cli-reference.mdx
@@ -171,13 +171,13 @@ Branch on `error.code`, not the message text: codes are a stable contract, while
 
 ## Agent skills
 
-The CLI ships agent skills for guided deploys. Install them into a repo with:
+An agent skill teaches a coding agent the Compute deploy workflow. Install it into a repo with:
 
 ```bash
-pnpm dlx skills@latest add prisma/prisma-cli/skills --all
+npx skills add prisma/skills --skill prisma-compute
 ```
 
-This adds the `prisma-cli`, `prisma-cli-deploy-nextjs`, and `prisma-cli-feedback` skills to `.agents/skills/`. To learn more, see [Agent skills](/compute/getting-started#agent-skills) in the getting started guide.
+This adds the `prisma-compute` skill to `.agents/skills/`, where supported agents pick it up. To install every Prisma skill at once, run `npx skills add prisma/skills`. To learn more, see [Agent skills](/compute/getting-started#agent-skills) in the getting started guide.
 
 ## Environment variables
 

--- a/apps/docs/content/docs/compute/configuration.mdx
+++ b/apps/docs/content/docs/compute/configuration.mdx
@@ -3,16 +3,16 @@ title: Configuration
 description: Declare your deployable app in a typed prisma.compute.ts file so deploys are reproducible and monorepos work, without re-passing flags every time.
 url: /compute/configuration
 metaTitle: "prisma.compute.ts configuration | Prisma Compute"
-metaDescription: Reference for the prisma.compute.ts file — declare your app's framework, root, port, environment, and build settings, or several apps in a monorepo, with full type safety.
+metaDescription: "Reference for the prisma.compute.ts file: declare your app's framework, root, port, environment, and build settings, or several apps in a monorepo, with full type safety."
 ---
 
-`prisma.compute.ts` is an optional, committed file that declares what you deploy. [`app deploy`](/compute/cli-reference#app) already works with zero config — it detects your framework and builds — so reach for a config file when you want one of these:
+`prisma.compute.ts` is an optional, committed file that declares what you deploy. [`app deploy`](/compute/cli-reference#app) already works with zero config (it detects your framework and builds), so reach for a config file when you want one of these:
 
 - **Reproducible deploys.** Pin the framework, port, and build settings so every deploy (yours, a teammate's, or [deploy-on-push](/compute/github)) does the same thing without re-passing flags.
 - **A monorepo.** Declare several apps in one repository and deploy them together, or one at a time.
 - **Type safety.** Catch a typo'd field or an invalid framework in your editor, before you deploy.
 
-The file is read by `app deploy`, `app build`, and `app run`. It never selects your project, branch, or production — those stay explicit. It also does not configure a database; that stays on the [`--db` flag](/compute/cli-reference#app-deploy-options).
+The file is read by `app deploy`, `app build`, and `app run`. It never selects your project, branch, or production; those stay explicit. It also does not configure a database; that stays on the [`--db` flag](/compute/cli-reference#app-deploy-options).
 
 ## A minimal config
 
@@ -30,7 +30,7 @@ export default defineComputeConfig({
 });
 ```
 
-Every field is optional — an empty `app: {}` is valid and defers entirely to detection. The values you do set become the defaults for `app deploy`; explicit flags still win over them.
+Every field is optional. An empty `app: {}` is valid and defers entirely to detection. The values you do set become the defaults for `app deploy`; explicit flags still win over them.
 
 :::info
 
@@ -40,7 +40,7 @@ Every field is optional — an empty `app: {}` is valid and defers entirely to d
 npm install -D @prisma/compute-sdk
 ```
 
-JavaScript configs work too — a plain `export default { app: { ... } }` from `prisma.compute.js`/`.mjs`/`.cjs` is valid, just without the type checking.
+JavaScript configs work too: a plain `export default { app: { ... } }` from `prisma.compute.js`/`.mjs`/`.cjs` is valid, just without the type checking.
 
 :::
 
@@ -95,7 +95,7 @@ export default defineComputeConfig({
 });
 ```
 
-File paths resolve from the config file's directory. Any `--env` flag you pass on the command line **replaces** the config's env inputs entirely — they do not merge.
+File paths resolve from the config file's directory. Any `--env` flag you pass on the command line **replaces** the config's env inputs entirely; they do not merge.
 
 :::info
 
@@ -123,7 +123,7 @@ export default defineComputeConfig({
 - `command: null` skips the build step entirely.
 - A `build` block applies to `nextjs`, `hono`, `tanstack-start`, and `bun`. `nuxt` and `astro` run their own framework CLI, so a `build` block with those frameworks is a configuration error.
 
-Without a `build` block, the CLI infers everything — running your `package.json` build script when there is one, otherwise the framework default — and shows you what it chose during the deploy.
+Without a `build` block, the CLI infers everything (running your `package.json` build script when there is one, otherwise the framework default) and shows you what it chose during the deploy.
 
 ## Where the file lives
 
@@ -157,7 +157,7 @@ export default defineComputeConfig({
 
 All the apps live in one project, deploying to the same branch. From here:
 
-- **Deploy everything** with a bare `app deploy` — it deploys every app in order. This is the default when no target is named or inferred:
+- **Deploy everything** with a bare `app deploy`, which deploys every app in order. This is the default when no target is named or inferred:
 
   ```npm
   npx @prisma/cli@latest app deploy
@@ -173,9 +173,9 @@ All the apps live in one project, deploying to the same branch. From here:
   cd apps/api && npx @prisma/cli@latest app deploy
   ```
 
-When you deploy everything at once, per-app flags like `--framework` or `--entry` are rejected as ambiguous — pass a target to apply them to one app. Project- and branch-level flags (`--branch`, `--db`, `--prod`, `--yes`) apply to the whole run.
+When you deploy everything at once, per-app flags like `--framework` or `--entry` are rejected as ambiguous. Pass a target to apply them to one app. Project- and branch-level flags (`--branch`, `--db`, `--prod`, `--yes`) apply to the whole run.
 
-`app build` and `app run` always target a single app in a multi-app config — unlike `deploy`, they have no all-apps form. Pass a target, or run from inside the app's `root`.
+`app build` and `app run` always target a single app in a multi-app config. Unlike `deploy`, they have no all-apps form, so pass a target or run from inside the app's `root`.
 
 ## How config and flags interact
 
@@ -185,7 +185,7 @@ Config values are deploy **defaults**. Explicit flags always win:
 - Any `--env` flag replaces the config's env inputs entirely.
 - `--app` and `PRISMA_APP_ID` outrank the config's app `name` for app selection.
 
-The config never sets your project, branch, or production target — those are always resolved the same way, [from the directory's project link and your Git branch](/compute/cli-reference#app-deploy-options). Settings that did come from the file are labeled `set by prisma.compute.ts` in the deploy output, so you can always see where a value came from.
+The config never sets your project, branch, or production target; those are always resolved the same way, [from the directory's project link and your Git branch](/compute/cli-reference#app-deploy-options). Settings that did come from the file are labeled `set by prisma.compute.ts` in the deploy output, so you can always see where a value came from.
 
 A config that fails to load or validate stops the deploy before any remote work, with a clear message pointing at the field to fix.
 

--- a/apps/docs/content/docs/compute/configuration.mdx
+++ b/apps/docs/content/docs/compute/configuration.mdx
@@ -1,0 +1,197 @@
+---
+title: Configuration
+description: Declare your deployable app in a typed prisma.compute.ts file so deploys are reproducible and monorepos work, without re-passing flags every time.
+url: /compute/configuration
+metaTitle: "prisma.compute.ts configuration | Prisma Compute"
+metaDescription: Reference for the prisma.compute.ts file — declare your app's framework, root, port, environment, and build settings, or several apps in a monorepo, with full type safety.
+---
+
+`prisma.compute.ts` is an optional, committed file that declares what you deploy. [`app deploy`](/compute/cli-reference#app) already works with zero config — it detects your framework and builds — so reach for a config file when you want one of these:
+
+- **Reproducible deploys.** Pin the framework, port, and build settings so every deploy (yours, a teammate's, or [deploy-on-push](/compute/github)) does the same thing without re-passing flags.
+- **A monorepo.** Declare several apps in one repository and deploy them together, or one at a time.
+- **Type safety.** Catch a typo'd field or an invalid framework in your editor, before you deploy.
+
+The file is read by `app deploy`, `app build`, and `app run`. It never selects your project, branch, or production — those stay explicit. It also does not configure a database; that stays on the [`--db` flag](/compute/cli-reference#app-deploy-options).
+
+## A minimal config
+
+Export a single `app` with `defineComputeConfig`:
+
+```ts title="prisma.compute.ts"
+import { defineComputeConfig } from "@prisma/compute-sdk/config";
+
+export default defineComputeConfig({
+  app: {
+    framework: "hono",
+    entry: "src/index.ts",
+    httpPort: 8080,
+  },
+});
+```
+
+Every field is optional — an empty `app: {}` is valid and defers entirely to detection. The values you do set become the defaults for `app deploy`; explicit flags still win over them.
+
+:::info
+
+`defineComputeConfig` is an identity helper that gives the file full type checking. The CLI resolves the import when it reads your config, so the file works without a local install. To get editor types, add the package as a dev dependency:
+
+```npm
+npm install -D @prisma/compute-sdk
+```
+
+JavaScript configs work too — a plain `export default { app: { ... } }` from `prisma.compute.js`/`.mjs`/`.cjs` is valid, just without the type checking.
+
+:::
+
+## App fields
+
+Each app accepts these fields. All are optional.
+
+| Field       | Type                          | Description                                                                                 |
+| ----------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
+| `name`      | `string`                      | The deployed app name. Defaults to the `apps` key, then to inference from `package.json`.   |
+| `root`      | `string`                      | The app directory, relative to the config file. Defaults to the config file's directory.    |
+| `framework` | framework name                | One of `nextjs`, `nuxt`, `astro`, `hono`, `tanstack-start`, `bun`. Defaults to detection.   |
+| `entry`     | `string`                      | Entrypoint path for `bun` and `hono` apps, relative to the app root.                         |
+| `httpPort`  | `number`                      | The port your app listens on. Defaults to the framework's default.                          |
+| `env`       | `string` or `{ file, vars }`  | Environment inputs for the deploy. See [Environment](#environment).                          |
+| `build`     | `{ command, outputDirectory }`| Build settings. See [Build settings](#build-settings).                                       |
+
+```ts title="prisma.compute.ts"
+import { defineComputeConfig } from "@prisma/compute-sdk/config";
+
+export default defineComputeConfig({
+  app: {
+    name: "api",
+    framework: "hono",
+    entry: "src/index.ts",
+    httpPort: 8080,
+  },
+});
+```
+
+### Environment
+
+`env` is either a dotenv file path, or an object with file path(s) and inline variables:
+
+```ts title="prisma.compute.ts"
+export default defineComputeConfig({
+  app: {
+    // Shorthand: a single dotenv file.
+    env: ".env",
+  },
+});
+```
+
+```ts title="prisma.compute.ts"
+export default defineComputeConfig({
+  app: {
+    env: {
+      file: [".env", ".env.production"],
+      vars: { LOG_LEVEL: "info" },
+    },
+  },
+});
+```
+
+File paths resolve from the config file's directory. Any `--env` flag you pass on the command line **replaces** the config's env inputs entirely — they do not merge.
+
+:::info
+
+`prisma.compute.ts` is committed to your repository, so keep secrets out of inline `vars`. For real secrets and your database connection string, use scoped [environment variables](/compute/environment-variables) instead.
+
+:::
+
+### Build settings
+
+A `build` block lets you own how an app is built:
+
+```ts title="prisma.compute.ts"
+export default defineComputeConfig({
+  app: {
+    framework: "nextjs",
+    build: {
+      command: "pnpm run build",
+      outputDirectory: ".next/standalone",
+    },
+  },
+});
+```
+
+- Both fields are optional. A field you set overrides the framework default; a field you omit is inferred.
+- `command: null` skips the build step entirely.
+- A `build` block applies to `nextjs`, `hono`, `tanstack-start`, and `bun`. `nuxt` and `astro` run their own framework CLI, so a `build` block with those frameworks is a configuration error.
+
+Without a `build` block, the CLI infers everything — running your `package.json` build script when there is one, otherwise the framework default — and shows you what it chose during the deploy.
+
+## Where the file lives
+
+`app deploy` reads the **nearest** config file, searching from your current directory up to the repository or workspace root (the closest ancestor with a `.git`, `pnpm-workspace.yaml`, `bun.lock`, or a `workspaces` field). Discovery never escapes the repository.
+
+Per directory, exactly one of `prisma.compute.ts`, `prisma.compute.mts`, `prisma.compute.js`, `prisma.compute.mjs`, or `prisma.compute.cjs` may exist.
+
+The config file's directory is treated as the project directory: the [`.prisma/local.json`](/compute/getting-started#link-an-existing-project) project pin lives there, and paths in the config (`root`, `env.file`) resolve from there. That means the config means the same thing no matter which subdirectory you run the command from.
+
+## Monorepos
+
+Use `apps` instead of `app` to declare several apps in one repository, keyed by a target name:
+
+```ts title="prisma.compute.ts"
+import { defineComputeConfig } from "@prisma/compute-sdk/config";
+
+export default defineComputeConfig({
+  apps: {
+    api: {
+      root: "apps/api",
+      framework: "hono",
+      entry: "src/index.ts",
+    },
+    web: {
+      root: "apps/web",
+      framework: "nextjs",
+    },
+  },
+});
+```
+
+All the apps live in one project, deploying to the same branch. From here:
+
+- **Deploy everything** with a bare `app deploy` — it deploys every app in order. This is the default when no target is named or inferred:
+
+  ```npm
+  npx @prisma/cli@latest app deploy
+  ```
+
+- **Deploy one app** by naming its target, or by running from inside its `root` (the deepest matching root wins):
+
+  ```npm
+  npx @prisma/cli@latest app deploy api
+  ```
+
+  ```npm
+  cd apps/api && npx @prisma/cli@latest app deploy
+  ```
+
+When you deploy everything at once, per-app flags like `--framework` or `--entry` are rejected as ambiguous — pass a target to apply them to one app. Project- and branch-level flags (`--branch`, `--db`, `--prod`, `--yes`) apply to the whole run.
+
+`app build` and `app run` always need a single target in a multi-app config, since a dev server can only run one app at a time.
+
+## How config and flags interact
+
+Config values are deploy **defaults**. Explicit flags always win:
+
+- `--framework`, `--entry`, and `--http-port` override their config value.
+- Any `--env` flag replaces the config's env inputs entirely.
+- `--app` and `PRISMA_APP_ID` outrank the config's app `name` for app selection.
+
+The config never sets your project, branch, or production target — those are always resolved the same way, [from the directory's project link and your Git branch](/compute/cli-reference#app-deploy-options). Settings that did come from the file are labeled `set by prisma.compute.ts` in the deploy output, so you can always see where a value came from.
+
+A config that fails to load or validate stops the deploy before any remote work, with a clear message pointing at the field to fix.
+
+## What's next
+
+- [CLI reference](/compute/cli-reference): every command, flag, and error code.
+- [Deploy your first app](/prisma-compute/deploy): the end-to-end quickstart.
+- [Environment variables](/compute/environment-variables): scoped configuration, secrets, and your database connection string.
+- [GitHub integration](/compute/github): deploy-on-push, including monorepos.

--- a/apps/docs/content/docs/compute/configuration.mdx
+++ b/apps/docs/content/docs/compute/configuration.mdx
@@ -175,7 +175,7 @@ All the apps live in one project, deploying to the same branch. From here:
 
 When you deploy everything at once, per-app flags like `--framework` or `--entry` are rejected as ambiguous — pass a target to apply them to one app. Project- and branch-level flags (`--branch`, `--db`, `--prod`, `--yes`) apply to the whole run.
 
-`app build` and `app run` always need a single target in a multi-app config, since a dev server can only run one app at a time.
+`app build` and `app run` always target a single app in a multi-app config — unlike `deploy`, they have no all-apps form. Pass a target, or run from inside the app's `root`.
 
 ## How config and flags interact
 

--- a/apps/docs/content/docs/compute/getting-started.mdx
+++ b/apps/docs/content/docs/compute/getting-started.mdx
@@ -89,7 +89,7 @@ npx @prisma/cli@latest project list
 
 ## Pick a framework
 
-The CLI detects your framework automatically. Today there is first-class support for **Next.js**, **Hono**, and **TanStack Start**:
+The CLI detects your framework automatically. Today there is first-class support for **Next.js**, **Nuxt**, **Astro**, **Hono**, and **TanStack Start**:
 
 ```npm
 npx @prisma/cli@latest app deploy --framework nextjs

--- a/apps/docs/content/docs/compute/getting-started.mdx
+++ b/apps/docs/content/docs/compute/getting-started.mdx
@@ -173,7 +173,7 @@ npx @prisma/cli@latest app deploy --create-project my-app --app web
 
 If a coding agent does your deploying, install the Prisma Compute agent skill into your repo:
 
-```bash
+```npm
 npx skills add prisma/skills --skill prisma-compute
 ```
 

--- a/apps/docs/content/docs/compute/getting-started.mdx
+++ b/apps/docs/content/docs/compute/getting-started.mdx
@@ -171,19 +171,15 @@ npx @prisma/cli@latest app deploy --create-project my-app --app web
 
 ### Agent skills
 
-If a coding agent does your deploying, install the Prisma CLI agent skills into your repo:
+If a coding agent does your deploying, install the Prisma Compute agent skill into your repo:
 
 ```bash
-pnpm dlx skills@latest add prisma/prisma-cli/skills --all
+npx skills add prisma/skills --skill prisma-compute
 ```
 
-This installs three skills into `.agents/skills/`, where supported agents pick them up automatically:
+The `prisma-compute` skill teaches your agent the Compute deploy workflow — auth, framework detection, deploys, logs, and domains — so it follows the right steps. Supported agents pick it up automatically from `.agents/skills/`.
 
-- `prisma-cli`: routes broad deploy prompts to the right workflow.
-- `prisma-cli-deploy-nextjs`: a guided Next.js deploy, from auth check to live URL.
-- `prisma-cli-feedback`: files bugs and feedback with the Prisma team.
-
-To match the skills to a specific CLI version, add `#cli-v<version>` to the source, for example `prisma/prisma-cli/skills#cli-v3.0.0-beta.3`, so the instructions your agent follows match the CLI version your project runs.
+To install every Prisma skill (ORM CLI, Postgres, and more) at once, run `npx skills add prisma/skills`.
 
 ### Structured output
 

--- a/apps/docs/content/docs/compute/getting-started.mdx
+++ b/apps/docs/content/docs/compute/getting-started.mdx
@@ -177,7 +177,7 @@ If a coding agent does your deploying, install the Prisma Compute agent skill in
 npx skills add prisma/skills --skill prisma-compute
 ```
 
-The `prisma-compute` skill teaches your agent the Compute deploy workflow — auth, framework detection, deploys, logs, and domains — so it follows the right steps. Supported agents pick it up automatically from `.agents/skills/`.
+The `prisma-compute` skill teaches your agent the Compute deploy workflow (auth, framework detection, deploys, logs, and domains), so it follows the right steps. Supported agents pick it up automatically from `.agents/skills/`.
 
 To install every Prisma skill (ORM CLI, Postgres, and more) at once, run `npx skills add prisma/skills`.
 

--- a/apps/docs/content/docs/compute/limitations.mdx
+++ b/apps/docs/content/docs/compute/limitations.mdx
@@ -11,14 +11,14 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). 
 ## CLI
 
 - The package is `@prisma/cli`; the executable is `prisma-cli`. The quickest way to run it is `npx @prisma/cli@latest <command>` (or `bunx`/`pnpm dlx`), with Node.js 22.12 or newer for `npx` and `pnpm`.
-- The command groups are `auth`, `project`, `project env`, `git`, `branch`, `app`, and `version`. There is no `init`, `schema`, `database`, or `migrate` command, and no product-branded `compute` namespace.
+- The command groups are `auth`, `project`, `project env`, `git`, `branch`, `database`, `app`, and `version`. There is no `init`, `schema`, or `migrate` command, and no product-branded `compute` namespace.
 - Project and app resolution never reads or writes committed config files. `.prisma/local.json` is a gitignored local pin, and `PRISMA_PROJECT_ID` / `PRISMA_APP_ID` override it for CI.
 
 ## Projects and branches
 
 - Project setup is explicit: `--yes` won't create or choose a project for you.
 - The first branch in a project is production; the rest are preview by default.
-- `branch list` and `branch show` inspect branches; they don't create remote state.
+- `branch list` inspects branches; it doesn't create remote state.
 - Deleting a branch on GitHub can tear down the matching platform branch, but production and default branches are always left alone.
 
 ## Frameworks and runtimes

--- a/apps/docs/content/docs/compute/limitations.mdx
+++ b/apps/docs/content/docs/compute/limitations.mdx
@@ -23,7 +23,7 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). 
 
 ## Frameworks and runtimes
 
-- `app deploy --framework` accepts `nextjs`, `hono`, `tanstack-start`, and `bun`.
+- `app deploy --framework` accepts `nextjs`, `nuxt`, `astro`, `hono`, `tanstack-start`, and `bun`.
 - `app build --build-type` accepts `auto`, `bun`, `nextjs`, `nuxt`, `astro`, and `tanstack-start`.
 - `app run --build-type` accepts `auto`, `bun`, and `nextjs`.
 - Use `--entry` for Bun, or whenever detection needs a hand.

--- a/apps/docs/content/docs/compute/meta.json
+++ b/apps/docs/content/docs/compute/meta.json
@@ -14,6 +14,7 @@
     "---Integrations---",
     "github",
     "---Reference---",
+    "configuration",
     "cli-reference",
     "---More---",
     "faq",


### PR DESCRIPTION
## What

1. **New Configuration reference page** for the `prisma.compute.ts` file (shipped in prisma/prisma-cli#84), slotted into the Compute section nav under **Reference**, before `cli-reference`. Covers:
   - when to use a config vs. zero-config deploy; the minimal single-`app` shape and `defineComputeConfig`
   - every app field (`name`, `root`, `framework`, `entry`, `httpPort`, `env`, `build`) as a table
   - `env` shapes and the committed-file secrets caveat
   - `build` settings incl. the nuxt/astro "no build block" rule
   - file discovery (nearest config up to repo root; config dir = project dir)
   - monorepos: the `apps` map, deploy-all vs. targeting one app, build/run needing a target
   - how config defaults interact with flags

2. **Framework-list consistency.** Nuxt and Astro deploy support is live, but the quickstart, getting-started, `cli-reference` `--framework`, and limitations still listed only nextjs/hono/tanstack-start/bun (while `--build-type` already listed nuxt/astro). Updated all of them to the full set: `nextjs`, `nuxt`, `astro`, `hono`, `tanstack-start`, `bun`.

## Verification

`lint:links` and `lint:code` pass; cross-link anchors resolve; formatted with oxfmt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Compute configuration guide for `prisma.compute.ts` (and JS/MTS variants), covering supported fields, env handling, build behavior, and monorepo discovery rules.
  * Expanded documented framework support to include **Nuxt** and **Astro** across setup and CLI references.
  * Updated Prisma Compute CLI documentation, including framework detection, agent skills installation via `npx`, and refreshed branch-related commands.
  * Refined Compute limitations and branching behavior guidance for the beta.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->