### PR TITLE
docs(compute): keep "$1.00 / 1M requests" rate on one line

### DIFF
--- a/apps/docs/content/docs/compute/pricing.mdx
+++ b/apps/docs/content/docs/compute/pricing.mdx
@@ -22,7 +22,7 @@ Each meter measures a different resource: how often your app runs (requests), ho
 
 | Meter              | Price                 | What it means                                                                         |
 | ------------------ | --------------------- | ------------------------------------------------------------------------------------- |
-| Requests           | `$1.00 / 1M requests` | Every inbound request your app handles.                                               |
+| Requests           | `$1.00 / 1M requests` | Every inbound request your app handles.                                               |
 | Provisioned memory | `$0.006 / GB-hour`    | Memory allocated while your app is running or intentionally kept awake.               |
 | Active CPU         | `$0.064 / vCPU-hour`  | CPU time your app actually consumes.                                                  |
 | Outbound bandwidth | `$0.025 / GB`         | Data your app sends out to the internet. Incoming requests do not count as bandwidth. |


### PR DESCRIPTION
## What

Fixes a layout glitch in the Prisma Compute pricing rates table: the **Requests** rate (`$1.00 / 1M requests`) is the longest price string and was wrapping mid-value — `$1.00 / 1M` on one line and `requests` on the next.

## How

Replaced the regular spaces inside that one code span with non-breaking spaces (U+00A0) so the rate stays on a single line. Rendering is visually identical to the other rates; only the wrap behavior changes.

The longer code spans in the example-cost tables are intentionally left breakable, so this change is scoped to just the one cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the formatting and spacing of pricing information display for enhanced readability in the pricing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->