### PR TITLE
Tighten content skills: remove no-ops and redundancy

### DIFF
--- a/.claude/skills/content-create-hero-image/SKILL.md
+++ b/.claude/skills/content-create-hero-image/SKILL.md
@@ -20,12 +20,7 @@ chat.
 Companion to `content-write-blog` (which scaffolds the post itself). This skill makes the
 imagery; it can be invoked standalone or as the cover step of that workflow.
 
-## Read first
-
-Use [`README.md`](README.md) when the operator asks how to use this skill or wants sample
-prompts. Use this `SKILL.md` as the execution contract when actually producing assets. Read
-[`references/design-system.md`](references/design-system.md) **before designing** and
-[`references/design-review.md`](references/design-review.md) **before the design-review pass**.
+Use [`README.md`](README.md) for usage and sample prompts; this `SKILL.md` is the execution contract for producing assets.
 
 ## References (load on demand)
 
@@ -77,11 +72,9 @@ cards. A single design may serve both files.
 
 ## Pre-conditions — halt if unmet
 
-1. A blog post slug is known or can be derived. If the operator has not given one, ask for the
-   slug or the post title and derive the kebab-case slug.
-2. The reference material is present: the bundled `assets/` (examples, logos, fonts, tokens) — or
-   the recent posts found during discovery. If nothing is available, ask the operator to supply
-   reference material before proceeding.
+1. A blog post slug, or a post title to derive the kebab-case slug from. Ask if neither is given.
+2. Reference material: the bundled `assets/` (examples, logos, fonts, tokens) or the recent posts
+   found during discovery. Ask the operator to supply some if none is available.
 
 ## Discover blog conventions
 
@@ -322,12 +315,11 @@ Visually inspect the rendered PNG, then verify:
 
 ## Anti-patterns
 
+(Format, filename, and destination rules live in _Output contract_ and _Validation_; these are the
+creative and brand traps a checklist can't catch.)
+
 - **Hardcoding blog conventions.** The repo evolves — always discover the image directory,
   filenames, and frontmatter fields from recent posts; the documented standard is a fallback.
-- **An SVG meta image.** Open Graph and social cards do not render SVG; the meta image is always
-  raster.
-- **A raster hero by default.** SVG is the house standard for the hero; use PNG only when the hero
-  is genuinely photographic and the operator asked for it.
 - **Generic AI look.** Glows everywhere, faux-3D blobs, busy gradients, literal robots. Prisma
   covers are restrained and typographic. When in doubt, remove an element.
 - **Off-system styling.** Inventing colors, or swapping the Mona Sans + Inter pairing (Barlow is
@@ -335,11 +327,6 @@ Visually inspect the rendered PNG, then verify:
 - **Decorative logos.** Marks are a footer sign-off or the subject — never wallpaper.
 - **Centering text-only layouts.** Default covers are left-anchored with right-side breathing room.
   Center only a single graphic-led composition.
-- **Content hashes or dimensions in filenames.** Keep the base names `hero` and `meta`; the
-  extension follows the format and nothing else.
-- **PNG-only or SVG-only.** SVG is the editable source of truth; the PNG is the export. Produce
-  both for the hero; the meta is always PNG.
-- **Saving to temp.** Final assets live in a durable repo location.
 - **Fabricating product palettes.** Postgres = teal, ORM = indigo. Compute/Next have no official
   tokens yet — use the platform teal and say so; don't invent a brand color.
 - **Tagline filler.** Avoid lines like `Resize. Encode. Cache.` If a secondary line is needed,

--- a/.claude/skills/content-write-blog/SKILL.md
+++ b/.claude/skills/content-write-blog/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 Produce a _skeleton_ for a Prisma blog post — frontmatter, section headings, and short stubs — not a finished article. The human author writes the prose.
 
-This skill produces content only. It does **not** check out, branch, commit, push, or open pull requests against the blog repository. The operator owns the repository workflow: they prepare their own checkout of the blog repo, place or accept the skeleton into it, and push and open the pull request themselves, conforming to that repository's contribution process. Keep the boundary clear at every step.
+This skill produces content only. It does **not** check out, branch, commit, push, or open pull requests against the blog repository. The operator owns that workflow: they prepare the checkout, place the skeleton into it, and push and open the pull request following the repo's contribution process.
 
 The blog is owned by DevRel but contributed to by everyone, so do not assume the operator is on the DevRel team or familiar with the blog repository. Treat first-time contributors as the default case.
 
@@ -19,7 +19,7 @@ The blog is owned by DevRel but contributed to by everyone, so do not assume the
 
 ## Asking the operator questions
 
-When this skill needs a decision with a small set of options (which existing author to use, whether a proposal looks right, where the checkout lives), prefer a structured-choice question if the environment supports one. Fall back to plain questions when it does not, or when the answer is genuinely freeform (a pitch, a slug, a bio). Bias toward reasonable defaults from context; ask only when multiple valid paths exist.
+For a decision with a small set of options (which author, whether a proposal looks right, where the checkout lives), prefer a structured-choice question where the environment supports one; fall back to a plain question for freeform answers (a pitch, a slug, a bio). Bias toward reasonable defaults from context; ask only when multiple valid paths exist.
 
 ## Step 1: Gather the pitch
 

--- a/.claude/skills/docs-writer/SKILL.md
+++ b/.claude/skills/docs-writer/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 
 Write documentation a developer can follow from start to finish without getting stuck or guessing. Every page answers three questions, in this order: what am I doing, why does it matter, and what do I do next.
 
-This skill is opinionated. If a rule here conflicts with an existing house style, follow the house style and tell the operator about the conflict.
+If a rule here conflicts with house style, follow the house style and flag the conflict to the operator.
 
 For a step-by-step example of writing each kind of page (how-to, concept, reference) and rewriting an existing one, see `references/how-to-use.md`.
 


### PR DESCRIPTION
## Summary

Follow-up to #7975 (merged). A surgical editing pass over the three content skills to remove no-ops and within-file redundancy and make the instructions tighter for both an agent and a human reader. No behavioral rules were dropped — only ceremony and restatement.

## Changes

**`content-write-blog/SKILL.md`**
- Cut the "Keep the boundary clear at every step" no-op (the surrounding sentences already establish the boundary).
- Tightened the structured-question guidance.

**`content-create-hero-image/SKILL.md`**
- Folded the "Read first" navigation block into one line — the per-reference "read before designing / before the review pass" directives already live in the References list right below it.
- Trimmed the wordy Pre-conditions.
- Dropped five Anti-patterns bullets that only restate the **Output contract** and **Validation** checklist (SVG-meta, raster-hero, PNG/SVG-only, filenames, temp dir). Kept the creative/brand traps a checklist can't catch (generic-AI look, off-system styling, decorative logos, centering, fabricated palettes, tagline filler, single-reference copying).

**`docs-writer/SKILL.md`**
- Dropped the "This skill is opinionated" filler; kept the house-style precedence rule.

## Notes

- Net: 3 files, +10 / −23 lines.
- Deliberately conservative: anti-pattern safety rails, the inline "#1 off-brand bug" font warning, the Validation gate, and the worked examples were all preserved — those reinforce behavior that an agent benefits from seeing at the point of use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for creating hero images, including where to find usage examples, required inputs, and what information must be provided before starting.
  * Tightened instructions for blog writing workflows, making the scope of the task and question formats clearer.
  * Updated documentation-writing guidance to better handle house style conflicts and when to flag them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->