### PR TITLE
Changelog design polish: labeled badges, de-duplicated dates and titles, compact hero

### DIFF
--- a/apps/site/content/changelog/2024-03-13.mdx
+++ b/apps/site/content/changelog/2024-03-13.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v5.11.0: Pulse reaches General Availability
-
 We're thrilled to announce that [Pulse](https://www.prisma.io/data-platform/pulse) has reached General Availability! This marks a significant milestone in our journey to redefine how developers interact with database-event driven compute.
 
 Pulse is managed database-event infrastructure that **simplifies database-event driven compute**, making it easy to power real-time functionality, like chat, notifications, data broadcast, and more.

--- a/apps/site/content/changelog/2024-04-03.mdx
+++ b/apps/site/content/changelog/2024-04-03.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v5.12.0: Cloudflare D1 in Preview
-
 Exciting news! **5.12.0** release brings Preview support for [Cloudflare D1](https://developers.cloudflare.com/d1/) with Prisma ORM 🥳
 
 ![blog-d1Launch@1.png](/changelog/image-66fc05379af15d65fd3dd6d792c9a575db648895-844x474-png-blog-d1Launch-1.png)

--- a/apps/site/content/changelog/2024-04-25.mdx
+++ b/apps/site/content/changelog/2024-04-25.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v5.13.0: Static IP support for Prisma Accelerate
-
 [Prisma Accelerate](https://www.prisma.io/data-platform/accelerate) introduces Static IP support, enabling secure connections to your database with predictable IPs for controlled access and minimized exposure. This allows connections from Accelerate to databases requiring trusted IP access.
 
 ![hero-firewall-teal@1.5x.png](/changelog/image-9a5f27696242c051a689abed3d4b7099a8145301-1200x674-png-hero-firewall-teal-1.5x.png)

--- a/apps/site/content/changelog/2024-05-15.mdx
+++ b/apps/site/content/changelog/2024-05-15.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v5.14.0: Prisma Optimize and createManyAndReturn
-
 Ever wondered what SQL the Prisma ORM generates under the hood? Want to understand the performance of your app and deliver a better and faster experience for your users? With [Prisma Optimize](https://www.npmjs.com/package/@prisma/extension-optimize) you can!
 
 ![changelog-optimize.png](/changelog/image-d662ff0fc23bcf0134f8ffea26db749bd670c6d1-844x474-png-changelog-optimize.png)

--- a/apps/site/content/changelog/2024-06-06.mdx
+++ b/apps/site/content/changelog/2024-06-06.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v5.15.0: multi-file schemas and Pulse delivery guarantees
-
 [Pulse](https://www.prisma.io/data-platform/pulse?utm_source=website&utm_medium=changelog&utm_campaign=pulse-dg) makes it easy to build event-driven apps by letting you react to changes in your database. Thanks to its new event persistence feature, all database change events are now guaranteed to be delivered *at least once* and *in the right order*!
 
 ![meta-delivery-guarantees.png](/changelog/image-6d76b801c5663654db08e0045d8a034526434668-1800x948-png-meta-delivery-guarantees.png)

--- a/apps/site/content/changelog/2024-06-27.mdx
+++ b/apps/site/content/changelog/2024-06-27.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v5.16.0: global omit for model fields
-
 In [5.13.0](https://github.com/prisma/prisma/releases/tag/5.13.0), we introduced Preview support for the `omit` option within the Prisma Client query options. Now, we’re more than happy to announce that we’re expanding the `omitApi` Preview feature to also include the ability to **omit fields globally**.
 
 Here's an example how you’re able to define fields to omit when instantiating Prisma Client either locally or globally:

--- a/apps/site/content/changelog/2024-07-18.mdx
+++ b/apps/site/content/changelog/2024-07-18.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v5.17.0: QueryRaw performance improvements
-
 We’ve changed the response format of `queryRaw` to decrease its average size, which reduces serialization CPU overhead. Here’s a peek at the results measuring before and after the improvements.
 
 ![perf-graphs.png](/changelog/image-a6312279b8aab81d7fcf21ad3308dd3a18710c7f-2724x1566-png-perf-graphs.png)

--- a/apps/site/content/changelog/2024-08-08.mdx
+++ b/apps/site/content/changelog/2024-08-08.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v5.18.0: native UUIDv7 support
-
 🎉 You can now use the latest version of UUIDs with Prisma ORM, providing even more flexibility and future-proofing for your applications.
 
 To support this, we’ve updated the `uuid()` function in Prisma Schema to accept an optional integer argument. Right now, the only valid values are `4` and `7`, with `4` being the default.

--- a/apps/site/content/changelog/2024-08-29.mdx
+++ b/apps/site/content/changelog/2024-08-29.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v5.19.0: introducing TypedSQL
-
 We're excited to introduce [`TypedSQL`](https://www.prisma.io/typedsql) in Prisma ORM, a new feature that brings type safety to your raw SQL queries. With `TypedSQL`, you can write raw SQL in `.sql` files and enjoy the benefits of type-checking and auto-completion, all within your Prisma projects.
 
 ![TypedSQL announcement 844x474.webp](/changelog/image-3591d625e8bce0c71d29d8cd0f026e5f8daf3f79-844x474-webp-TypedSQL-announcement-844x474.webp)

--- a/apps/site/content/changelog/2024-09-26.mdx
+++ b/apps/site/content/changelog/2024-09-26.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v5.20.0: Prisma Optimize is now GA
-
 Prisma Optimize is now in GA, offering AI-powered tools to analyze and improve database query performance. It identifies problematic queries, provides actionable insights like reducing excessive rows or adding indexes, and allows you to track performance improvements in real-time.
 
 ![blogpost-optimize 8.svg](/changelog/image-a2d1af619fb547bcc995ef12e208107bffafc97f-844x474-svg-blogpost-optimize-8.svg)

--- a/apps/site/content/changelog/2024-10-17.mdx
+++ b/apps/site/content/changelog/2024-10-17.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v5.21.0: new Optimize recommendations
-
 With this release, Prisma Optimize brings two new recommendations to help you enhance the performance of your database operations. Explore the new insights and take full advantage of our optimization engine to streamline your development experience.
 
 [Resolve repeated queries with caching](https://www.prisma.io/docs/optimize/recommendations/repeated-query)

--- a/apps/site/content/changelog/2024-11-07.mdx
+++ b/apps/site/content/changelog/2024-11-07.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v5.22.0: Prisma Postgres enters Early Access
-
 Our biggest news yet: Prisma now offers a managed PostgreSQL service! Entering Early Access, Prisma Postgres is a pay-as-you-go, serverless Postgres offering that offers competitive pricing and no cold starts!
 
 We’re confident that the technology powering Prisma Postgres is the path forward for database offerings. So much so that [we’ve gone in depth on our blog](https://www.prisma.io/blog/announcing-prisma-postgres-early-access) on how we brought Prisma Postgres to life.

--- a/apps/site/content/changelog/2024-11-28.mdx
+++ b/apps/site/content/changelog/2024-11-28.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.0.0: Prisma ORM v6 has arrived
-
 Prisma 6 is here, bringing improvements for future-proofing and enhanced performance. We've updated the minimum supported versions of TypeScript and Node.js and significantly improved full-text search capabilities by promoting the `fullTextIndex` and `fullTextSearch` features to General Availability.
 
 - **Explore what's new**: Read the [launch blog](https://pris.ly/prisma-6?utm_source=website&utm_medium=changelog) to learn how Prisma has evolved, including tooling updates and new features for improved performance and flexibility.

--- a/apps/site/content/changelog/2024-12-19.mdx
+++ b/apps/site/content/changelog/2024-12-19.mdx
@@ -11,9 +11,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.1.0: tracing is now stable
-
 We’re really excited about Prisma ORM 6.1.0 as our `tracing` Preview feature is now stable! There are a few changes needed if you are using the `tracing` feature, make sure you check out [the release notes](https://github.com/prisma/prisma/releases/tag/6.1.0) for all the details.
 
 ## 📜 Our Manifesto for Prisma ORM

--- a/apps/site/content/changelog/2025-01-09.mdx
+++ b/apps/site/content/changelog/2025-01-09.mdx
@@ -11,9 +11,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.2.0: omit API is now GA
-
 Prisma ORM 6.2.0 might be a minor release, but the changes in it are **major.** In this release we are moving the omit API ([our most requested feature](https://github.com/prisma/prisma/issues/5042)) to Generally Available. You can now use the omit API without a Preview feature flag!
 
 6.2.0 also includes some other highly requested features:

--- a/apps/site/content/changelog/2025-01-30.mdx
+++ b/apps/site/content/changelog/2025-01-30.mdx
@@ -11,9 +11,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.3.0: Prisma Studio returns to Console
-
 [We’ve released a new version of Prisma Studio!](https://www.prisma.io/blog/we-made-prisma-studio-even-better) This version is packaged with Prisma ORM 6.3.0 and also marks the triumphant return of **Prisma Studio in the Console**.
 
 Be sure to **check out our blog post** for all the details, but here’s a shortlist:

--- a/apps/site/content/changelog/2025-02-20.mdx
+++ b/apps/site/content/changelog/2025-02-20.mdx
@@ -11,9 +11,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.4.0: Prisma Postgres is GA
-
 Prisma Postgres, our hosted PostgreSQL offering, is ready for production!
 
 We’re really excited to finally have a database offering, especially since Prisma Postgres comes standard with:

--- a/apps/site/content/changelog/2025-03-13.mdx
+++ b/apps/site/content/changelog/2025-03-13.mdx
@@ -15,9 +15,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.5.0: Rust to TypeScript update
-
 ![image.png](/changelog/image-f94c7ac0283481bbc8177d30bb3bc92464f1ca33-844x474-png-image.png)
 
 Our ORM team is making progress on our transition from Rust to TypeScript. We've developed [a migration plan](https://www.prisma.io/blog/from-rust-to-typescript-a-new-chapter-for-prisma-orm) and now have [an initial prototype with benchmarks](https://www.prisma.io/blog/rust-to-typescript-update-boosting-prisma-orm-performance)!

--- a/apps/site/content/changelog/2025-04-10.mdx
+++ b/apps/site/content/changelog/2025-04-10.mdx
@@ -15,9 +15,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.6.0: MCP Server for Prisma Postgres
-
 [Prisma Postgres](https://www.prisma.io/postgres) is the first serverless database without cold starts. Designed for optimal efficiency and high performance, it's the perfect database to be used alongside AI tools like Cursor, Windsurf, Lovable or co.dev.
 
 In the [v6.6.0](https://github.com/prisma/prisma/releases/tag/6.6.0) ORM release, we added a command to start a Prisma MCP server that you can integrate in your AI development environment. Thanks to that MCP server, you can now:

--- a/apps/site/content/changelog/2025-05-01.mdx
+++ b/apps/site/content/changelog/2025-05-01.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.7.0: Prisma Postgres on Vercel Marketplace
-
 We’re excited to announce that Prisma Postgres is now available as a [Vercel Marketplace integration](https://vercel.com/marketplace/prisma). With the [integration](https://www.prisma.io/blog/connect-your-apps-to-prisma-postgres-via-vercel-marketplace-integration), you can:
 
 - create Prisma Postgres instances without leaving the Vercel Dashboard

--- a/apps/site/content/changelog/2025-05-19.mdx
+++ b/apps/site/content/changelog/2025-05-19.mdx
@@ -15,9 +15,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.8.0: local Prisma Postgres with prisma dev
-
 #### 💻 **Local development with Prisma Postgres via `prisma dev` (Early Access)**
 
 In 6.8.0, we released a way to develop against Prisma Postgres *locally* — no Docker required!

--- a/apps/site/content/changelog/2025-06-05.mdx
+++ b/apps/site/content/changelog/2025-06-05.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.9.0: no Rust engines for PostgreSQL and SQLite
-
 If you've been excited about our work of removing the Rust engines from Prisma ORM but hesitated trying it out because it was in an [Early Access](https://www.prisma.io/docs/orm/more/releases#early-access) (EA) phase, now is a great time for you to get your hands on the [Rust-free Prisma ORM version](https://www.prisma.io/blog/try-the-new-rust-free-version-of-prisma-orm-early-access).
 
 This major architectural change has moved from EA into [Preview](https://www.prisma.io/docs/orm/more/releases#preview) in this release, meaning there are no more know major issues. If you want to try it out, add the `queryCompiler` and `driverAdapters` preview feature flags to your `generator`, install the driver adapter for your database, and get going:

--- a/apps/site/content/changelog/2025-06-17.mdx
+++ b/apps/site/content/changelog/2025-06-17.mdx
@@ -15,9 +15,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.10.0: no Rust engines for MS SQL Server and PlanetScale
-
 We are in the process of [removing the Rust engines](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/no-rust-engine) from Prisma ORM. If you want to try this, you can configure your `generator` like this:
 
 ```typescript

--- a/apps/site/content/changelog/2025-07-02.mdx
+++ b/apps/site/content/changelog/2025-07-02.mdx
@@ -15,9 +15,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.11.0: embed Prisma Studio in your React apps
-
 If you’re using Prisma Postgres (yourself or [by offering it to your own users](https://www.prisma.io/partners)), you can now embed Prisma Studio to offer an amazing data editing experience via the [`@prisma/studio-core`](https://www.npmjs.com/package/@prisma/studio-core) npm package.
 
 ![Studio-component[LIGHT]@4x.png](/changelog/image-d2c35b8243dd6f86ff9a353d5bb64ad79510920f-2836x981-png-Studio-component-LIGHT-4x.png)

--- a/apps/site/content/changelog/2025-07-17.mdx
+++ b/apps/site/content/changelog/2025-07-17.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.12.0: ESM-compatible prisma-client in Preview
-
 #### ESM-compatible `prisma-client` generator now in Preview
 
 We’re excited to share that our new and more flexible [`prisma-client` generator](https://www.prisma.io/docs/orm/prisma-schema/overview/generators#prisma-client-early-access) is moving into [Preview](https://www.prisma.io/docs/orm/more/releases#preview)! As a reminder, here’s what it looks like:

--- a/apps/site/content/changelog/2025-07-30.mdx
+++ b/apps/site/content/changelog/2025-07-30.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.13.0: Prisma Config is now GA
-
 #### 📂 Prisma Config is now Generally Available
 
 The [`prisma.config.ts`](https://www.prisma.io/docs/orm/reference/prisma-config-reference) file is Prisma ORM’s native way to provide configuration options for your project. The Prisma Config file now allows you to:

--- a/apps/site/content/changelog/2025-08-27.mdx
+++ b/apps/site/content/changelog/2025-08-27.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.15.0: AI guardrails prevent database resets
-
 Prisma ORM now includes built-in safety checks that protect against destructive commands when triggered by AI coding assistants. The CLI can recognize when it is being executed by popular AI agents such as Claude Code, Gemini CLI, Qwen Code, Cursor, Aider and Replit.
 
 If a command like `prisma migrate reset --force` is attempted, Prisma ORM will prompt for explicit confirmation before proceeding.

--- a/apps/site/content/changelog/2025-09-10.mdx
+++ b/apps/site/content/changelog/2025-09-10.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.16.0: Rust-free ORM and driver adapters are GA
-
 Eight months ago, we published our [ORM manifesto](https://www.prisma.io/blog/prisma-orm-manifesto) with the first hint that we’re going to remove the Rust-based query engine from Prisma ORM:
 
 *We’re addressing this by migrating Prisma’s core logic from Rust to TypeScript and redesigning the ORM to make customization and extension easier.*

--- a/apps/site/content/changelog/2025-10-08.mdx
+++ b/apps/site/content/changelog/2025-10-08.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.17.0: Prisma Postgres works with any tool
-
 Previously, the *only* way to connect to Prisma Postgres was using Prisma ORM. That combination is great because it gives you connection pooling, global caching and overall an amazing DX.
 
 That being said, preferences may vary and some developers prefer to use plain SQL or lower-level query builders in their applications. As of this release, these ways for connecting to Prisma Postgres are now officially Generally Available (GA) and can be used in your production apps!

--- a/apps/site/content/changelog/2025-11-05.mdx
+++ b/apps/site/content/changelog/2025-11-05.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v6.19.0: connection pooling for Prisma Postgres
-
 Prisma ORM is the most popular ORM in the TypeScript ecosystem. Today’s release brings a bunch of new bug fixes and overall improvements:
 
 - [\#5675](https://github.com/prisma/prisma-engines/pull/5675): When dropping a model from a schema, do not append the default schema to the migration.

--- a/apps/site/content/changelog/2025-11-19.mdx
+++ b/apps/site/content/changelog/2025-11-19.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v7.0.0: Rust-free Prisma Client becomes the default
-
 **Rust-free Prisma Client as the default**
 
 The Rust-free Prisma Client has been in the works for some time now, all the way [back to v6.16.0](https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-6), with early iterations being available for developers to adopt. Now with version 7.0, we’re making this the default for all new projects. With this, developers are able to get:

--- a/apps/site/content/changelog/2025-12-03.mdx
+++ b/apps/site/content/changelog/2025-12-03.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v7.1.0: SQL comments and Prisma 7 read replicas
-
 - [\#28735](https://github.com/prisma/prisma/pull/28735): **pnpm monorepo issues with prisma client runtime utils** Resolves issues in pnpm monorepos where users would report TypeScript issues related to `@prisma/client-runtime-utils`.
 - [\#28769](https://github.com/prisma/prisma/pull/28769): **implement sql commenter plugins for Prisma Client** This PR implements support for SQL commenter plugins to Prisma Client. The feature will allow users to add metadata to SQL queries as comments, following the [sqlcommenter format](https://google.github.io/sqlcommenter/). Here are two related PRs that were also merged:
   - [\#28796](https://github.com/prisma/prisma/pull/28796): **implement query tags for SQL commenter plugin**

--- a/apps/site/content/changelog/2025-12-17.mdx
+++ b/apps/site/content/changelog/2025-12-17.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v7.2.0: migrate URL flags and Bun-aware prisma init
-
 - [\#28830](https://github.com/prisma/prisma/pull/28830): feat: add `sqlcommenter-query-insights` plugin
   - Adds a new SQL commenter plugin to support query insights metadata.
 - [\#28860](https://github.com/prisma/prisma/pull/28860): feat(migrate): add `-url` param for `db pull`, `db push`, `migrate dev`

--- a/apps/site/content/changelog/2026-01-21.mdx
+++ b/apps/site/content/changelog/2026-01-21.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-03-31T10:29:19.701Z"
 ---
-
-## Prisma ORM v7.3.0: fast and small query compilers
-
 - [\#28976](https://github.com/prisma/prisma/pull/28976): Fast and Small Query Compilers
 We've been working on various performance-related bugs since the initial ORM 7.0 release. With 7.3.0, we're introducing a new `compilerBuild` option for the client generator block in `schema.prisma` with two options: `fast` and `small`. This allows you to swap the underlying Query Compiler engine based on your selection, one built for speed (with an increase in size), and one built for size (with the trade-off for speed). By default, the `fast` mode is used, but this can be set by the user. We still have more in progress for performance, but this new `compilerBuild` option is our first step toward addressing your concerns!
 

--- a/apps/site/content/changelog/2026-02-11.mdx
+++ b/apps/site/content/changelog/2026-02-11.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-04-14T00:00:00.000Z"
 ---
-
-## Prisma ORM v7.4.0: Prisma Client query caching and partial indexes
-
 ## Highlights
 
 ## ORM

--- a/apps/site/content/changelog/2026-02-19.mdx
+++ b/apps/site/content/changelog/2026-02-19.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-04-14T00:00:00.000Z"
 ---
-
-## Prisma ORM v7.4.1: bug fixes and quality improvements
-
 Prisma ORM v7.4.1 is a patch release focused on bug fixes and quality improvements across Prisma Client, driver adapters, and the Prisma Schema Language.
 
 ## Fixes

--- a/apps/site/content/changelog/2026-02-27.mdx
+++ b/apps/site/content/changelog/2026-02-27.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-04-14T00:00:00.000Z"
 ---
-
-## Prisma ORM v7.4.2: bug fixes and quality improvements
-
 Prisma ORM v7.4.2 is a patch release focused on bug fixes and quality improvements across Prisma Client, driver adapters, and the Schema Engine.
 
 ## Fixes

--- a/apps/site/content/changelog/2026-03-11.mdx
+++ b/apps/site/content/changelog/2026-03-11.mdx
@@ -13,9 +13,6 @@ share:
 source:
   exportedAt: "2026-04-14T00:00:00.000Z"
 ---
-
-## Prisma ORM v7.5.0: nested transaction savepoints and Studio updates
-
 ## ORM
 
 ### Nested transaction rollbacks via savepoints

--- a/apps/site/content/changelog/2026-03-27.mdx
+++ b/apps/site/content/changelog/2026-03-27.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-04-14T00:00:00.000Z"
 ---
-
-## Prisma ORM v7.6.0: prisma postgres link and Studio dark mode
-
 ## ORM
 
 ### Features

--- a/apps/site/content/changelog/2026-04-07.mdx
+++ b/apps/site/content/changelog/2026-04-07.mdx
@@ -14,9 +14,6 @@ share:
 source:
   exportedAt: "2026-04-14T00:00:00.000Z"
 ---
-
-## Prisma ORM v7.7.0: the new prisma bootstrap command
-
 ## ORM
 
 ### `prisma bootstrap` command

--- a/apps/site/content/changelog/2026-04-22.mdx
+++ b/apps/site/content/changelog/2026-04-22.mdx
@@ -12,12 +12,11 @@ share:
   active: true
   content: "Look at this page: "
 ---
-
-## Prisma: a query plan cache size option and JSON equality fixes
-
 Prisma ORM adds a parameter to size the query plan cache and corrects how equality is evaluated on JSON values.
 
 ## Prisma ORM
+
+Query plan cache tuning, plus JSON and Cloudflare D1 correctness fixes.
 
 - **New** · [#29503](https://github.com/prisma/prisma/pull/29503): A new parameter sets the size of the query plan cache.
 

--- a/apps/site/content/changelog/2026-04-27.mdx
+++ b/apps/site/content/changelog/2026-04-27.mdx
@@ -12,20 +12,19 @@ share:
   active: true
   content: "Look at this page: "
 ---
-
-## Prisma: clearer errors when a database driver fails
-
 Unmapped database driver errors now surface as a clear, catchable Prisma error instead of a raw crash. This week also ships routine security patches and a MongoDB setup fix.
 
 ## Highlights
 
-### Unmapped driver errors now surface as a clear error · Improved
+### Improved · Unmapped driver errors now surface as a clear error
 
 When a database driver returned an error Prisma had no specific mapping for, the raw driver error was rethrown and could crash the client. These now surface as a user-facing `P2039`, so you can catch and handle them like any other Prisma error.
 
 Shipped in [#29512](https://github.com/prisma/prisma/pull/29512).
 
 ## Prisma ORM
+
+A MongoDB setup fix and patched bundled dependencies.
 
 - **Fixed** · [#29515](https://github.com/prisma/prisma/pull/29515): MongoDB replica set initialization is idempotent in the Docker setup, so re-running it no longer errors.
 

--- a/apps/site/content/changelog/2026-05-15.mdx
+++ b/apps/site/content/changelog/2026-05-15.mdx
@@ -12,12 +12,11 @@ share:
   active: true
   content: "Look at this page: "
 ---
-
-## Prisma: a Safari scrolling fix in Prisma Studio
-
 Prisma Studio restores horizontal scrolling in Safari, so wide tables are usable again.
 
 ## Prisma Studio
+
+A scrolling fix for Safari.
 
 - **Fixed** · [#1512](https://github.com/prisma/studio/pull/1512): The data grid scrolls horizontally again in Safari.
 

--- a/apps/site/content/changelog/2026-05-19.mdx
+++ b/apps/site/content/changelog/2026-05-19.mdx
@@ -12,12 +12,11 @@ share:
   active: true
   content: "Look at this page: "
 ---
-
-## Prisma: Node.js compatibility fix
-
 Prisma ORM drops a deprecated Node.js call, clearing a deprecation warning on recent Node.js versions.
 
 ## Prisma ORM
+
+A cleaner console on recent Node.js versions.
 
 - **Fixed** · [#29538](https://github.com/prisma/prisma/pull/29538): Removed a deprecated `Buffer()` call, clearing the deprecation warning it raised on recent Node.js versions.
 

--- a/apps/site/content/changelog/2026-06-05.mdx
+++ b/apps/site/content/changelog/2026-06-05.mdx
@@ -15,14 +15,11 @@ share:
   active: true
   content: "Look at this page: "
 ---
-
-## Prisma: Query Insights in Prisma Studio
-
 Query Insights now lives inside Prisma Studio, so you can inspect slow queries next to the data you are browsing. Prisma Next adds backward cursor pagination, a migration preview, and a published version support policy. Prisma ORM improves type-checking performance and tightens how it stores platform credentials.
 
 ## Highlights
 
-### Query Insights comes to Prisma Studio · New
+### New · Query Insights comes to Prisma Studio
 
 Checking slow queries used to mean leaving Prisma Studio for a separate view. Prisma Studio now has a Queries view of its own, so you can inspect query performance next to the data you are browsing. The SQL view also validates AI-generated SQL before it shows it to you.
 
@@ -30,7 +27,9 @@ Shipped in [#1515](https://github.com/prisma/studio/pull/1515).
 
 ## Prisma Next
 
-> ℹ️ **Note:** Prisma Next is in Early Access. Scope and behavior may still change.
+Backward cursor pagination, migration previews, and a published version support policy.
+
+> **Note:** Prisma Next is in Early Access. Scope and behavior may still change.
 
 - **New** · [#671](https://github.com/prisma/prisma-next/pull/671): `orderBy` items expose `reverse()` for backward cursor pagination.
 - **New** · [#735](https://github.com/prisma/prisma-next/pull/735): `migration --show` previews the migration path before you apply it.
@@ -38,10 +37,14 @@ Shipped in [#1515](https://github.com/prisma/studio/pull/1515).
 
 ## Prisma Studio
 
+Query details are easier to copy, and the SQL view respects your schema selection.
+
 - **Improved** · [#1520](https://github.com/prisma/studio/pull/1520): Copy a query's details straight from the Query Details panel.
 - **Fixed** · [#1518](https://github.com/prisma/studio/pull/1518): The SQL view runs against the schema you select.
 
 ## Prisma ORM
+
+Faster type-checking and stricter credential storage.
 
 - **Improved** · [#29592](https://github.com/prisma/prisma/pull/29592): Type-checking is faster on large generated client types.
 - **Improved** · [#29568](https://github.com/prisma/prisma/pull/29568): Stored platform auth credentials now use stricter file permissions.

--- a/apps/site/content/changelog/2026-06-11.mdx
+++ b/apps/site/content/changelog/2026-06-11.mdx
@@ -14,9 +14,6 @@ share:
   active: true
   content: "Look at this page: "
 ---
-
-## Prisma: Public Beta for Prisma Compute, and first-class enums in Prisma Next
-
 Prisma Compute is now in Public Beta: deploy a TypeScript app right next to your Prisma Postgres database, with custom domains and database branches. Prisma Next makes enums first-class and adds native UUID columns, and Prisma ORM ships clearer adapter error messages.
 
 ## Highlights
@@ -25,27 +22,33 @@ Prisma Compute is now in Public Beta: deploy a TypeScript app right next to your
 
 Hosting an app close to its database used to mean wiring up a separate platform and managing two sets of environments. Prisma Compute deploys TypeScript apps alongside Prisma Postgres, with hosting, database branches, and previews managed together. It is now open to everyone in Public Beta.
 
-> ℹ️ **Note:** Prisma Compute is in Public Beta. Behavior and limits may still change.
+> **Note:** Prisma Compute is in Public Beta. Behavior and limits may still change.
 
-📚 Read the announcement on the [Prisma blog](https://www.prisma.io/blog/launching-prisma-compute-public-beta) and the [Prisma Compute docs](https://www.prisma.io/docs/compute).
+Read the announcement on the [Prisma blog](https://www.prisma.io/blog/launching-prisma-compute-public-beta) and the [Prisma Compute docs](https://www.prisma.io/docs/compute).
 
 ### Prisma Next: first-class enums and native UUID columns
 
 Working with enums and UUIDs in Prisma Next meant extra mapping in application code. Enums are now first-class, with typed reads and writes and declaration-order sorting, and PostgreSQL columns can use a native UUID storage type.
 
-> ℹ️ **Note:** Prisma Next is in Early Access. Scope and behavior may still change.
+> **Note:** Prisma Next is in Early Access. Scope and behavior may still change.
 
 Shipped in [#769](https://github.com/prisma/prisma-next/pull/769), [#810](https://github.com/prisma/prisma-next/pull/810).
 
 ## Prisma Compute
 
-- **New** · Attach a custom domain to a Prisma Compute service. 📚 [How we built custom domains](https://www.prisma.io/blog/prisma-compute-custom-domains).
+Custom domains for your services.
+
+- **New** · Attach a custom domain to a Prisma Compute service. [How we built custom domains](https://www.prisma.io/blog/prisma-compute-custom-domains).
 
 ## Prisma Next
+
+Grouped writes on the SQLite facade.
 
 - **New** · [#737](https://github.com/prisma/prisma-next/pull/737): The SQLite facade gains `db.transaction()` for grouping writes.
 
 ## Prisma ORM
+
+Clearer error messages for driver adapters.
 
 - **Improved** · [#29624](https://github.com/prisma/prisma/pull/29624): Adapter-related errors now carry clearer messages.
 

--- a/apps/site/content/changelog/2026-06-19.mdx
+++ b/apps/site/content/changelog/2026-06-19.mdx
@@ -15,9 +15,6 @@ share:
   active: true
   content: "Look at this page: "
 ---
-
-## Prisma: TypeScript config and rollbacks for Prisma Compute, schema tooling for Prisma Next
-
 Prisma Compute deploys are now configured in TypeScript, NestJS joins the auto-detected frameworks alongside Nuxt and Astro, and you can roll a service back to any prior version from the Prisma Console (Public Beta). Prisma Next adds a schema formatter and editor diagnostics.
 
 ## Highlights
@@ -26,13 +23,13 @@ Prisma Compute deploys are now configured in TypeScript, NestJS joins the auto-d
 
 A bad deploy used to mean rebuilding and redeploying an older commit under pressure. The Prisma Console now lets you promote any prior version of a Prisma Compute service back to live, so recovering from a bad deploy is one action instead of a rebuild.
 
-📚 [Prisma Compute docs](https://www.prisma.io/docs/compute).
+*Read more:* [Prisma Compute docs](https://www.prisma.io/docs/compute).
 
 ### Prisma Next: schema formatting and editor diagnostics
 
 Working on a Prisma Next schema meant formatting by hand and finding mistakes only at generate time. Prisma Next adds a Prisma Schema Language formatter, available through `prisma format`, and a language server that reports schema diagnostics in your editor as you type.
 
-> ℹ️ **Note:** Prisma Next is in Early Access. Scope and behavior may still change.
+> **Note:** Prisma Next is in Early Access. Scope and behavior may still change.
 
 Shipped in [#850](https://github.com/prisma/prisma-next/pull/850), [#852](https://github.com/prisma/prisma-next/pull/852).
 
@@ -40,11 +37,13 @@ Shipped in [#850](https://github.com/prisma/prisma-next/pull/850), [#852](https:
 
 Configuration, framework support, and published pricing for your Public Beta deploys.
 
-- **New** · Configure a deploy in TypeScript with a `prisma.compute.ts` file. 📚 [Configure Prisma Compute in TypeScript](https://www.prisma.io/blog/prisma-compute-config-file) and the [config reference](https://www.prisma.io/docs/compute).
-- **New** · NestJS apps are now auto-detected at deploy, so they build without manual entrypoint configuration. Nuxt and Astro are also supported. 📚 [Prisma Compute docs](https://www.prisma.io/docs/compute).
-- **New** · Prisma Compute pricing is published in the docs. 📚 [Prisma Compute docs](https://www.prisma.io/docs/compute).
+- **New** · Configure a deploy in TypeScript with a `prisma.compute.ts` file. [Configure Prisma Compute in TypeScript](https://www.prisma.io/blog/prisma-compute-config-file) and the [config reference](https://www.prisma.io/docs/compute).
+- **New** · NestJS apps are now auto-detected at deploy, so they build without manual entrypoint configuration. Nuxt and Astro are also supported. [Prisma Compute docs](https://www.prisma.io/docs/compute).
+- **New** · Prisma Compute pricing is published in the docs. [Prisma Compute docs](https://www.prisma.io/docs/compute).
 
 ## Prisma Next
+
+A browser playground for the Prisma Schema Language.
 
 - **New** · [#856](https://github.com/prisma/prisma-next/pull/856): A browser-based PSL playground lets you edit a schema and see diagnostics live, wired to the same language server.
 

--- a/apps/site/content/changelog/2026-06-24.mdx
+++ b/apps/site/content/changelog/2026-06-24.mdx
@@ -13,9 +13,6 @@ share:
   active: true
   content: "Look at this page: "
 ---
-
-## Prisma: manage Prisma Compute apps by API, and many-to-many with row-level security in Prisma Next
-
 Prisma Compute services can now be managed end to end without the dashboard: the Management API gains apps and deployments surfaces with a deployment logs endpoint, and the Prisma Console adds per-service environment variables (Public Beta). Prisma Next lets you declare many-to-many relations and row-level security policies directly in your schema.
 
 ## Highlights
@@ -24,22 +21,26 @@ Prisma Compute services can now be managed end to end without the dashboard: the
 
 Automating Prisma Compute meant working around dashboard-only workflows. The Management API now exposes apps and deployments as first-class surfaces, including an endpoint for fetching a deployment's logs, so scripts and agents can drive the same workflows the Prisma Console offers. The earlier route names keep working and are deprecated below.
 
-📚 [Prisma Compute docs](https://www.prisma.io/docs/compute).
+*Read more:* [Prisma Compute docs](https://www.prisma.io/docs/compute).
 
 ### Author many-to-many relations and row-level security in your schema
 
 Many-to-many relations meant hand-writing a junction table, and row-level security lived outside your schema. Prisma Next now lets you author both in Prisma Schema Language: a many-to-many relation generates the junction for you, and SELECT row-level security policies are declared in the schema, enforced, and checked so drift fails verification.
 
-> ℹ️ **Note:** Prisma Next is in Early Access. Scope and behavior may still change.
+> **Note:** Prisma Next is in Early Access. Scope and behavior may still change.
 
 Shipped in [#819](https://github.com/prisma/prisma-next/pull/819), [#771](https://github.com/prisma/prisma-next/pull/771).
 
 ## Prisma Compute
 
+Environment variables in the Prisma Console and custom build artifacts.
+
 - **New** · Manage environment variables per service from the Prisma Console, with separate production and preview values.
 - **New** · Custom build artifacts: bring your own build output instead of relying on a detected framework build.
 
 ## Prisma Next
+
+The language server picks up diagnostics and formatting.
 
 - **New** · [#862](https://github.com/prisma/prisma-next/pull/862): The language server surfaces schema symbol diagnostics as you type.
 - **Improved** · [#857](https://github.com/prisma/prisma-next/pull/857): Schema formatting is available through the language server, not just the CLI.

--- a/apps/site/content/changelog/2026-07-03.mdx
+++ b/apps/site/content/changelog/2026-07-03.mdx
@@ -14,28 +14,27 @@ share:
   active: true
   content: "Look at this page: "
 ---
-
-## Prisma: get started with Prisma Next, and debuggable Prisma Compute builds
-
 Prisma Next now has getting started guides for new and existing projects, on PostgreSQL and MongoDB, alongside new schema capabilities like scalar lists and enums on MongoDB. Prisma Compute builds are easier to debug: a failed build emails you, build logs are available through the Management API, and a stuck build step fails fast instead of hanging.
 
 ## Highlights
 
-### Get started with Prisma Next · New
+### New · Get started with Prisma Next
 
 Trying Prisma Next meant piecing the setup together from scattered posts. The docs now have getting started guides covering new projects and adding Prisma Next to an existing project, for PostgreSQL and MongoDB, with companion posts on what changes and why.
 
-> ℹ️ **Note:** Prisma Next is in Early Access. Scope and behavior may still change.
+> **Note:** Prisma Next is in Early Access. Scope and behavior may still change.
 
-📚 [Prisma Next docs](https://www.prisma.io/docs/next) and [The Next Evolution of Prisma ORM](https://www.prisma.io/blog/the-next-evolution-of-prisma-orm).
+*Read more:* [Prisma Next docs](https://www.prisma.io/docs/next) and [The Next Evolution of Prisma ORM](https://www.prisma.io/blog/the-next-evolution-of-prisma-orm).
 
-### See why a Prisma Compute build failed · New
+### New · See why a Prisma Compute build failed
 
 A failing build used to mean re-running the deploy and watching. Prisma Compute now emails you when a build fails, streams complete build logs through the Management API (with a pointer on the deploy check run), and enforces per-step timeouts so a stuck step fails fast with a clear reason instead of hanging.
 
-📚 [Prisma Compute docs](https://www.prisma.io/docs/compute).
+*Read more:* [Prisma Compute docs](https://www.prisma.io/docs/compute).
 
 ## Prisma Next
+
+Scalar lists, MongoDB enums, a client-safe static surface, and richer editor support.
 
 - **New** · [#870](https://github.com/prisma/prisma-next/pull/870): Scalar list fields, authored in the schema and carried through migrations and inference.
 - **New** · [#834](https://github.com/prisma/prisma-next/pull/834): Enums on MongoDB, authored in the schema, enforced by validators, and typed on reads.

--- a/apps/site/src/app/changelog/[...slug]/page.tsx
+++ b/apps/site/src/app/changelog/[...slug]/page.tsx
@@ -1,11 +1,23 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  type ComponentProps,
+  type ElementType,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import { createRelativeLink } from "fumadocs-ui/mdx";
 import { Badge, InlineTOC, Separator } from "@prisma/eclipse";
 import { formatDate, formatTag } from "@/lib/format";
 import { createPageMetadata } from "@/lib/page-metadata";
-import { changelogSource } from "@/lib/changelog-source";
+import {
+  changelogSource,
+  getSortedReleaseNotes,
+} from "@/lib/changelog-source";
 import { getMDXComponents } from "@/mdx-components";
 
 interface PageParams {
@@ -19,6 +31,117 @@ interface TOCItem {
   items?: TOCItem[];
 }
 
+const changeLabelColors = {
+  New: "success",
+  Improved: "neutral",
+  Fixed: "neutral",
+  Breaking: "error",
+  Deprecated: "warning",
+} as const;
+
+const changeLabelPrefix = new RegExp(
+  `^(?:${Object.keys(changeLabelColors).join("|")}) · `,
+);
+
+function stripChangeLabels(items: TOCItem[]): TOCItem[] {
+  return items.map((item) => ({
+    ...item,
+    title:
+      typeof item.title === "string"
+        ? item.title.replace(changeLabelPrefix, "")
+        : item.title,
+    items: item.items ? stripChangeLabels(item.items) : undefined,
+  }));
+}
+
+function textOf(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join("");
+  if (isValidElement(node)) {
+    return textOf((node.props as { children?: ReactNode }).children);
+  }
+  return "";
+}
+
+/** Splits "**Label** · rest" list-item children into label + remainder. */
+function parseChangeLabelItem(li: ReactElement) {
+  const kids = Children.toArray(
+    (li.props as { children?: ReactNode }).children,
+  );
+  const label = textOf(kids[0]).trim() as keyof typeof changeLabelColors;
+  const second = kids[1];
+  if (!isValidElement(kids[0]) || !(label in changeLabelColors)) return null;
+  if (typeof second !== "string" || !second.startsWith(" · ")) return null;
+  const rest = second.slice(3);
+  return { label, rest: [...(rest ? [rest] : []), ...kids.slice(2)] };
+}
+
+/**
+ * Groups consecutive same-label items ("New", "Improved", ...) under one
+ * badge instead of repeating the bold label on every bullet. Lists without
+ * labels render unchanged.
+ */
+function withChangeLabelGroups(List: ElementType) {
+  return function GroupedList({ children, ...props }: ComponentProps<"ul">) {
+    const items = Children.toArray(children).filter(isValidElement);
+    const parsed = items.map((li) => parseChangeLabelItem(li as ReactElement));
+    if (items.length === 0 || parsed.some((p) => p === null)) {
+      return <List {...props}>{children}</List>;
+    }
+    const groups: {
+      label: keyof typeof changeLabelColors;
+      items: ReactElement[];
+    }[] = [];
+    items.forEach((li, i) => {
+      const { label, rest } = parsed[i]!;
+      const item = cloneElement(
+        li as ReactElement<{ children?: ReactNode }>,
+        { children: rest },
+      );
+      const last = groups[groups.length - 1];
+      if (last && last.label === label) last.items.push(item);
+      else groups.push({ label, items: [item] });
+    });
+    return (
+      <div className="flex flex-col gap-5 my-5">
+        {groups.map((group, i) => (
+          <div key={i}>
+            <Badge
+              color={changeLabelColors[group.label]}
+              label={group.label}
+            />
+            <List {...props} className="mt-2 mb-0">
+              {group.items.map((item, j) => cloneElement(item, { key: j }))}
+            </List>
+          </div>
+        ))}
+      </div>
+    );
+  };
+}
+
+/** Renders a leading "New · " / "Improved · " etc. in a heading as a badge. */
+function withChangeLabelBadge(Heading: ElementType) {
+  return function LabeledHeading({ children, ...props }: ComponentProps<"h3">) {
+    const nodes = Children.toArray(children);
+    const first = nodes[0];
+    if (typeof first === "string") {
+      for (const [label, color] of Object.entries(changeLabelColors)) {
+        if (first.startsWith(`${label} · `)) {
+          return (
+            <Heading {...props}>
+              <Badge color={color} label={label} className="align-middle mr-1" />
+              {first.slice(label.length + 3)}
+              {nodes.slice(1)}
+            </Heading>
+          );
+        }
+      }
+    }
+    return <Heading {...props}>{children}</Heading>;
+  };
+}
+
 export default async function ReleaseNotesPage({ params }: { params: Promise<PageParams> }) {
   const { slug } = await params;
   const page = changelogSource.getPage(slug);
@@ -28,7 +151,23 @@ export default async function ReleaseNotesPage({ params }: { params: Promise<Pag
   const MDX = page.data.body;
   const description = page.data.summary ?? page.data.description;
   const tags = page.data.tags ?? [];
-  const toc = (page.data.toc as TOCItem[] | undefined) ?? [];
+  const toc = stripChangeLabels(
+    (page.data.toc as TOCItem[] | undefined) ?? [],
+  );
+  const sorted = getSortedReleaseNotes();
+  const position = sorted.findIndex((entry) => entry.url === page.url);
+  const newer = position > 0 ? sorted[position - 1] : null;
+  const older =
+    position >= 0 && position < sorted.length - 1
+      ? sorted[position + 1]
+      : null;
+
+  // Date-labeled entries set version to the date; showing both repeats it
+  const versionLabel =
+    page.data.date &&
+    page.data.version === new Date(page.data.date).toISOString().slice(0, 10)
+      ? null
+      : page.data.version;
 
   return (
     <main className="flex-1 w-full max-w-249 mx-auto px-4 py-8 z-1">
@@ -45,19 +184,21 @@ export default async function ReleaseNotesPage({ params }: { params: Promise<Pag
             <h1 className="text-4xl sm:text-5xl md:text-6xl stretch-display mb-0 text-left mt-0 font-sans-display text-foreground-neutral">
               {page.data.title}
             </h1>
-            <div className="text-sm flex gap-2 items-center text-foreground-neutral mb-4">
-              <Badge
-                color="neutral"
-                label={page.data.version}
-                className="border border-stroke-neutral bg-background-default text-foreground-neutral"
-              />
+            <div className="text-sm flex gap-2 items-center text-foreground-neutral mt-4 mb-6">
+              {versionLabel ? (
+                <Badge
+                  color="neutral"
+                  label={versionLabel}
+                  className="border border-stroke-neutral bg-background-default text-foreground-neutral"
+                />
+              ) : null}
+              {versionLabel && page.data.date ? (
+                <Separator orientation="vertical" className="h-4" />
+              ) : null}
               {page.data.date ? (
-                <>
-                  <Separator orientation="vertical" className="h-4" />
-                  <span className="text-foreground-neutral-weak">
-                    {formatDate(new Date(page.data.date).toISOString())}
-                  </span>
-                </>
+                <span className="text-foreground-neutral-weak">
+                  {formatDate(new Date(page.data.date).toISOString())}
+                </span>
               ) : null}
             </div>
             {tags.length > 0 ? (
@@ -80,13 +221,58 @@ export default async function ReleaseNotesPage({ params }: { params: Promise<Pag
               {description ? <p className="font-semibold text-lg">{description}</p> : null}
 
               <MDX
-                components={getMDXComponents({
-                  a: createRelativeLink(changelogSource, page),
-                })}
+                components={(() => {
+                  const components = getMDXComponents({
+                    a: createRelativeLink(changelogSource, page),
+                  });
+                  components.h3 = withChangeLabelBadge(
+                    (components.h3 ?? "h3") as ElementType,
+                  );
+                  components.ul = withChangeLabelGroups(
+                    (components.ul ?? "ul") as ElementType,
+                  );
+                  return components;
+                })()}
               />
             </div>
           </article>
           <Separator className="my-12" />
+
+          {older || newer ? (
+            <nav
+              aria-label="More release notes"
+              className="flex justify-between gap-8 mb-12"
+            >
+              {older ? (
+                <Link
+                  href={older.url}
+                  className="group flex flex-col gap-1 max-w-[45%]"
+                >
+                  <span className="text-sm text-foreground-neutral-weak">
+                    ← Older
+                  </span>
+                  <span className="text-foreground-neutral font-semibold group-hover:underline">
+                    {older.data.title}
+                  </span>
+                </Link>
+              ) : (
+                <span />
+              )}
+              {newer ? (
+                <Link
+                  href={newer.url}
+                  className="group flex flex-col gap-1 max-w-[45%] text-right items-end"
+                >
+                  <span className="text-sm text-foreground-neutral-weak">
+                    Newer →
+                  </span>
+                  <span className="text-foreground-neutral font-semibold group-hover:underline">
+                    {newer.data.title}
+                  </span>
+                </Link>
+              ) : null}
+            </nav>
+          ) : null}
 
           {/* Share Container */}
           {/* <BlogShare desc={page.data.metaDescription as string} /> */}

--- a/apps/site/src/app/changelog/page.tsx
+++ b/apps/site/src/app/changelog/page.tsx
@@ -29,19 +29,17 @@ export default async function ChangelogPage() {
 
   return (
     <main className="flex-1 w-full z-1 bg-background-default">
-      <div className="hero -mt-24 pt-40 flex items-end justify-center px-4 relative">
+      <div className="hero -mt-24 pt-40 relative">
         <div className="absolute inset-0 pointer-events-none z-1 bg-[linear-gradient(180deg,var(--color-foreground-ppg)_0%,var(--color-background-default)_100%)] opacity-20" />
-        <section className="content relative z-2 flex flex-col gap-8 pb-12">
-          <div className="flex flex-col gap-4 items-center text-center">
-            <div className="flex items-center gap-2 text-foreground-ppg-weak type-title-sm">
-              <i className="fa-regular fa-sparkles" aria-hidden />
-              <span>Changelog</span>
-            </div>
-            <h1 className="text-4xl sm:text-5xl md:text-6xl stretch-display mb-0 text-center mt-0 font-sans-display text-foreground-neutral max-w-4xl mx-auto">
-              The Latest News from Prisma
-            </h1>
+        <section className="max-w-249 mx-auto px-4 relative z-2 flex flex-col gap-4 pb-8">
+          <div className="flex items-center gap-2 text-foreground-ppg-strong type-title-sm">
+            <i className="fa-regular fa-sparkles" aria-hidden />
+            <span>Changelog</span>
           </div>
-          <p className="m-0 max-w-[640px] mx-auto text-center text-base text-foreground-neutral md:text-lg">
+          <h1 className="type-title-3xl md:type-title-4xl lg:type-title-5xl m-0 font-sans-display text-foreground-neutral">
+            The Latest News from Prisma
+          </h1>
+          <p className="m-0 max-w-[640px] text-base text-foreground-neutral md:text-lg">
             Here you’ll find all improvements and updates we’ve made to our
             products.
           </p>
@@ -52,6 +50,13 @@ export default async function ChangelogPage() {
         <div className="grid gap-6 mt-12 grid-cols-1">
           {entriesWithPreview.map(({ entry, summary }) => {
             const tags = entry.data.tags ?? [];
+            // Date-labeled entries set version to the date; showing both repeats it
+            const versionLabel =
+              entry.data.date &&
+              entry.data.version ===
+                new Date(entry.data.date).toISOString().slice(0, 10)
+                ? null
+                : entry.data.version;
 
             return (
               <Link
@@ -62,11 +67,13 @@ export default async function ChangelogPage() {
                 <div className="order-1 flex flex-col justify-between">
                   <div>
                     <div className="eyebrow flex gap-2 items-center flex-wrap">
-                      <Badge
-                        color="neutral"
-                        label={entry.data.version}
-                        className="w-fit"
-                      />
+                      {versionLabel ? (
+                        <Badge
+                          color="neutral"
+                          label={versionLabel}
+                          className="w-fit"
+                        />
+                      ) : null}
                       {tags.length > 0 ? (
                         <Badge
                           color="success"


### PR DESCRIPTION
## What

Design and consistency pass on the changelog pages and the 2026 backfill entries, reviewed live against a local run of this branch.

### Page code (`apps/site/src/app/changelog/`)

- Change-type labels (`New`, `Improved`, `Fixed`, `Breaking`, `Deprecated`) render as subtle badges: once per highlight heading, and once per group in bullet lists instead of bold text repeated on every line. Lists without labels are untouched.
- The version badge is hidden when it just repeats the entry date (this changelog sets `version` to the date). Real version labels like `v7.5.0` still show.
- Older/newer navigation at the bottom of each entry.
- The index hero is left-aligned and uses the blog-article hero type scale, so entries start above the fold; the eyebrow moved to `foreground-ppg-strong` to pass WCAG AA (was 2.49:1).
- Entry header spacing opened up; TOC titles no longer show raw label prefixes.

### Content (`apps/site/content/changelog/`)

- Removed the body-leading H2 that duplicated the frontmatter title on 49 entries (it rendered the title twice and polluted the TOC).
- Every product section in the 2026 backfill entries now opens with a one-line summary derived from its items (previously only 2 of 16 had one).
- Change-type labels moved to the front of highlight headings.
- Emoji conventions replaced with text: `📚` links became `*Read more:*`, `ℹ️ **Note:**` became `**Note:**`.

## Notes for reviewers

- `pnpm --filter site types:check` passes.
- The label-badge and section-summary conventions diverge from the generator skill in prisma/ignite#162; if this lands, the skill's `mdx-structure.md`/`voice.md` should be updated to match so future generated entries stay consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Changelog pages now show clearer release labels and badges, with improved grouping for labeled items.
  * Release note headers and navigation have been updated for easier browsing between newer and older entries.
* **Bug Fixes**
  * Removed duplicate or redundant headings from many changelog entries.
  * Fixed release note pages so content starts more cleanly and avoids repeated version titles.
  * Improved list and heading rendering in changelog posts for more consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->