### PR TITLE
blog: call out the Prisma Next performance benchmark from older performance posts

### DIFF
--- a/apps/blog/content/blog/performance-benchmarks-comparing-query-latency-across-typescript-orms-and-databases/index.mdx
+++ b/apps/blog/content/blog/performance-benchmarks-comparing-query-latency-across-typescript-orms-and-databases/index.mdx
@@ -12,6 +12,10 @@ tags:
   - "orm"
 ---
 
+::::note[New: the Prisma Next performance benchmark]
+Since this post, we've benchmarked [Prisma Next](https://pris.ly/pn-series), the new TypeScript-first foundation for Prisma ORM: it reaches about 87% of the raw `pg` driver's peak throughput, sustains 52% more requests per second than Prisma 7, and ships as a 9× smaller bundle. [See the latest results](/prisma-next-performance-benchmark).
+::::
+
 We have created open-source [performance benchmarks](https://benchmarks.prisma.io) to compare query latencies for Prisma ORM, TypeORM and Drizzle ORM with different database providers such as PostgreSQL on AWS RDS, Supabase and Neon. Read on to learn about our methodology and which TypeScript ORM is the fastest.
 
 ## Contents

--- a/apps/blog/content/blog/performance-engineering-aeduv0rei0jk/index.mdx
+++ b/apps/blog/content/blog/performance-engineering-aeduv0rei0jk/index.mdx
@@ -11,6 +11,10 @@ heroImagePath: "/performance-engineering-aeduv0rei0jk/imgs/hero-e43f947aa769d070
 heroImageAlt: "How We're Constantly Improving the Performance of Prisma"
 ---
 
+::::note[New: the Prisma Next performance benchmark]
+For a current look at Prisma performance, we've benchmarked [Prisma Next](https://pris.ly/pn-series), the new TypeScript-first foundation for Prisma ORM: about 87% of the raw `pg` driver's peak throughput and 52% more requests per second than Prisma 7. [See the latest results](/prisma-next-performance-benchmark).
+::::
+
 Fast and predictable performance is crucial for software to succeed. Therefore, ensuring great performance is one of
   our key goals. This post discusses the practices and tools used by our engineering team to make sure that our software
   meets our high performance standards.

--- a/apps/blog/content/blog/prisma-6-better-performance-more-flexibility-and-type-safe-sql/index.mdx
+++ b/apps/blog/content/blog/prisma-6-better-performance-more-flexibility-and-type-safe-sql/index.mdx
@@ -10,6 +10,10 @@ metaImagePath: "/prisma-6-better-performance-more-flexibility-and-type-safe-sql/
 heroImagePath: "/prisma-6-better-performance-more-flexibility-and-type-safe-sql/imgs/hero-1613e4843bb6239ae9f0e74962909b219dfafbc8-844x474.svg"
 ---
 
+::::note[New: the Prisma Next performance benchmark]
+Looking for the newest performance numbers? We've benchmarked [Prisma Next](https://pris.ly/pn-series), the new TypeScript-first foundation for Prisma ORM: about 87% of the raw `pg` driver's peak throughput and 52% more requests per second than Prisma 7. [See the latest results](/prisma-next-performance-benchmark).
+::::
+
 Today, we are releasing [Prisma v6](https://github.com/prisma/prisma/releases/tag/6.0.0)! Since the last major version, we have been hard at work incorporating user feedback, making Prisma ORM faster and more flexible, and adding amazing features like type-safe raw SQL queries.
 
 ## Prisma v6: What you need to know

--- a/apps/blog/content/blog/prisma-7-performance-benchmarks/index.mdx
+++ b/apps/blog/content/blog/prisma-7-performance-benchmarks/index.mdx
@@ -12,6 +12,10 @@ tags:
   - "orm"
 ---
 
+::::note[New: the Prisma Next performance benchmark]
+The work described here landed in [Prisma Next](https://pris.ly/pn-series), the new TypeScript-first foundation for Prisma ORM, and we've now benchmarked it: about 87% of the raw `pg` driver's peak throughput and 52% more requests per second than Prisma 7. [See the latest results](/prisma-next-performance-benchmark).
+::::
+
 Prisma 7 shipped on **November 19th**. Since then, we have heard *a lot* from the community. Many of you love the new setup and the move away from Rust, while others have raised concerns about performance. This post is meant to be a transparent overview of what is happening and how we’re going to address it.
 
 ## Is Prisma 7 slow?

--- a/apps/blog/content/blog/prisma-orm-v7-4-query-caching-partial-indexes-and-major-performance-improvements/index.mdx
+++ b/apps/blog/content/blog/prisma-orm-v7-4-query-caching-partial-indexes-and-major-performance-improvements/index.mdx
@@ -12,6 +12,10 @@ tags:
   - "orm"
 ---
 
+::::note[New: the Prisma Next performance benchmark]
+For the newest numbers on where Prisma performance is heading, we've benchmarked [Prisma Next](https://pris.ly/pn-series), the new TypeScript-first foundation for Prisma ORM: about 87% of the raw `pg` driver's peak throughput and 52% more requests per second than Prisma 7. [See the latest results](/prisma-next-performance-benchmark).
+::::
+
 We’re excited to share the release of Prisma ORM v7.4! This release comes with new features like partial indexes, a fix for BigInt precision, and a new query caching layer to address performance issues. Let’s dive in.
 
 ## Partial indexes preview feature

--- a/apps/blog/content/blog/prisma-orm-without-rust-latest-performance-benchmarks/index.mdx
+++ b/apps/blog/content/blog/prisma-orm-without-rust-latest-performance-benchmarks/index.mdx
@@ -16,6 +16,10 @@ tags:
   - "education"
 ---
 
+::::note[New: the Prisma Next performance benchmark]
+The move away from Rust continues with [Prisma Next](https://pris.ly/pn-series), the new TypeScript-first foundation for Prisma ORM. In our newest benchmark it reaches about 87% of the raw `pg` driver's peak throughput and sustains 52% more requests per second than Prisma 7. [See the latest results](/prisma-next-performance-benchmark).
+::::
+
 Our move from Rust to TypeScript in the Prisma ORM internals is now in Preview for all first-class databases! In this article, we’re sharing the performance improvements we observed in our latest benchmarks and give an outlook for Prisma v7 where the ORM will become “Rust-free” by default.
 
 ### TL;DR: The Rust-Free ORM is ready for production-use

--- a/apps/blog/content/blog/rust-to-typescript-update-boosting-prisma-orm-performance/index.mdx
+++ b/apps/blog/content/blog/rust-to-typescript-update-boosting-prisma-orm-performance/index.mdx
@@ -13,6 +13,10 @@ series: rust-to-typescript-migration-journey
 seriesIndex: 2
 ---
 
+::::note[New: the Prisma Next performance benchmark]
+The move away from Rust continues with [Prisma Next](https://pris.ly/pn-series), the new TypeScript-first foundation for Prisma ORM. In our newest benchmark it reaches about 87% of the raw `pg` driver's peak throughput and sustains 52% more requests per second than Prisma 7. [See the latest results](/prisma-next-performance-benchmark).
+::::
+
 The Query Compiler project upgrades Prisma ORM by swapping out the traditional Rust engine for a leaner solution built on a WASM module and TypeScript. This change boosts query performance and cuts the bundle size by 85–90%, while also improving compatibility with a variety of web frameworks and bundlers. As Prisma ORM heads toward version 7, developers can expect a smoother, more efficient experience.
 
 ### TL;DR: The Rust-Free ORM is ready for production-use

--- a/apps/blog/content/blog/why-prisma-orm-checks-types-faster-than-drizzle/index.mdx
+++ b/apps/blog/content/blog/why-prisma-orm-checks-types-faster-than-drizzle/index.mdx
@@ -15,6 +15,10 @@ tags:
   - "orm"
 ---
 
+::::note[New: the Prisma Next performance benchmark]
+This post is about type-checking performance. On the runtime side, we've now benchmarked [Prisma Next](https://pris.ly/pn-series), the new TypeScript-first foundation for Prisma ORM: it reaches about 87% of the raw `pg` driver's peak throughput and sustains 52% more requests per second than Prisma 7. [See the latest results](/prisma-next-performance-benchmark).
+::::
+
 Type performance is just as important as runtime speed for developer experience. Slow types mean laggy editors, broken autocomplete, and long CI runs. This post benchmarks Prisma ORM and Drizzle ORM to show how their different approaches affect TypeScript compiler performance.
 
 ## What is type performance & why it matters


### PR DESCRIPTION
## What

Adds a `::::note` callout at the top of the eight older performance-related blog posts, pointing readers to the new [Prisma Next performance benchmark](https://www.prisma.io/blog/prisma-next-performance-benchmark) post.

## Posts updated

- why-prisma-orm-checks-types-faster-than-drizzle (copy notes it covers type-checking, links runtime results)
- performance-benchmarks-comparing-query-latency-across-typescript-orms-and-databases
- prisma-7-performance-benchmarks (framed as the follow-up to that post's performance work)
- prisma-orm-without-rust-latest-performance-benchmarks
- rust-to-typescript-update-boosting-prisma-orm-performance
- prisma-orm-v7-4-query-caching-partial-indexes-and-major-performance-improvements
- prisma-6-better-performance-more-flexibility-and-type-safe-sql
- performance-engineering-aeduv0rei0jk

Each callout is one sentence with the headline numbers (about 87% of the raw `pg` driver's peak throughput, 52% more req/s than Prisma 7) and links to `/prisma-next-performance-benchmark` plus the pris.ly/pn-series overview. Copy follows the Early Access framing (no "not production ready" language).

Verified rendering with the blog dev server.

Related: prisma/benchmarks-site#24 adds a Prisma Next tab with animated results to benchmarks.prisma.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new benchmark update note to several blog posts, pointing readers to the latest performance results.
  * Included updated performance highlights and comparison figures in the relevant articles.
  * Added links to a dedicated page with the newest benchmark details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->