### PR TITLE
fix(blog): link pricing post to workload form

### DIFF
--- a/apps/blog/content/blog/price-the-work-not-the-workflow/index.mdx
+++ b/apps/blog/content/blog/price-the-work-not-the-workflow/index.mdx
@@ -245,8 +245,10 @@ we think the platform should treat builders.
 
 To get that right, we need to learn from real workloads. How long apps stay
 alive, how much they compute versus wait, how much data they send out. Compute is
-now in public beta and free during this time. Tell us where these meters match
-how you actually build, and where they do not.
+now in public beta and free during this time. [Share the shape of your
+workload](https://tally.so/r/NpEZXB?source=blog&post=price-the-work-not-the-workflow&campaign=compute-pricing-feedback&cta=blog_end_cta)
+so we can see where these meters match how you actually build, and where they do
+not.
 
 Read the [Compute pricing docs](https://www.prisma.io/docs/compute/pricing) and
 follow the [Prisma Compute series](https://www.prisma.io/blog/series/prisma-compute)


### PR DESCRIPTION
## Overview
Updates the closing CTA in the Compute pricing blog post to send readers to the workload feedback Tally form.

## Validation
- `pnpm --filter blog types:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the blog post’s call-to-action to invite readers to share the shape of their workload.
  * Added a new hyperlink in the “The future we are building for” section while keeping the surrounding message unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->