### PR TITLE
docs(compute): add Prisma Compute pricing page

### DIFF
--- a/apps/blog/content/blog/bun-rust-rewrite-prisma-compute/index.mdx
+++ b/apps/blog/content/blog/bun-rust-rewrite-prisma-compute/index.mdx
@@ -99,7 +99,7 @@ A benchmark tells you one kind of truth, and a minimal repro isolates another. B
 This is the feedback loop open-source runtimes need. We hit failures in production, reduced them to reports someone could act on, and watched the Rust rewrite resolve several of them. We launched on the build that behaved better, and we'll keep sending what we learn upstream.
 
 
-[Prisma Compute is in public beta](https://pris.ly/compute-blog-pb) now. To try it out, sign in once:
+[Prisma Compute is in public beta](https://pris.ly/compute-blog-pb) now, and [free to use during the beta](https://docs.prisma.io/docs/compute/pricing). To try it out, sign in once:
 
 ```bash
 bunx @prisma/cli@latest auth login

--- a/apps/blog/content/blog/bun-rust-rewrite-prisma-compute/index.mdx
+++ b/apps/blog/content/blog/bun-rust-rewrite-prisma-compute/index.mdx
@@ -99,7 +99,7 @@ A benchmark tells you one kind of truth, and a minimal repro isolates another. B
 This is the feedback loop open-source runtimes need. We hit failures in production, reduced them to reports someone could act on, and watched the Rust rewrite resolve several of them. We launched on the build that behaved better, and we'll keep sending what we learn upstream.
 
 
-[Prisma Compute is in public beta](https://pris.ly/compute-blog-pb) now, and [free to use during the beta](https://docs.prisma.io/docs/compute/pricing). To try it out, sign in once:
+[Prisma Compute is in public beta](https://pris.ly/compute-blog-pb) now, and [free to use during the beta](https://pris.ly/pricing-compute). To try it out, sign in once:
 
 ```bash
 bunx @prisma/cli@latest auth login

--- a/apps/blog/content/blog/launching-prisma-compute-public-beta/index.mdx
+++ b/apps/blog/content/blog/launching-prisma-compute-public-beta/index.mdx
@@ -46,7 +46,7 @@ With Prisma Compute, Prisma becomes a platform for product builders who want to 
 
 ## Try it
 
-Compute is in public beta starting today. Sign in once with `bunx @prisma/cli@latest auth login`, the one step that needs a human, then point your coding agent at your project and tell it:
+Compute is in public beta starting today, and free to use while in beta (see the [expected pricing](https://docs.prisma.io/docs/compute/pricing) for when production billing turns on). Sign in once with `bunx @prisma/cli@latest auth login`, the one step that needs a human, then point your coding agent at your project and tell it:
 
 <AgentPrompt
   prompt="Deploy your app with @prisma/cli@latest."

--- a/apps/blog/content/blog/launching-prisma-compute-public-beta/index.mdx
+++ b/apps/blog/content/blog/launching-prisma-compute-public-beta/index.mdx
@@ -46,7 +46,7 @@ With Prisma Compute, Prisma becomes a platform for product builders who want to 
 
 ## Try it
 
-Compute is in public beta starting today, and free to use while in beta (see the [expected pricing](https://docs.prisma.io/docs/compute/pricing) for when production billing turns on). Sign in once with `bunx @prisma/cli@latest auth login`, the one step that needs a human, then point your coding agent at your project and tell it:
+Compute is in public beta starting today, and free to use while in beta (see the [expected pricing](https://pris.ly/pricing-compute) for when production billing turns on). Sign in once with `bunx @prisma/cli@latest auth login`, the one step that needs a human, then point your coding agent at your project and tell it:
 
 <AgentPrompt
   prompt="Deploy your app with @prisma/cli@latest."

--- a/apps/docs/content/docs/compute/faq.mdx
+++ b/apps/docs/content/docs/compute/faq.mdx
@@ -113,6 +113,10 @@ No. Your app connects to a database through a connection string you set as an en
 
 Yes. Use it to inspect projects, branches, apps, deployments, integrations, env var names, and domain status.
 
+## Is Prisma Compute free?
+
+Yes, Compute is free to use during public beta. We've published the rates we expect to charge once production billing turns on, so you can understand the model and estimate future usage before then. See [Pricing](https://pris.ly/pricing-compute) for the expected rates, worked examples, and what is not billed separately.
+
 ## What does Public Beta mean for Compute?
 
 The core model and documented happy paths are stable enough for evaluation, staging, internal tools, and low-risk apps; details like limits, pricing, and some CLI, API, and Console behavior can still change before general availability. See [Public Beta](/console/more/feature-maturity#public-beta) on the feature maturity page.

--- a/apps/docs/content/docs/compute/faq.mdx
+++ b/apps/docs/content/docs/compute/faq.mdx
@@ -115,7 +115,7 @@ Yes. Use it to inspect projects, branches, apps, deployments, integrations, env 
 
 ## Is Prisma Compute free?
 
-Yes, Compute is free to use during public beta. We've published the rates we expect to charge once production billing turns on, so you can understand the model and estimate future usage before then. See [Pricing](https://pris.ly/pricing-compute) for the expected rates, worked examples, and what is not billed separately.
+Yes, Compute is free during public beta. We've published the rates we expect to charge once we enable production billing, so you can estimate future usage now. See [Pricing](https://pris.ly/pricing-compute) for the rates, worked examples, and what is not billed separately.
 
 ## What does Public Beta mean for Compute?
 

--- a/apps/docs/content/docs/compute/meta.json
+++ b/apps/docs/content/docs/compute/meta.json
@@ -16,6 +16,7 @@
     "---Reference---",
     "cli-reference",
     "---More---",
+    "pricing",
     "faq",
     "limitations"
   ]

--- a/apps/docs/content/docs/compute/pricing.mdx
+++ b/apps/docs/content/docs/compute/pricing.mdx
@@ -1,0 +1,116 @@
+---
+title: Pricing
+description: How Prisma Compute pricing works, with the expected production rates and worked examples.
+url: /compute/pricing
+metaTitle: Pricing | Prisma Compute
+metaDescription: How Prisma Compute pricing works, including the expected per-meter rates, worked cost examples, the billing formula, and what is not billed.
+---
+
+Compute is free during public beta. The rates below are what we expect to charge once production billing turns on. We are publishing them now so you can understand the model, estimate future usage, and tell us where real workloads don't fit.
+
+:::info[Public Beta]
+
+Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta), so rates, limits, and included usage may change before billing begins. If something has to change, we will change it and say so clearly.
+
+:::
+
+## Expected usage rates
+
+| Meter               | Price                  | What it means                                                                          |
+| ------------------- | ---------------------- | -------------------------------------------------------------------------------------- |
+| Requests            | `$1.00 / 1M requests`  | Every inbound request your app handles.                                                |
+| Provisioned memory  | `$0.006 / GB-hour`     | Memory allocated while your app is running or intentionally kept awake.                |
+| Active CPU          | `$0.064 / vCPU-hour`   | CPU time your app actually consumes.                                                   |
+| Outbound bandwidth  | `$0.025 / GB`          | Data your app sends out to the internet. Incoming requests do not count as bandwidth.  |
+
+Each meter covers a different part of serving a request: requests start the work, provisioned memory keeps it alive, active CPU executes it, and outbound bandwidth delivers the results.
+
+## Examples
+
+These examples are estimates, not benchmarks. They use simple round inputs so the math is easy to inspect. Compute is free during beta, so these examples show what the same usage would amount to under the expected pricing model.
+
+### Preview workflow
+
+A normal pull request might deploy a preview several times while an agent fixes and tests a change.
+
+Assume the preview gets `10,000` requests, stays running for `3,000s` at `1 GB`, uses `600 vCPU-seconds` of active CPU, and sends `0.25 GB` of data out.
+
+| Meter               | Estimate                                                  |
+| ------------------- | --------------------------------------------------------- |
+| Requests            | `10,000 * $1.00 / 1M = $0.0100`                           |
+| Provisioned memory  | `3,000s at 1 GB = 0.833 GB-hours * $0.006 = $0.0050`      |
+| Active CPU          | `600 vCPU-seconds = 0.167 vCPU-hours * $0.064 = $0.0107`  |
+| Outbound bandwidth  | `0.25 GB * $0.025 = $0.0063`                              |
+| Total               | `$0.0320`, about `$0.03`                                  |
+
+The deploys aren't the bill, and neither is the [preview branch](/compute/branching). The usage is.
+
+### Agent workflow
+
+Agent-backed work often spends more time waiting than computing, and the bill reflects that.
+
+Assume an app runs `10,000` agent tasks in a month. Each task takes `30s` wall-clock time, mostly waiting on a model API or another service. Together, the tasks stay running for `300,000s` at `1 GB`, use `30,000 vCPU-seconds` of active CPU, and send `5 GB` of data out.
+
+| Meter               | Estimate                                                       |
+| ------------------- | -------------------------------------------------------------- |
+| Requests            | `10,000 * $1.00 / 1M = $0.0100`                                |
+| Provisioned memory  | `300,000s at 1 GB = 83.33 GB-hours * $0.006 = $0.5000`         |
+| Active CPU          | `30,000 vCPU-seconds = 8.33 vCPU-hours * $0.064 = $0.5333`     |
+| Outbound bandwidth  | `5 GB * $0.025 = $0.1250`                                      |
+| Total               | `$1.1683`, about `$1.17`                                       |
+
+Wall-clock waiting is not CPU time, but CPU used while waiting still counts. Waiting also keeps memory allocated because the app is still alive, even though it doesn't look like CPU-heavy work. That is why Compute separates provisioned memory from active CPU.
+
+### High-transfer workflow
+
+If your app streams responses, returns large generations, or serves files, most of the bill can come from bandwidth rather than compute. This is the case worth checking before you ship.
+
+Assume an app serves `50,000` requests in a month, stays running for `15,000s` at `1 GB`, uses `1,500 vCPU-seconds` of active CPU, and sends `200 GB` of data out.
+
+| Meter               | Estimate                                                     |
+| ------------------- | ------------------------------------------------------------ |
+| Requests            | `50,000 * $1.00 / 1M = $0.0500`                              |
+| Provisioned memory  | `15,000s at 1 GB = 4.167 GB-hours * $0.006 = $0.0250`        |
+| Active CPU          | `1,500 vCPU-seconds = 0.417 vCPU-hours * $0.064 = $0.0267`   |
+| Outbound bandwidth  | `200 GB * $0.025 = $5.0000`                                  |
+| Total               | `$5.1017`, about `$5.10`                                     |
+
+Here the compute is almost free and bandwidth is nearly the whole bill. If your app moves a lot of data, that is the number to watch.
+
+## Formula
+
+```text
+bill =
+  requests * 1.00 / 1_000_000
+  + provisioned_memory_gb_hours * 0.006
+  + active_vcpu_hours * 0.064
+  + outbound_bandwidth_gb * 0.025
+```
+
+## What is not billed separately
+
+You pay for work, not for the existence of a resource. The following are not billed on their own:
+
+- Deployments
+- Preview branch creation
+- Inactive apps
+- Apps that have scaled to zero
+- A Prisma-specific compute unit
+
+Preview branches can still accrue usage when they receive traffic or run background work, but creating one costs nothing by itself.
+
+## Usage data for humans and agents
+
+The same usage data we show in the [Console](https://pris.ly/pdp) is available through the [CLI](/compute/cli-reference), API, and JSON output, so agents can estimate a cost, explain a change, and suggest a fix.
+
+## Beta and bandwidth
+
+Compute is free during public beta, and the expected pricing above may change as we learn from real usage. If something has to change before production billing turns on, we will change it and say so clearly.
+
+Outbound bandwidth means data sent from Compute to the public internet. Small JSON or API apps may barely notice it, while streaming apps, exports, media, and high-transfer APIs will. During beta, we are measuring real traffic to validate the rate, included usage, and edge cases before production billing turns on.
+
+## What to read next
+
+- [Known limitations](/compute/limitations): what the beta can and can't do.
+- [FAQ](/compute/faq): quick answers to common questions.
+- [Branching](/compute/branching): how preview branches isolate work and accrue usage.

--- a/apps/docs/content/docs/compute/pricing.mdx
+++ b/apps/docs/content/docs/compute/pricing.mdx
@@ -121,6 +121,7 @@ This pricing is still taking shape during the beta, and your input shapes where 
 
 ## What to read next
 
+- [Get started](/compute/getting-started): the quickstart, deploy your first app to a live URL in two commands.
 - [Known limitations](/compute/limitations): what the beta can and can't do.
 - [FAQ](/compute/faq): quick answers to common questions.
 - [Branching](/compute/branching): how preview branches isolate work and when they cost money.

--- a/apps/docs/content/docs/compute/pricing.mdx
+++ b/apps/docs/content/docs/compute/pricing.mdx
@@ -12,6 +12,8 @@ Compute is free during public beta. The rates below are what we expect to charge
 
 Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta), so rates, limits, and included usage may change before billing begins. If something has to change, we will change it and say so clearly.
 
+This pricing isn't final, and your feedback shapes it. If a rate or meter doesn't fit how your app runs, tell us in the `prisma-compute` channel on our [Discord](https://pris.ly/discord).
+
 :::
 
 ## Expected usage rates
@@ -111,7 +113,11 @@ The usage data shown in the [Console](https://pris.ly/pdp) is also available fro
 
 Compute is free during public beta. The rates above are estimates and may change as we learn from real usage. If anything changes before we enable production billing, we will say so clearly.
 
-Outbound bandwidth is the data your app sends from Compute to the public internet; inbound requests don't count. Small JSON or API responses use little of it, while streaming, file downloads, and media use much more. During beta we are measuring real traffic to confirm the rate and included usage before billing starts.
+Outbound bandwidth is the data your app sends from Compute to the public internet; inbound requests don't count. Small JSON or API responses use little of it, while streaming, file downloads, and media use much more. During beta we are measuring real traffic to confirm the rate, included usage, and edge cases before billing starts.
+
+## Share your pricing feedback
+
+This pricing is still taking shape during the beta, and your input shapes where it lands. If a rate, meter, or included amount doesn't match how your app actually runs, tell us in the `prisma-compute` channel on our [Discord](https://pris.ly/discord). That feedback is exactly what we are measuring against before billing turns on.
 
 ## What to read next
 

--- a/apps/docs/content/docs/compute/pricing.mdx
+++ b/apps/docs/content/docs/compute/pricing.mdx
@@ -16,6 +16,8 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta), 
 
 ## Expected usage rates
 
+Each meter measures a different resource: how often your app runs (requests), how much memory it holds and CPU it uses while running (provisioned memory and active CPU), and how much data it sends back (outbound bandwidth).
+
 | Meter              | Price                 | What it means                                                                         |
 | ------------------ | --------------------- | ------------------------------------------------------------------------------------- |
 | Requests           | `$1.00 / 1M requests` | Every inbound request your app handles.                                               |
@@ -23,9 +25,9 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta), 
 | Active CPU         | `$0.064 / vCPU-hour`  | CPU time your app actually consumes.                                                  |
 | Outbound bandwidth | `$0.025 / GB`         | Data your app sends out to the internet. Incoming requests do not count as bandwidth. |
 
-Each meter measures a different resource: how often your app runs (requests), how much memory it holds and CPU it uses while running (provisioned memory and active CPU), and how much data it sends back (outbound bandwidth).
+## Example costs by workload
 
-## Examples
+The three examples below show how the same rates add up for different kinds of apps, from a short-lived preview to a bandwidth-heavy service.
 
 These examples are estimates, not benchmarks. The inputs are round numbers so the math is easy to follow. Each total is what the usage would cost under the expected rates, once billing starts.
 
@@ -77,7 +79,9 @@ Assume an app serves `50,000` requests in a month, stays running for `15,000s` a
 
 Here compute is almost free and bandwidth is nearly the whole bill. If your app moves a lot of data, estimate bandwidth first.
 
-## Formula
+## Formula to estimate your bill
+
+To estimate any month yourself, add up the four meters at their rates:
 
 ```text
 bill =

--- a/apps/docs/content/docs/compute/pricing.mdx
+++ b/apps/docs/content/docs/compute/pricing.mdx
@@ -6,7 +6,7 @@ metaTitle: Pricing | Prisma Compute
 metaDescription: How Prisma Compute pricing works, including the expected per-meter rates, worked cost examples, the billing formula, and what is not billed.
 ---
 
-Compute is free during public beta. The rates below are what we expect to charge once production billing turns on. We are publishing them now so you can understand the model, estimate future usage, and tell us where real workloads don't fit.
+Compute is free during public beta. The rates below are what we expect to charge once we enable production billing. We are publishing them now so you can understand the model, estimate future usage, and tell us where real workloads don't fit.
 
 :::info[Public Beta]
 
@@ -16,66 +16,66 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta), 
 
 ## Expected usage rates
 
-| Meter               | Price                  | What it means                                                                          |
-| ------------------- | ---------------------- | -------------------------------------------------------------------------------------- |
-| Requests            | `$1.00 / 1M requests`  | Every inbound request your app handles.                                                |
-| Provisioned memory  | `$0.006 / GB-hour`     | Memory allocated while your app is running or intentionally kept awake.                |
-| Active CPU          | `$0.064 / vCPU-hour`   | CPU time your app actually consumes.                                                   |
-| Outbound bandwidth  | `$0.025 / GB`          | Data your app sends out to the internet. Incoming requests do not count as bandwidth.  |
+| Meter              | Price                 | What it means                                                                         |
+| ------------------ | --------------------- | ------------------------------------------------------------------------------------- |
+| Requests           | `$1.00 / 1M requests` | Every inbound request your app handles.                                               |
+| Provisioned memory | `$0.006 / GB-hour`    | Memory allocated while your app is running or intentionally kept awake.               |
+| Active CPU         | `$0.064 / vCPU-hour`  | CPU time your app actually consumes.                                                  |
+| Outbound bandwidth | `$0.025 / GB`         | Data your app sends out to the internet. Incoming requests do not count as bandwidth. |
 
-Each meter covers a different part of serving a request: requests start the work, provisioned memory keeps it alive, active CPU executes it, and outbound bandwidth delivers the results.
+Each meter measures a different resource: how often your app runs (requests), how much memory it holds and CPU it uses while running (provisioned memory and active CPU), and how much data it sends back (outbound bandwidth).
 
 ## Examples
 
-These examples are estimates, not benchmarks. They use simple round inputs so the math is easy to inspect. Compute is free during beta, so these examples show what the same usage would amount to under the expected pricing model.
+These examples are estimates, not benchmarks. The inputs are round numbers so the math is easy to follow. Each total is what the usage would cost under the expected rates, once billing starts.
 
 ### Preview workflow
 
-A normal pull request might deploy a preview several times while an agent fixes and tests a change.
+A pull request might deploy a preview several times as an agent fixes and tests a change.
 
 Assume the preview gets `10,000` requests, stays running for `3,000s` at `1 GB`, uses `600 vCPU-seconds` of active CPU, and sends `0.25 GB` of data out.
 
-| Meter               | Estimate                                                  |
-| ------------------- | --------------------------------------------------------- |
-| Requests            | `10,000 * $1.00 / 1M = $0.0100`                           |
-| Provisioned memory  | `3,000s at 1 GB = 0.833 GB-hours * $0.006 = $0.0050`      |
-| Active CPU          | `600 vCPU-seconds = 0.167 vCPU-hours * $0.064 = $0.0107`  |
-| Outbound bandwidth  | `0.25 GB * $0.025 = $0.0063`                              |
-| Total               | `$0.0320`, about `$0.03`                                  |
+| Meter              | Estimate                                                 |
+| ------------------ | -------------------------------------------------------- |
+| Requests           | `10,000 * $1.00 / 1M = $0.0100`                          |
+| Provisioned memory | `3,000s at 1 GB = 0.833 GB-hours * $0.006 = $0.0050`     |
+| Active CPU         | `600 vCPU-seconds = 0.167 vCPU-hours * $0.064 = $0.0107` |
+| Outbound bandwidth | `0.25 GB * $0.025 = $0.0063`                             |
+| Total              | `$0.0320`, about `$0.03`                                 |
 
-The deploys aren't the bill, and neither is the [preview branch](/compute/branching). The usage is.
+The usage is the bill, not the deploys or the [preview branch](/compute/branching).
 
 ### Agent workflow
 
-Agent-backed work often spends more time waiting than computing, and the bill reflects that.
+Agent work often spends more time waiting on other services than running on the CPU.
 
 Assume an app runs `10,000` agent tasks in a month. Each task takes `30s` wall-clock time, mostly waiting on a model API or another service. Together, the tasks stay running for `300,000s` at `1 GB`, use `30,000 vCPU-seconds` of active CPU, and send `5 GB` of data out.
 
-| Meter               | Estimate                                                       |
-| ------------------- | -------------------------------------------------------------- |
-| Requests            | `10,000 * $1.00 / 1M = $0.0100`                                |
-| Provisioned memory  | `300,000s at 1 GB = 83.33 GB-hours * $0.006 = $0.5000`         |
-| Active CPU          | `30,000 vCPU-seconds = 8.33 vCPU-hours * $0.064 = $0.5333`     |
-| Outbound bandwidth  | `5 GB * $0.025 = $0.1250`                                      |
-| Total               | `$1.1683`, about `$1.17`                                       |
+| Meter              | Estimate                                                   |
+| ------------------ | ---------------------------------------------------------- |
+| Requests           | `10,000 * $1.00 / 1M = $0.0100`                            |
+| Provisioned memory | `300,000s at 1 GB = 83.33 GB-hours * $0.006 = $0.5000`     |
+| Active CPU         | `30,000 vCPU-seconds = 8.33 vCPU-hours * $0.064 = $0.5333` |
+| Outbound bandwidth | `5 GB * $0.025 = $0.1250`                                  |
+| Total              | `$1.1683`, about `$1.17`                                   |
 
-Wall-clock waiting is not CPU time, but CPU used while waiting still counts. Waiting also keeps memory allocated because the app is still alive, even though it doesn't look like CPU-heavy work. That is why Compute separates provisioned memory from active CPU.
+While a task waits it uses almost no CPU, so active CPU stays low. But the app keeps running the whole time, so it holds its memory and you pay for that. This is why Compute bills provisioned memory separately from active CPU.
 
 ### High-transfer workflow
 
-If your app streams responses, returns large generations, or serves files, most of the bill can come from bandwidth rather than compute. This is the case worth checking before you ship.
+If your app streams responses, returns large results, or serves file downloads, bandwidth can make up most of the bill instead of compute. It is worth estimating this before you ship.
 
 Assume an app serves `50,000` requests in a month, stays running for `15,000s` at `1 GB`, uses `1,500 vCPU-seconds` of active CPU, and sends `200 GB` of data out.
 
-| Meter               | Estimate                                                     |
-| ------------------- | ------------------------------------------------------------ |
-| Requests            | `50,000 * $1.00 / 1M = $0.0500`                              |
-| Provisioned memory  | `15,000s at 1 GB = 4.167 GB-hours * $0.006 = $0.0250`        |
-| Active CPU          | `1,500 vCPU-seconds = 0.417 vCPU-hours * $0.064 = $0.0267`   |
-| Outbound bandwidth  | `200 GB * $0.025 = $5.0000`                                  |
-| Total               | `$5.1017`, about `$5.10`                                     |
+| Meter              | Estimate                                                   |
+| ------------------ | ---------------------------------------------------------- |
+| Requests           | `50,000 * $1.00 / 1M = $0.0500`                            |
+| Provisioned memory | `15,000s at 1 GB = 4.167 GB-hours * $0.006 = $0.0250`      |
+| Active CPU         | `1,500 vCPU-seconds = 0.417 vCPU-hours * $0.064 = $0.0267` |
+| Outbound bandwidth | `200 GB * $0.025 = $5.0000`                                |
+| Total              | `$5.1017`, about `$5.10`                                   |
 
-Here the compute is almost free and bandwidth is nearly the whole bill. If your app moves a lot of data, that is the number to watch.
+Here compute is almost free and bandwidth is nearly the whole bill. If your app moves a lot of data, estimate bandwidth first.
 
 ## Formula
 
@@ -89,7 +89,7 @@ bill =
 
 ## What is not billed separately
 
-You pay for work, not for the existence of a resource. The following are not billed on their own:
+You pay for the work your app does, not for resources sitting idle. These are not billed on their own:
 
 - Deployments
 - Preview branch creation
@@ -97,20 +97,20 @@ You pay for work, not for the existence of a resource. The following are not bil
 - Apps that have scaled to zero
 - A Prisma-specific compute unit
 
-Preview branches can still accrue usage when they receive traffic or run background work, but creating one costs nothing by itself.
+A preview branch only costs money when it does work, such as serving traffic or running a background task. Creating one is free.
 
 ## Usage data for humans and agents
 
-The same usage data we show in the [Console](https://pris.ly/pdp) is available through the [CLI](/compute/cli-reference), API, and JSON output, so agents can estimate a cost, explain a change, and suggest a fix.
+The usage data shown in the [Console](https://pris.ly/pdp) is also available from the [CLI](/compute/cli-reference) and API, including as JSON. An agent can read it to estimate a cost, explain a change, or suggest a fix.
 
 ## Beta and bandwidth
 
-Compute is free during public beta, and the expected pricing above may change as we learn from real usage. If something has to change before production billing turns on, we will change it and say so clearly.
+Compute is free during public beta. The rates above are estimates and may change as we learn from real usage. If anything changes before we enable production billing, we will say so clearly.
 
-Outbound bandwidth means data sent from Compute to the public internet. Small JSON or API apps may barely notice it, while streaming apps, exports, media, and high-transfer APIs will. During beta, we are measuring real traffic to validate the rate, included usage, and edge cases before production billing turns on.
+Outbound bandwidth is the data your app sends from Compute to the public internet; inbound requests don't count. Small JSON or API responses use little of it, while streaming, file downloads, and media use much more. During beta we are measuring real traffic to confirm the rate and included usage before billing starts.
 
 ## What to read next
 
 - [Known limitations](/compute/limitations): what the beta can and can't do.
 - [FAQ](/compute/faq): quick answers to common questions.
-- [Branching](/compute/branching): how preview branches isolate work and accrue usage.
+- [Branching](/compute/branching): how preview branches isolate work and when they cost money.

--- a/apps/docs/cspell.json
+++ b/apps/docs/cspell.json
@@ -378,6 +378,7 @@
     "VARBINARY",
     "varbit",
     "VARBIT",
+    "vcpu",
     "Vdbi",
     "veroh",
     "waitlist",

--- a/apps/site/src/app/compute/page.tsx
+++ b/apps/site/src/app/compute/page.tsx
@@ -317,16 +317,30 @@ export default async function Page() {
             to your database. A good fit for APIs and AI agents that hold state, stream responses,
             and keep connections open.
           </p>
-          <div className="flex flex-col md:flex-row gap-4 items-center justify-center">
-            <Button asChild variant="ppg" size="2xl">
-              <a
-                href="https://pris.ly/pdp?utm_source=site&utm_campaign=compute&utm_term=devrel"
-                className="flex items-center gap-2"
-              >
-                <span>Try Prisma Compute</span>
-                <i className="flex items-center fa-regular fa-arrow-up-right" aria-hidden="true" />
-              </a>
-            </Button>
+          <div className="flex flex-col gap-3 items-center">
+            <div className="flex flex-col md:flex-row gap-4 items-center justify-center">
+              <Button asChild variant="ppg" size="2xl">
+                <a
+                  href="https://pris.ly/pdp?utm_source=site&utm_campaign=compute&utm_term=devrel"
+                  className="flex items-center gap-2"
+                >
+                  <span>Try Prisma Compute</span>
+                  <i className="flex items-center fa-regular fa-arrow-up-right" aria-hidden="true" />
+                </a>
+              </Button>
+              <Button asChild variant="default-strong" size="2xl">
+                <a
+                  href="https://pris.ly/pricing-compute?utm_source=site&utm_campaign=compute&utm_term=devrel"
+                  className="flex items-center gap-2"
+                >
+                  <span>See pricing</span>
+                  <i className="flex items-center fa-regular fa-tag" aria-hidden="true" />
+                </a>
+              </Button>
+            </div>
+            <p className="text-sm text-foreground-neutral-weaker m-0">
+              Free while in public beta.
+            </p>
           </div>
         </div>
       </div>

--- a/apps/site/src/app/pricing/pricing-page-content.tsx
+++ b/apps/site/src/app/pricing/pricing-page-content.tsx
@@ -52,7 +52,7 @@ export function PricingPageContent() {
               Prisma Compute is free during Public Beta. See the{" "}
               <a
                 className="underline underline-offset-2 decoration-[var(--color-foreground-ppg)] hover:text-foreground-neutral"
-                href="/compute/pricing"
+                href="https://pris.ly/pricing-compute"
               >
                 expected pricing
               </a>{" "}

--- a/apps/site/src/app/pricing/pricing-page-content.tsx
+++ b/apps/site/src/app/pricing/pricing-page-content.tsx
@@ -49,7 +49,14 @@ export function PricingPageContent() {
               Deploy TypeScript apps on Prisma Compute
             </h3>
             <p className="m-0 max-w-[560px] text-foreground-neutral-weak text-md">
-              Prisma Compute is in Public Beta. We&apos;ll share pricing soon. 
+              Prisma Compute is free during Public Beta. See the{" "}
+              <a
+                className="underline underline-offset-2 decoration-[var(--color-foreground-ppg)] hover:text-foreground-neutral"
+                href="/compute/pricing"
+              >
+                expected pricing
+              </a>{" "}
+              for when production billing turns on.
             </p>
           </div>
           <Button asChild variant="ppg" size="2xl">


### PR DESCRIPTION
## What

Adds a **Prisma Compute pricing** docs page and points everyone who looks for Compute pricing to it.

### New page — `apps/docs/content/docs/compute/pricing.mdx`
Adapts the drafted pricing content into the Compute docs voice (flowing prose, no em dashes, standard frontmatter, internal cross-links). Covers:
- Expected per-meter rates (requests, provisioned memory, active CPU, outbound bandwidth)
- Three worked cost examples (preview, agent, high-transfer workflows)
- The billing formula
- What is *not* billed separately
- Beta status and the bandwidth caveat

Added to the Compute nav under **More** (`meta.json`).

### Cross-links to the pricing page (via `https://pris.ly/pricing-compute`)
- **Site pricing page** (`pricing-page-content.tsx`): the Compute section said "We'll share pricing soon" — now notes it's free during Public Beta and links to pricing.
- **Compute marketing page** (`app/compute/page.tsx`): added a **See pricing** button in the hero, with a "Free while in public beta" note.
- **Compute FAQ** (`faq.mdx`): new "Is Prisma Compute free?" entry that answers yes-during-beta and links to pricing.
- **Blog: Launching Prisma Compute in Public Beta** and **Bun Rust rewrite on Prisma Compute**: free-during-beta note linking to pricing.

## Notes
- All numbers, rates, and examples are preserved verbatim from the source draft; only prose was adapted to match docs style.
- External pointers use the `https://pris.ly/pricing-compute` short link; the docs page's `url` is `/compute/pricing`.
- The custom-domains post was left unchanged — it has no natural pricing/CTA anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive Prisma Compute pricing documentation, including expected post-beta rates, billing formula, and worked cost examples.
  * Added an FAQ entry clarifying Compute is free during public beta.
  * Updated Compute docs navigation to include the new Pricing page.

* **Updates**
  * Refreshed website and blog call-to-action messaging to emphasize “free during public beta,” with links to expected pricing.
  * Added a “See pricing” button and beta note to the Compute hero section.

* **Chores**
  * Updated spelling dictionary for “vcpu.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->