### PR TITLE
fix(csp): allow Promptwatch analytics domain in CSP

### DIFF
--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -5,6 +5,7 @@ const withMDX = createMDX();
 const ContentSecurityPolicy = `
   default-src 'self';
   script-src 'self' 'unsafe-inline' 'unsafe-eval'
+    https://ingest.promptwatch.com
     https://cdn-cookieyes.com
     https://cdn.tolt.io
     https://unpkg.com
@@ -78,6 +79,7 @@ const ContentSecurityPolicy = `
     https://raw.githubusercontent.com;
 
   connect-src 'self'
+    https://ingest.promptwatch.com
     https://api.github.com
     https://p2zxqf70.api.sanity.io
     https://www.youtube.com

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -6,6 +6,7 @@ const withMDX = createMDX();
 const ContentSecurityPolicy = `
   default-src 'self';
   script-src 'self' 'unsafe-inline' 'unsafe-eval'
+    https://ingest.promptwatch.com
     https://cdn-cookieyes.com
     https://cdn.tolt.io
     https://unpkg.com
@@ -84,6 +85,7 @@ const ContentSecurityPolicy = `
     https://raw.githubusercontent.com;
 
   connect-src 'self'
+    https://ingest.promptwatch.com
     https://api.github.com
     https://p2zxqf70.api.sanity.io
     https://www.youtube.com

--- a/apps/eclipse/next.config.mjs
+++ b/apps/eclipse/next.config.mjs
@@ -5,6 +5,7 @@ const withMDX = createMDX();
 const ContentSecurityPolicy = `
   default-src 'self';
   script-src 'self' 'unsafe-inline' 'unsafe-eval'
+    https://ingest.promptwatch.com
     https://cdn-cookieyes.com
     https://cdn.tolt.io
     https://unpkg.com
@@ -83,6 +84,7 @@ const ContentSecurityPolicy = `
     https://raw.githubusercontent.com;
 
   connect-src 'self'
+    https://ingest.promptwatch.com
     https://api.github.com
     https://p2zxqf70.api.sanity.io
     https://www.youtube.com

--- a/apps/site/next.config.mjs
+++ b/apps/site/next.config.mjs
@@ -45,6 +45,7 @@ if (
 const ContentSecurityPolicy = `
   default-src 'self';
   script-src 'self' 'unsafe-inline' 'unsafe-eval'
+    https://ingest.promptwatch.com
     https://cdn-cookieyes.com
     https://cdn.tolt.io
     https://unpkg.com
@@ -123,6 +124,7 @@ const ContentSecurityPolicy = `
     https://www.prisma.io;
 
   connect-src 'self'
+    https://ingest.promptwatch.com
     https://api.github.com
     https://p2zxqf70.api.sanity.io
     https://www.youtube.com


### PR DESCRIPTION
## What

Adds `https://ingest.promptwatch.com` to the `script-src` and `connect-src` CSP directives in all four apps (site, docs, blog, eclipse).

## Why

Promptwatch visitor analytics (AI referrer tracking) stopped receiving data on 2026-05-06, dropping from 400-1,000 visits/day to zero. The timing matches #7864.

The Promptwatch snippet is correctly consent-gated: it ships as `type="text/plain"` and CookieYes activates it once a visitor grants analytics consent. But when CookieYes flips it live, the browser blocks it anyway because the CSP allows neither loading the script from `ingest.promptwatch.com` (`script-src`) nor sending events to it (`connect-src`). Other analytics vendors (GA, PostHog, LinkedIn, CookieYes itself) are allowlisted; Promptwatch is not.

## Scope

- One domain added to two directives per app, 8 lines total.
- No change to the consent gating. Tracking still only runs for visitors who accept analytics cookies.

## Verification

After deploy: accept analytics consent on prisma.io, confirm no CSP violations for `ingest.promptwatch.com` in the browser console, and check that visits appear in Promptwatch Visitor Analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated site security settings to allow a new trusted analytics/monitoring endpoint.
  * This helps pages load and communicate with the service without being blocked by browser security policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->