### PR TITLE
fix(blog): Prisma Next posts still teach the removed `migration apply` command

### DIFF
--- a/apps/blog/content/blog/mongodb-without-compromise/index.mdx
+++ b/apps/blog/content/blog/mongodb-without-compromise/index.mdx
@@ -119,7 +119,7 @@ Migration: 20260409T1200_add_post_indexes
   Create index on posts (authorId)          [additive]
   Create index on posts (createdAt, desc)   [additive]
 
-2 operations. Run `prisma-next migration apply` to execute.
+2 operations. Run `prisma-next migrate` to execute.
 ```
 
 It includes pre-checks, post-checks, full history, branching, and rollback, following the same structure as Prisma Next's SQL migrations. Your indexes, validators, and collection options are versioned alongside your code and deployed through CI/CD.

--- a/apps/blog/content/blog/typescript-migrations-in-prisma-next/index.mdx
+++ b/apps/blog/content/blog/typescript-migrations-in-prisma-next/index.mdx
@@ -184,7 +184,7 @@ $ npx prisma-next migration plan
 ├─ Add column "displayName" to "user" [additive]
 └─ Set NOT NULL on "user"."displayName" [destructive]
 
-$ npx prisma-next migration apply --verbose
+$ npx prisma-next migrate --verbose
 ✔ Applied 1 migration(s)
 
 └─ 20260424T0930_add_user_displayname [2 op(s)]
@@ -199,10 +199,10 @@ When you do need to edit a migration, for example to backfill data before a cons
 Where it gets interesting is when something goes wrong. The runner doesn't just bail with a database error. It names the operation that failed and the check inside it that the database refused to satisfy:
 
 ```text
-$ npx prisma-next migration apply
+$ npx prisma-next migrate
 ✖ Operation alterNullability.setNotNull.user.displayName failed during precheck: ensure no NULL values in "displayName" (PN-RUN-5001)
   Why: Migration runner halted before destructive ALTER
-  Fix: Fix the issue and re-run `prisma-next migration apply`. Previously applied migrations are preserved.
+  Fix: Fix the issue and re-run `prisma-next migrate`. Previously applied migrations are preserved.
 ```
 
 You know which operation failed (`alterNullability.setNotNull.user.displayName`) and which check failed inside it (`ensure no NULL values in "displayName"`). Both come straight from `ops.json`, and both tell you exactly where to look. From here, you fix it. You might backfill the nulls, drop and re-add the column with a default, or edit the migration to add a backfill step before the `setNotNull`. Then you re-run.
@@ -214,7 +214,7 @@ You know which operation failed (`alterNullability.setNotNull.user.displayName`)
 1. Edit your `contract.prisma`
 2. Plan a migration: `migration plan`
 3. Edit the TypeScript and run `./migration.ts`
-4. Apply the migration: `migration apply`
+4. Apply the migration: `prisma-next migrate`
 5. Read the output, iterate
 
 The contract describes the database schema you want. `migration.ts` lets you edit the migration easily. The JSON is what runs. The feedback is granular enough to act on.


### PR DESCRIPTION
## Product gotcha: published content teaches a removed CLI verb

The Prisma Next CLI replaced `prisma-next migration apply` with the top-level **`prisma-next migrate`** (verified against `prisma/prisma-next` `origin/main`: the CLI ships an explicit removed-verb redirect that exits with "Use `prisma-next migrate --to <contract>` instead"). Two published blog posts still teach the old verb, so readers copying commands hit an unknown-command error on current builds.

## Fixed here

- [TypeScript Migrations in Prisma Next](https://www.prisma.io/blog/typescript-migrations-in-prisma-next): two `$ npx prisma-next migration apply` invocations, the `Fix:` line inside the sample error output, and the workflow list item.
- [MongoDB Without Compromise](https://www.prisma.io/blog/mongodb-without-compromise): one narrative "Run `prisma-next migration apply` to execute."

## Not fixed here (needs the docs team, flagging for follow-up)

The `apps/docs/content/docs/cli/next/*` reference section documents the old CLI surface more broadly and needs regeneration rather than find/replace, e.g.:

- `cli/next/migration-apply.mdx` exists as a page (the verb is gone; the replacement `migrate` has different flags: `--to`, `--advance-ref`, `--show`, `--from`)
- `cli/next/migration-ref.mdx` documents `migration apply --ref <name>` (removed; refs are now `prisma-next ref set|list|delete` plus `--to <ref>`)
- `cli/next/configuration.mdx` lists `migration apply` among commands needing `db.connection`
- `cli/next/db-update.mdx` links to the migration-apply page

The new `/orm/next/migrations` section (#8025) documents the current surface and can serve as the reference for that update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration command examples in two blog posts to use the current `prisma-next migrate` command.
  * Revised related walkthrough steps and error-output examples so readers see the latest migration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->