### PR TITLE
fix(nav): point Docs link to /docs/orm

### DIFF
--- a/apps/site/src/app/layout.tsx
+++ b/apps/site/src/app/layout.tsx
@@ -169,7 +169,7 @@ function baseOptions() {
         ],
       },
       {
-        url: "https://www.prisma.io/docs/next",
+        url: "https://www.prisma.io/docs/orm",
         text: "Docs",
       },
       {


### PR DESCRIPTION
## Summary

The navbar **Docs** link on the marketing site pointed to `https://www.prisma.io/docs/next`. This changes it to `https://www.prisma.io/docs/orm` so clicking **Docs** lands on the ORM docs.

## Test plan

- [ ] Load the site and click **Docs** in the navbar → lands on `/docs/orm`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Docs navigation link to point to the current Prisma ORM documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->