### PR TITLE
docs: add datasource env() example

### DIFF
--- a/apps/docs/content/docs/orm/prisma-schema/overview/index.mdx
+++ b/apps/docs/content/docs/orm/prisma-schema/overview/index.mdx
@@ -139,6 +139,7 @@ Environment variables can be accessed using the `env()` function:
 ```prisma
 datasource db {
   provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 ```
 


### PR DESCRIPTION
## Summary
The previous example introduced env() but didn't show its usage, making it harder for users to understand how to implement it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Prisma schema example to show `env("DATABASE_URL")` for the datasource URL, making the environment variable usage clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->