### PR TITLE
Add technical depth to Xeito customer story

### DIFF
--- a/apps/blog/content/blog/how-xeito-builds-features-not-database-infrastructure-with-prisma/index.mdx
+++ b/apps/blog/content/blog/how-xeito-builds-features-not-database-infrastructure-with-prisma/index.mdx
@@ -84,6 +84,42 @@ Xeito runs on a simple, modern stack:
 
 That last part is the value. The database is still critical, but it does not become the work Gabriel has to sell to users.
 
+## How the data layer works
+
+The technical challenge in Xeito is not just storing users and matches. It is keeping a fast-moving sports domain consistent while the product keeps adding new workflows.
+
+A league night touches many parts of the model at once:
+
+- referees submit points from the court
+- matches update game and point state
+- team standings change as results come in
+- captains check rosters and availability
+- clubs publish events, registrations, schedules, and payments
+- players follow the results from their dashboard
+
+That makes the schema important product surface area. When Gabriel adds a workflow such as tournament registrations or live referee scoring, he is not only adding UI. He is changing the relationships between clubs, players, teams, matches, points, standings, payments, and events.
+
+Prisma gives him one place to make those relationships explicit. He models the data in the Prisma schema, turns schema changes into migrations, and uses the generated Prisma Client to keep queries typed in the Next.js application.
+
+<Quotes speakerName="Gabriel Gil Graña">
+Prisma has been quite a success in making sure the runtime is extremely well synchronized with the data.
+</Quotes>
+
+That matters when the product grows quickly. A live referee panel can send many reads and writes while players are watching the table move. A tournament workflow can add registrations, brackets, venue screens, court calls, organizer controls, and notifications. Future AI coaching will introduce match events, statistics, heat maps, and recommendations.
+
+Each new feature expands the model. Prisma keeps that expansion close to the code path where Gabriel is already working, instead of splitting it across hand-written SQL, migration scripts, generated types, and infrastructure configuration.
+
+There is still engineering judgment involved. Gabriel mentioned that schema changes across development, preview, staging, and production require understanding how migrations work and how to recover when something unexpected happens. But that is a smaller surface area than running the full database platform himself.
+
+For Xeito, the practical loop is:
+
+1. model the new sports workflow in the Prisma schema
+2. generate and review the migration
+3. use the typed client in the Next.js feature
+4. deploy without spending the release cycle tuning database infrastructure
+
+That is what keeps the article from being only a story about defaults. Prisma is not hiding the data layer from Gabriel. It is making the right parts explicit, typed, and close to the product code, while the operational defaults stay handled in the background.
+
 ## What comes next for Xeito
 
 Next comes tournament software: brackets, schedules, venue screens, organizer controls, and notifications. After that comes AI coaching: match analysis, player statistics, heat maps, and recommendations.


### PR DESCRIPTION
Adds Gabriel's requested technical depth to the merged Xeito customer story so it reads less promotional and gives Prisma's technical audience a clearer view of how the data layer supports the product.

## Changes

- **Xeito blog post**: Adds a new “How the data layer works” section to `apps/blog/content/blog/how-xeito-builds-features-not-database-infrastructure-with-prisma/index.mdx`.
- **Technical narrative**: Explains the live-scoring data flow, the expanding sports domain model, and how Prisma schema, migrations, and Prisma Client keep Xeito's data model close to the Next.js application.
- **Customer feedback**: Keeps the existing founder-friendly story while adding a practical implementation loop around modeling, migration review, typed queries, and deploys.

## Why

Gabriel's feedback was that Prisma readers are technical and would benefit from more of the “how,” not only the promotional story. This keeps the article aligned with the original narrative while making the Prisma value more concrete.

## Validation

- `pnpm --filter blog types:check`
- `pnpm --filter blog lint:links`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section explaining how the app’s data layer stays consistent during league-night updates.
  * Expanded coverage of key sports-domain actions, including match updates, standings, roster checks, event publishing, and payment-related flows.
  * Clarified the practical workflow for updating the data model and using typed database access in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->