### PR TITLE
Added support for updatedAt field in Blogs

### DIFF
--- a/apps/blog/source.config.ts
+++ b/apps/blog/source.config.ts
@@ -17,6 +17,7 @@ export const blogPosts = defineCollections({
     authors: z.array(z.string()),
     authorSrc: z.string().optional(),
     date: z.coerce.date(),
+    updatedAt: z.coerce.date().optional(),
     heroImagePath: z.string().optional(),
     metaImagePath: z.string().optional(),
     series: z.string().optional(),

--- a/apps/blog/src/app/(blog)/[slug]/page.tsx
+++ b/apps/blog/src/app/(blog)/[slug]/page.tsx
@@ -190,6 +190,14 @@ export default async function Page(props: { params: Promise<{ slug: string }> })
                 </span>
               </>
             ) : null}
+            {page.data.updatedAt ? (
+              <>
+                <Separator orientation="vertical" className="h-4" />
+                <span className="text-foreground-neutral-weak">
+                  Updated {formatDate(new Date(page.data.updatedAt).toISOString())}
+                </span>
+              </>
+            ) : null}
           </div>
           {page.data.tags && page.data.tags.length > 0 && (
             <div className="filter-badge flex gap-2">

--- a/apps/blog/src/app/(blog)/[slug]/page.tsx
+++ b/apps/blog/src/app/(blog)/[slug]/page.tsx
@@ -98,7 +98,9 @@ function getBlogPostingJsonLd(page: ReturnType<typeof blog.getPage>): BlogPostin
 
   const datePublished = toIsoDate(page.data.date);
   const dateModified =
-    toIsoDate((page.data as { lastModified?: unknown }).lastModified) ?? datePublished;
+    toIsoDate(page.data.updatedAt) ??
+    toIsoDate((page.data as { lastModified?: unknown }).lastModified) ??
+    datePublished;
 
   const jsonLd: BlogPostingSchema = {
     "@context": "https://schema.org",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blog posts now display an optional **“Updated”** timestamp when an updated date is available, alongside the publication date.
  * Updated posts also improve metadata by using the updated date for the page’s **date-modified** value when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->