### PR TITLE
docs: improve query alignment of Vercel app deployment guide (GEO)

### DIFF
--- a/apps/docs/content/docs/guides/integrations/vercel-deployment.mdx
+++ b/apps/docs/content/docs/guides/integrations/vercel-deployment.mdx
@@ -1,19 +1,27 @@
 ---
 title: Vercel app deployment
-description: Learn how to programmatically deploy applications with Vercel and Prisma Postgres using the instant deployment API
+description: Programmatically deploy full-stack apps to Vercel with a provisioned Prisma Postgres database. Built for AI app builders, agent platforms, and no-code tools.
 image: /img/guides/vercel_app_deployments.png
 url: /guides/integrations/vercel-deployment
-metaTitle: Instant app deployment with Vercel and Prisma Postgres
-metaDescription: Learn how to programmatically deploy applications with Vercel and Prisma Postgres using the instant deployment API
+metaTitle: Deploy apps to Vercel with a database via API | Prisma Postgres
+metaDescription: Programmatically create, deploy, and transfer full-stack apps on Vercel with a provisioned Prisma Postgres database. A guide for AI app builders, no-code platforms, and agent workflows.
 ---
 
 ## Introduction
 
-This guide shows you how to implement instant app deployment using [Vercel](https://vercel.com)'s API with integrated [Prisma Postgres](/postgres) databases. You'll learn to programmatically create, deploy, and transfer full-stack applications with a single API call.
+This guide shows you how to deploy a full-stack application to [Vercel](https://vercel.com) with a ready-to-use [Prisma Postgres](/postgres) database, entirely through API calls. The flow takes six Vercel API requests: create a project, authorize the Prisma integration, provision a database, connect it to the project, deploy the application code, and generate a claim code that transfers ownership to your user. No dashboard steps are required at any point.
 
-Instant app deployment solves a critical problem for AI coding platforms, no-code tools, and educational platforms: getting from generated code to a live, production-ready application. Instead of requiring users to manually set up hosting infrastructure, you can offer one-click deployments with both application and database.
+This is the deployment pattern used by AI app builders, agent platforms, no-code tools, and educational platforms that generate applications on behalf of their users. Your platform deploys the app and database programmatically, the user claims it with one click, and billing moves to their Vercel account. Every database provisioned through this flow is a full Prisma Postgres instance: managed PostgreSQL with connection pooling built in, so deployed apps handle serverless traffic without extra pooling infrastructure.
 
-By the end of this guide, you'll understand how to integrate Vercel's deployment API with Prisma Postgres to create a smooth deployment experience for your users.
+:::note[Looking for a different Vercel guide?]
+
+- To deploy **your own app** that uses Prisma ORM to Vercel, see [Deploy to Vercel](/orm/prisma-client/deployment/serverless/deploy-to-vercel).
+- To add a **Prisma Postgres database to an existing Vercel project** via the Marketplace integration, see [Prisma Postgres on Vercel](/guides/postgres/vercel).
+- To create and manage Prisma Postgres databases programmatically **outside of Vercel**, see the [Management API](/management-api).
+
+This guide covers **platforms deploying apps on behalf of their users** with Vercel's deployment API.
+
+:::
 
 ## Try the live demo
 
@@ -607,6 +615,32 @@ Track key metrics for your deployment service:
 - **Claim conversion rate**: Track how many users claim their deployments
 - **Performance metrics**: Measure deployment time and user experience
 - **Cost analysis**: Monitor Vercel and Prisma usage costs
+
+## FAQ
+
+### Can I deploy an app to Vercel with a database in a single API flow?
+
+Yes. The six-step flow in this guide creates a Vercel project, provisions a Prisma Postgres database, connects the two, and deploys the application code using only Vercel API endpoints. There is no dashboard interaction, which makes the flow suitable for automated pipelines and AI agents.
+
+### How many databases can I create programmatically?
+
+The Prisma Postgres Free plan includes 50 databases per account, and paid plans (Starter, Pro, Business) each include 1,000. Platforms that deploy on behalf of many users should [apply for partner access](https://www.prisma.io/partners), which uses the `partnerEntry` billing plan and provides higher database creation limits.
+
+### What happens to billing when a user claims a deployment?
+
+Ownership of both the Vercel project and the Prisma Postgres database transfers to the user's Vercel team, and that team becomes responsible for hosting and database costs from that point on. Claim codes are valid for 24 hours.
+
+### Which frameworks can be deployed this way?
+
+Anything Vercel can build and host, including Next.js, Nuxt, SvelteKit, and Remix. The demo templates use Next.js with Prisma ORM, and one variant adds authentication with Better Auth.
+
+### Do deployed apps need a connection pooler like pgBouncer?
+
+No. Prisma Postgres includes connection pooling by default, so apps deployed through this flow handle Vercel's serverless function scaling without a separate pooler.
+
+### Can I provision Prisma Postgres databases without Vercel?
+
+Yes. The [Prisma Postgres Management API](/management-api) lets you create and manage databases directly, which is useful for platforms that host applications elsewhere but still want programmatic database provisioning.
 
 ## Next steps
 


### PR DESCRIPTION
## Why

Promptwatch flagged `/docs/guides/vercel-deployment` as an untapped page: **59 AI crawls in the last 30 days from 2 unique crawlers, but 0 citation-bot visits and 0 AI clicks**. Crawlers evaluate the page for Vercel-deployment queries and consistently decide not to cite it.

The likely cause: the page described itself in internal vocabulary ("instant app deployment") instead of the language of the queries it should own (deploying apps programmatically via API, provisioning a database per deployment, AI app builder / agent platform workflows).

## What changed

- **Frontmatter**: meta title/description now lead with "deploy apps to Vercel with a database via API" and name the audience (AI app builders, no-code platforms, agent workflows).
- **Intro**: answers the question in the first paragraph with concrete, quotable claims (six API requests, what each does, no dashboard steps), and states what Prisma Postgres is (managed PostgreSQL with built-in connection pooling).
- **Disambiguation note**: routes the three distinct Vercel intents to the right pages (own-app deployment → ORM guide, Marketplace → `/guides/postgres/vercel`, non-Vercel provisioning → Management API). Helps both readers and AI engines match the right page to the right query.
- **FAQ section**: six self-contained Q&As built only from facts already on the page or in sibling docs (database limits, claim billing transfer, 24h claim code validity, pooling, frameworks, Management API).

No changes to the deployment steps, code samples, or API reference content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the deployment guide to better explain full-stack app deployment on Vercel with a provisioned Prisma Postgres database.
  * Clarified the end-to-end API-based flow, from project creation through database setup and code deployment, with no dashboard steps.
  * Added an FAQ covering database limits, billing responsibilities, supported frameworks, pooling requirements, and database provisioning options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->