### PR TITLE
fix(blog): update PostHog query to filter posts by month range

### DIFF
--- a/apps/blog/scripts/update-posthog-blog-tiles.mjs
+++ b/apps/blog/scripts/update-posthog-blog-tiles.mjs
@@ -82,7 +82,7 @@ function postsPerMonthQuery(tuples) {
     display: "ActionsBar",
     source: {
       kind: "HogQLQuery",
-      query: `SELECT toDate(concat(t.1, '-01')) AS month, t.2 AS posts FROM (SELECT arrayJoin([${tuples}]) AS t) ORDER BY month`,
+      query: `SELECT month, posts FROM (SELECT toDate(concat(t.1, '-01')) AS month, t.2 AS posts FROM (SELECT arrayJoin([${tuples}]) AS t)) WHERE month >= toStartOfMonth(today()) - toIntervalMonth(11) ORDER BY month`,
     },
     chartSettings: {
       xAxis: { column: "month" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Blog posts published per month” tile now shows a rolling 12-month view, rather than all historical months.
  * This keeps the chart focused on the most recent year and makes trends easier to read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->