### PR TITLE
feat(analytics): Adds Google Analytics

### DIFF
--- a/apps/blog/src/app/layout.tsx
+++ b/apps/blog/src/app/layout.tsx
@@ -8,6 +8,7 @@ import Script from "next/script";
 import { BLOG_HOME_DESCRIPTION, BLOG_HOME_TITLE } from "@/lib/blog-metadata";
 import { FontAwesomeScript as EclipseFA } from "@prisma/eclipse";
 import { JsonLd } from "@prisma-docs/ui/components/json-ld";
+import { GoogleTagManager } from "@prisma-docs/ui/components/google-tag-manager";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -30,11 +31,7 @@ const blogStructuredData = createBlogStructuredData();
 
 export default function Layout({ children }: LayoutProps<"/">) {
   return (
-    <html
-      lang="en"
-      className={`${inter.variable} ${barlow.variable}`}
-      suppressHydrationWarning
-    >
+    <html lang="en" className={`${inter.variable} ${barlow.variable}`} suppressHydrationWarning>
       <head>
         <JsonLd id="blog-structured-data" data={blogStructuredData} />
         {/* FontAwesome — not render-critical; explicit strategy prevents accidental beforeInteractive promotion */}
@@ -50,6 +47,8 @@ export default function Layout({ children }: LayoutProps<"/">) {
           src="https://cdn-cookieyes.com/client_data/96980f76df67ad5235fc3f0d/script.js"
           strategy="afterInteractive"
         />
+        {/* Google Tag Manager — consent-gated; activates only after CookieYes analytics consent */}
+        <GoogleTagManager section="blog" />
       </head>
       <body className="flex flex-col min-h-screen relative">
         <div className="bg-blog absolute inset-0 -z-1 overflow-hidden" />

--- a/apps/blog/src/components/BlogCTA.tsx
+++ b/apps/blog/src/components/BlogCTA.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import { Button } from "@prisma/eclipse";
+import { trackCTA } from "@prisma-docs/ui/lib/analytics";
 
 const CTA_HREF = "https://pris.ly/pdp?utm_source=blog&utm_medium=blog_cta&utm_campaign=blog_post";
 
@@ -16,7 +19,17 @@ export const BlogCTA = () => {
           </p>
         </div>
         <Button asChild variant="ppg" size="2xl">
-          <a href={CTA_HREF}>
+          <a
+            href={CTA_HREF}
+            onClick={() =>
+              trackCTA({
+                cta_text: "Try Prisma",
+                cta_location: "blog_post_footer",
+                cta_destination: CTA_HREF,
+                section: "blog",
+              })
+            }
+          >
             <span>Try Prisma</span>
             <i className="fa-regular fa-arrow-right" aria-hidden />
           </a>

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import Script from "next/script";
 import { FontAwesomeScript as EclipseFA } from "@prisma/eclipse";
+import { GoogleTagManager } from "@prisma-docs/ui/components/google-tag-manager";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -55,11 +56,7 @@ export const metadata: Metadata = {
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <html
-      lang="en"
-      className={`${inter.variable} ${barlow.variable}`}
-      suppressHydrationWarning
-    >
+    <html lang="en" className={`${inter.variable} ${barlow.variable}`} suppressHydrationWarning>
       <head>
         <script
           type="application/ld+json"
@@ -73,8 +70,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                 "@type": "SearchAction",
                 target: {
                   "@type": "EntryPoint",
-                  urlTemplate:
-                    "https://www.prisma.io/docs?q={search_term_string}",
+                  urlTemplate: "https://www.prisma.io/docs?q={search_term_string}",
                 },
                 "query-input": "required name=search_term_string",
               },
@@ -88,6 +84,8 @@ export default function Layout({ children }: { children: ReactNode }) {
           src="https://cdn-cookieyes.com/client_data/96980f76df67ad5235fc3f0d/script.js"
           strategy="afterInteractive"
         />
+        {/* Google Tag Manager — consent-gated; activates only after CookieYes analytics consent */}
+        <GoogleTagManager section="docs" />
         {/* FontAwesome — icons are non-critical; explicit strategy avoids
             Next.js silently defaulting to afterInteractive without a source hint */}
         <Script

--- a/apps/site/src/app/layout.tsx
+++ b/apps/site/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { SITE_HOME_DESCRIPTION, SITE_HOME_TITLE } from "@/lib/site-metadata";
 import { NavigationWrapper, FooterWrapper } from "@/components/navigation-wrapper";
 import { Footer } from "@prisma-docs/ui/components/footer";
 import { JsonLd } from "@prisma-docs/ui/components/json-ld";
+import { GoogleTagManager } from "@prisma-docs/ui/components/google-tag-manager";
 import { ThemeProvider } from "@prisma-docs/ui/components/theme-provider";
 import { FontAwesomeScript as WebFA } from "@prisma/eclipse";
 import { UtmPersistence } from "@/components/utm-persistence";
@@ -210,20 +211,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           data-cookieyes="cookieyes-analytics"
           data-cookieyes-category="analytics"
         />
-        <script
-          id="gmanager"
-          type="text/plain"
-          data-cookieyes="cookieyes-analytics"
-          data-cookieyes-category="analytics"
-          dangerouslySetInnerHTML={{
-            __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-          })(window,document,'script','dataLayer','GTM-KCGZPWB');
-          `,
-          }}
-        />
+        <GoogleTagManager section="website" />
         <JsonLd id="site-structured-data" data={siteStructuredData} />
       </head>
       <body className="flex flex-col min-h-screen relative">

--- a/apps/site/src/components/console-cta-button.tsx
+++ b/apps/site/src/components/console-cta-button.tsx
@@ -12,6 +12,8 @@ interface ConsoleCtaButtonProps extends Omit<ButtonProps, "asChild"> {
   rel?: string;
   /** Where this CTA sits, e.g. "navbar", "hero", "pricing". Sent with the cta_click event. */
   ctaLocation?: string;
+  /** Explicit label for the cta_click event; falls back to `children` when it is a string. */
+  ctaText?: string;
 }
 
 function buildConsoleHref(consolePath: "/login" | "/sign-up", utmParams: UtmParams) {
@@ -33,6 +35,7 @@ export function ConsoleCtaButton({
   target,
   rel,
   ctaLocation,
+  ctaText,
   ...props
 }: ConsoleCtaButtonProps) {
   const [href, setHref] = useState(() => buildConsoleHref(consolePath, defaultUtm));
@@ -53,7 +56,8 @@ export function ConsoleCtaButton({
         rel={rel}
         onClick={() =>
           trackCTA({
-            cta_text: typeof children === "string" ? children : consolePath.replace("/", ""),
+            cta_text:
+              ctaText ?? (typeof children === "string" ? children : consolePath.replace("/", "")),
             cta_location: ctaLocation ?? "console_cta",
             cta_destination: href,
             section: "website",

--- a/apps/site/src/components/console-cta-button.tsx
+++ b/apps/site/src/components/console-cta-button.tsx
@@ -3,12 +3,15 @@
 import { useEffect, useState } from "react";
 import { Button, type ButtonProps } from "@prisma/eclipse";
 import { getUtmParams, hasUtmParams, type UtmParams } from "@prisma-docs/ui/lib/utm";
+import { trackCTA } from "@prisma-docs/ui/lib/analytics";
 
 interface ConsoleCtaButtonProps extends Omit<ButtonProps, "asChild"> {
   consolePath: "/login" | "/sign-up";
   defaultUtm: UtmParams;
   target?: string;
   rel?: string;
+  /** Where this CTA sits, e.g. "navbar", "hero", "pricing". Sent with the cta_click event. */
+  ctaLocation?: string;
 }
 
 function buildConsoleHref(consolePath: "/login" | "/sign-up", utmParams: UtmParams) {
@@ -29,6 +32,7 @@ export function ConsoleCtaButton({
   children,
   target,
   rel,
+  ctaLocation,
   ...props
 }: ConsoleCtaButtonProps) {
   const [href, setHref] = useState(() => buildConsoleHref(consolePath, defaultUtm));
@@ -43,7 +47,19 @@ export function ConsoleCtaButton({
 
   return (
     <Button asChild {...props}>
-      <a href={href} target={target} rel={rel}>
+      <a
+        href={href}
+        target={target}
+        rel={rel}
+        onClick={() =>
+          trackCTA({
+            cta_text: typeof children === "string" ? children : consolePath.replace("/", ""),
+            cta_location: ctaLocation ?? "console_cta",
+            cta_destination: href,
+            section: "website",
+          })
+        }
+      >
         {children}
       </a>
     </Button>

--- a/packages/ui/src/components/google-tag-manager.tsx
+++ b/packages/ui/src/components/google-tag-manager.tsx
@@ -1,0 +1,47 @@
+/**
+ * Consent-gated Google Tag Manager loader.
+ *
+ * Renders the GTM bootstrap as an inert `type="text/plain"` script tagged for
+ * CookieYes' analytics category. CookieYes activates it only after the visitor
+ * grants analytics consent — mirroring the pattern already used across the apps
+ * for Tolt and the previous GTM container. Before activation nothing loads, so
+ * no Google network calls happen without consent (GDPR/ePrivacy compliant).
+ *
+ * The same container (one per the prisma.io domain) is used by every zone; each
+ * zone passes its `section` so all hits carry a `site_section` dimension and can
+ * be segmented (website vs blog vs docs) in GA4.
+ *
+ * Note: no `<noscript>` iframe fallback is rendered on purpose — a plain iframe
+ * would load GTM regardless of consent and break the consent gate.
+ */
+
+// Public, client-side container ID (Prisma Main › prisma.io). Ships in the HTML
+// to every visitor by design, so it is intentionally hardcoded, not an env var.
+const GTM_CONTAINER_ID = "GTM-KRTRXXQ6";
+
+export type SiteSection = "website" | "blog" | "docs";
+
+type GoogleTagManagerProps = {
+  section: SiteSection;
+};
+
+export function GoogleTagManager({ section }: GoogleTagManagerProps) {
+  const html = `
+window.dataLayer = window.dataLayer || [];
+window.dataLayer.push({ site_section: ${JSON.stringify(section)} });
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${GTM_CONTAINER_ID}');`.trim();
+
+  return (
+    <script
+      id="gtm-loader"
+      type="text/plain"
+      data-cookieyes="cookieyes-analytics"
+      data-cookieyes-category="analytics"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/packages/ui/src/components/google-tag-manager.tsx
+++ b/packages/ui/src/components/google-tag-manager.tsx
@@ -15,11 +15,11 @@
  * would load GTM regardless of consent and break the consent gate.
  */
 
+import type { SiteSection } from "../lib/analytics";
+
 // Public, client-side container ID (Prisma Main › prisma.io). Ships in the HTML
 // to every visitor by design, so it is intentionally hardcoded, not an env var.
 const GTM_CONTAINER_ID = "GTM-KRTRXXQ6";
-
-export type SiteSection = "website" | "blog" | "docs";
 
 type GoogleTagManagerProps = {
   section: SiteSection;

--- a/packages/ui/src/lib/analytics.ts
+++ b/packages/ui/src/lib/analytics.ts
@@ -7,6 +7,9 @@
  * are inert — nothing leaves the browser.
  */
 
+/** The public prisma.io zones tracked under one GA4 property. */
+export type SiteSection = "website" | "blog" | "docs";
+
 export type CtaClickPayload = {
   /** Visible label of the CTA, e.g. "Try Prisma". */
   cta_text: string;
@@ -15,7 +18,7 @@ export type CtaClickPayload = {
   /** Resolved destination href. */
   cta_destination: string;
   /** Overrides the page-level `site_section` for this event if provided. */
-  section?: string;
+  section?: SiteSection;
 };
 
 type DataLayerObject = Record<string, unknown>;

--- a/packages/ui/src/lib/analytics.ts
+++ b/packages/ui/src/lib/analytics.ts
@@ -1,0 +1,39 @@
+/**
+ * Client-side analytics helpers.
+ *
+ * Events are pushed to the Google Tag Manager `dataLayer`. GTM itself is loaded
+ * consent-gated (see `components/google-tag-manager.tsx`), so when the visitor has
+ * not granted analytics consent there is no `dataLayer` consumer and these pushes
+ * are inert — nothing leaves the browser.
+ */
+
+export type CtaClickPayload = {
+  /** Visible label of the CTA, e.g. "Try Prisma". */
+  cta_text: string;
+  /** Where the CTA lives, e.g. "blog_post_footer", "navbar", "hero". */
+  cta_location: string;
+  /** Resolved destination href. */
+  cta_destination: string;
+  /** Overrides the page-level `site_section` for this event if provided. */
+  section?: string;
+};
+
+type DataLayerObject = Record<string, unknown>;
+
+declare global {
+  interface Window {
+    dataLayer?: DataLayerObject[];
+  }
+}
+
+/**
+ * Records a CTA click as a `cta_click` event in the GTM dataLayer.
+ *
+ * Safe no-op during SSR or before GTM has initialised (e.g. consent not granted),
+ * because `window.dataLayer` will be absent.
+ */
+export function trackCTA(payload: CtaClickPayload): void {
+  if (typeof window === "undefined" || !Array.isArray(window.dataLayer)) return;
+
+  window.dataLayer.push({ event: "cta_click", ...payload });
+}


### PR DESCRIPTION
Load a single consent-gated GTM container (GTM-KRTRXXQ6, Prisma Main › prisma.io) across all three public zones, feeding the new GA4 property (G-4B72WBX9ET). Replaces the legacy GTM-KCGZPWB container in the site app.

- Add shared <GoogleTagManager> loader in @prisma-docs/ui, reusing the existing CookieYes consent-gating pattern (type="text/plain" + data-cookieyes-category="analytics") so nothing loads before consent.
- Seed a `site_section` dataLayer value per zone (website/blog/docs) so GA4 reports unified totals and clean per-section breakdowns.
- Add trackCTA() helper and wire it into the blog CTA and ConsoleCtaButton for structured `cta_click` events; a GTM auto-click trigger covers the rest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Analytics & Tracking Improvements**
  * Added CTA click tracking across the blog, docs, and main site, capturing CTA text, destination, location, and section.
  * Introduced a shared Google Tag Manager integration that loads only after analytics consent is granted.
  * Updated site/blog/docs layouts to use the consent-gated tag manager setup.

* **Chores / Maintenance**
  * Minor formatting cleanups in document layout markup (no behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->