### PR TITLE
feat(site): simplify tagline to "Agent Infrastructure for TypeScript"

### DIFF
--- a/apps/site/src/app/(index)/page.tsx
+++ b/apps/site/src/app/(index)/page.tsx
@@ -218,7 +218,7 @@ export const metadata = createPageMetadata({
 
 const homeStructuredData = createCollectionPageStructuredData({
   path: "/",
-  name: "Prisma is The Agent Infrastructure for TypeScript",
+  name: "Agent Infrastructure for TypeScript",
   description: SITE_HOME_DESCRIPTION,
   items: [
     {
@@ -275,7 +275,7 @@ export default function SiteHome() {
               className="mb-0 text-center mt-0 type-title-6xl text-foreground-neutral max-w-4xl mx-auto text-balance"
               style={{ fontSize: "clamp(2rem, 6vw, 3.25rem)", lineHeight: 1.12 }}
             >
-              Prisma is The Agent Infrastructure for TypeScript
+              Agent Infrastructure for TypeScript
             </h1>
           </div>
           <p className="text-center text-foreground-neutral-weak max-w-2xl mx-auto text-lg leading-relaxed text-balance">

--- a/apps/site/src/lib/site-metadata.ts
+++ b/apps/site/src/lib/site-metadata.ts
@@ -1,4 +1,4 @@
-export const SITE_HOME_TITLE = "Prisma | The Agent Infrastructure for TypeScript";
+export const SITE_HOME_TITLE = "Agent Infrastructure for TypeScript";
 
 export const SITE_HOME_DESCRIPTION =
   "Prisma gives TypeScript and Node.js teams Prisma ORM, Prisma Postgres, and Prisma Compute: a type-safe ORM, managed Postgres, and Compute for deploying TypeScript apps, from schema to deployed app.";


### PR DESCRIPTION
## What

Simplifies the homepage tagline to just:

> **Agent Infrastructure for TypeScript**

Drops the "Prisma is The" lead-in and the "Prisma |" title prefix — visitors already know they're on the Prisma site.

## Changes

- `apps/site/src/app/(index)/page.tsx` — hero `<h1>` and structured-data `name`
- `apps/site/src/lib/site-metadata.ts` — `SITE_HOME_TITLE`

All three now read exactly "Agent Infrastructure for TypeScript".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed homepage heading and page title messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->