### PR TITLE
blog: cross-link Prisma Next posts to the /orm/next docs

### DIFF
--- a/apps/blog/content/blog/data-migrations-in-prisma-next/index.mdx
+++ b/apps/blog/content/blog/data-migrations-in-prisma-next/index.mdx
@@ -17,11 +17,11 @@ series: prisma-next
 seriesIndex: 5
 ---
 
-Sooner or later, you need a migration to change data as well as schema. In Prisma Next, that happens inside your migration in TypeScript, with the same query builder you use in your app.
+Sooner or later, you need a migration to change data as well as schema. In Prisma Next, that happens inside your migration in TypeScript, with the same [query builder](https://www.prisma.io/docs/orm/next/fundamentals/writing-data) you use in your app.
 
-In the [previous post](https://pris.ly/ts-migrations-pn) we covered how migrations change the database schema: a TypeScript migration file with a list of operations, compiled to JSON, applied by the migration runner. Start there if any of those terms are unfamiliar.
+In the [previous post](https://pris.ly/ts-migrations-pn) we covered [how migrations change the database schema](https://www.prisma.io/docs/orm/next/migrations/how-migrations-work): a TypeScript migration file with a list of operations, compiled to JSON, applied by the [migration runner](https://www.prisma.io/docs/orm/next/migrations/applying-a-migration). Start there if any of those terms are unfamiliar.
 
-Take a common example. You've added a `displayName` column to `User` in `contract.prisma` and you want to make it `NOT NULL`. There's a snag: there are already rows in the table, and they don't have a `displayName` yet, so setting the column `NOT NULL` fails, every existing row violates the constraint.
+Take a common example. You've added a `displayName` column to `User` in [`contract.prisma`](https://www.prisma.io/docs/orm/next/contract-authoring/the-data-contract) and you want to make it `NOT NULL`. There's a snag: there are already rows in the table, and they don't have a `displayName` yet, so setting the column `NOT NULL` fails, every existing row violates the constraint.
 
 A simple approach to solve this problem is to:
 
@@ -76,7 +76,7 @@ People have asked for the obvious fix, being able to use the Prisma client _insi
 
 ## In Prisma Next, you write the data step in TypeScript
 
-Here is the same example, written as a Prisma Next migration. The initial file is written for you by `migration plan` when you change your `contract.prisma`. The `dataTransform()` line you'd add by hand:
+Here is the same example, written as a Prisma Next migration. The initial file is written for you by [`migration plan`](https://www.prisma.io/docs/orm/next/migrations/generating-a-migration) when you change your `contract.prisma`. The `dataTransform()` line you'd add by hand:
 
 ```typescript
 // migrations/20260422T0748_add_user_display_name/migration.ts
@@ -184,7 +184,7 @@ This is what lets a data transformation reference columns the same migration is 
 
 ## MongoDB gets data transformations too
 
-Here's a `dataTransform` against a Mongo collection, backfilling a `status` field on a `products` collection so it can be made required:
+Here's a `dataTransform` against a [Mongo collection](https://www.prisma.io/docs/orm/next/data-modeling/mongodb), backfilling a `status` field on a `products` collection so it can be made required:
 
 ```typescript
 import { dataTransform } from "@prisma-next/target-mongo/migration";

--- a/apps/blog/content/blog/mongodb-without-compromise/index.mdx
+++ b/apps/blog/content/blog/mongodb-without-compromise/index.mdx
@@ -14,7 +14,7 @@ tags:
   - "announcement"
 ---
 
-For the first time, Prisma Next brings the MongoDB-native experience to TypeScript. Type-safe queries, database migrations, polymorphic models, embedded collections and more. Designed in collaboration with the MongoDB DX team.
+For the first time, [Prisma Next](https://www.prisma.io/docs/orm/next) brings the MongoDB-native experience to TypeScript. Type-safe queries, database migrations, polymorphic models, embedded collections and more. Designed in collaboration with the MongoDB DX team.
 
 ## What MongoDB development looks like today
 
@@ -25,7 +25,7 @@ If you've built a MongoDB app with TypeScript recently, you've probably gone thr
 - You write a query and the types don't fully connect, so you cast, add guards, or accept a little `any`.
 - You need an index, so you drop into the MongoDB shell or a deployment script and hope your database stays in sync with your code.
 
-In Prisma Next, you describe your data model as a contract:
+In Prisma Next, you describe your [data model](https://www.prisma.io/docs/orm/next/data-modeling/mongodb) as a contract:
 
 ```prisma
 model User {
@@ -97,13 +97,13 @@ const recentPosts = await orm.posts
 // recentPosts[0].author.bio -> string | null
 ```
 
-The `.include('author')` compiles to a `$lookup` pipeline stage. Skip the `.include()` and the author isn't loaded and isn't in the type. Your documents are typed all the way down, no matter how far you nest.
+The [`.include('author')`](https://www.prisma.io/docs/orm/next/fundamentals/relations-and-joins) compiles to a `$lookup` pipeline stage. Skip the `.include()` and the author isn't loaded and isn't in the type. Your documents are typed all the way down, no matter how far you nest.
 
 ## Real migrations for MongoDB
 
 MongoDB is not schema-less. Your deployment has real, persistent, server-side state, and that state directly affects correctness and performance. Yet most tools do not manage it properly.
 
-The `@@index` declarations in the contract above are not just documentation. They are managed by a migration system that versions, diffs, and deploys your database state.
+The `@@index` declarations in the contract above are not just documentation. They are managed by a [migration system](https://www.prisma.io/docs/orm/next/migrations/how-migrations-work) that versions, diffs, and deploys your database state.
 
 - **Indexes:** unique, compound, TTL, partial, geospatial, text, and wildcard. If an index is wrong, queries slow down. If a unique constraint is missing, duplicate data can slip in.
 - **JSON Schema validators:** document-level validation rules generated from your model definitions. Even writes that bypass the ORM are still validated by the server.
@@ -165,7 +165,7 @@ Polymorphism connects to migrations too. An index on a variant-specific field, `
 
 ## Typed aggregation pipelines
 
-When you need MongoDB's aggregation pipeline for grouping, projecting, or faceting, Prisma Next provides a typed pipeline builder:
+When you need MongoDB's aggregation pipeline for grouping, projecting, or faceting, Prisma Next provides a [typed pipeline builder](https://www.prisma.io/docs/orm/next/fundamentals/advanced-queries):
 
 ```typescript
 const { pipeline, runtime } = orm;
@@ -198,7 +198,7 @@ Field references like `f.authorId` and `f.createdAt` check against your contract
 }))
 ```
 
-When the pipeline builder doesn't cover what you need, you can drop to raw MongoDB commands:
+When the pipeline builder doesn't cover what you need, you can drop to [raw MongoDB commands](https://www.prisma.io/docs/orm/next/reference/raw-queries):
 
 ```typescript
 const raw = orm.raw.collection('posts');

--- a/apps/blog/content/blog/prisma-next-call-for-extension-authors/index.mdx
+++ b/apps/blog/content/blog/prisma-next-call-for-extension-authors/index.mdx
@@ -20,13 +20,13 @@ seriesIndex: 6
 
 If you've ever wanted to integrate your tool, your database, or your library with Prisma, or you tried in Prisma 6 or 7 and gave up, this post is for you. Read the [Prisma Next Early Access announcement](https://www.prisma.io/blog/prisma-next-early-access-write-your-contract-prompt-your-agent-ship-your-app) for the full launch story.
 
-Prisma Next has a deliberately tiny core that knows nothing about any specific database. Postgres support is an extension. Vector search is an extension. JSON-with-schema is an extension. Whatever Prisma Next can do, it does because someone wrote it using the same components that are available to you.
+[Prisma Next](https://www.prisma.io/docs/orm/next) has a deliberately tiny core that knows nothing about any specific database. Postgres support is an extension. Vector search is an extension. JSON-with-schema is an extension. Whatever Prisma Next can do, it does because someone wrote it using the same components that are available to you.
 
 The API surface is real, the same shape we used to build Postgres support ourselves, and ready to build against today.
 
 ## Postgres is an extension
 
-The Prisma Next framework knows about contracts, plans, query lifecycle, and the policies that gate execution. It does _not_ know what Postgres, SQL, Mongo, vectors, or any column type other than `unknown` are.
+The Prisma Next framework knows about [contracts](https://www.prisma.io/docs/orm/next/contract-authoring/the-data-contract), plans, query lifecycle, and the policies that gate execution. It does _not_ know what Postgres, SQL, Mongo, vectors, or any column type other than `unknown` are.
 
 Every database we support and every native feature you've used in Prisma Next was added by an extension package on a public service provider interface (SPI). The Postgres target, the SQL family (its contract shape, operations, and lanes), the Postgres adapter and driver, the pgvector vector type and its similarity operators, and the arktype-JSON codec are all extensions.
 
@@ -34,14 +34,14 @@ There is no "core API" and "plugin API." There is one SPI, used by the team buil
 
 ## What an extension can ship
 
-An extension is a normal npm package: `@yourname/prisma-next-extension-foo`. Your users `pnpm add` it, add one line to `prisma-next.config.ts`, and your additions show up in their contract, their queries, and (if you ship migrations) their migration plans.
+An extension is a normal npm package: `@yourname/prisma-next-extension-foo`. Your users `pnpm add` it, [add one line to `prisma-next.config.ts`](https://www.prisma.io/docs/orm/next/extensions/using-extensions), and your additions show up in their contract, their queries, and (if you ship migrations) their migration plans.
 
 An extension can include any subset of four layers, in any combination:
 
 - **Contract layer**: column types, field builders, index types, and authoring constructs that show up in `contract.ts` and `contract.json` with your namespace and your validation rules. This is how pgvector adds dimensioned vector columns and how ParadeDB adds typed BM25 indexes
 - **Query layer**: typed methods on the query builder. Users discover them through autocomplete; they compile to SQL via lowerers you provide. This is how pgvector adds `cosineDistance` on vector columns
-- **Runtime layer**: codecs that translate between the database wire format and your TypeScript types. Codecs can be synchronous (pgvector vectors decode to `number[]`) or asynchronous (encryption codecs decrypt on read with key material from an external service). Runtime middleware is also part of this slice, covering observability, audit, and policy interception around every query
-- **Migration layer**: custom DDL and data operations with pre/post checks and idempotency declarations, integrated into the migration planner. ParadeDB's planned BM25 index ops land here, and so does anything else that needs to participate in the migration graph rather than ship as a one-off script
+- **Runtime layer**: codecs that translate between the database wire format and your TypeScript types. Codecs can be synchronous (pgvector vectors decode to `number[]`) or asynchronous (encryption codecs decrypt on read with key material from an external service). [Runtime middleware](https://www.prisma.io/docs/orm/next/middleware/how-middleware-works) is also part of this slice, covering observability, audit, and policy interception around every query
+- **Migration layer**: custom DDL and data operations with pre/post checks and idempotency declarations, integrated into the migration planner. ParadeDB's planned BM25 index ops land here, and so does anything else that needs to participate in [the migration graph](https://www.prisma.io/docs/orm/next/migrations/the-migration-graph) rather than ship as a one-off script
 
 Pick the layers you need. A useful extension can be one layer (a single codec, a single index type) or all four for a full vertical slice.
 

--- a/apps/blog/content/blog/prisma-next-early-access-write-your-contract-prompt-your-agent-ship-your-app/index.mdx
+++ b/apps/blog/content/blog/prisma-next-early-access-write-your-contract-prompt-your-agent-ship-your-app/index.mdx
@@ -39,7 +39,7 @@ Today, **Prisma Next is open for Early Access for Postgres and [MongoDB](https:/
 
 If you've ever picked up a new framework, you know how long it takes to climb a steep learning curve. You read the docs, build a toy project and make mistakes the docs warned you about. It takes weeks to absorb the framework's idioms until you're confident enough to actually build.
 
-One command scaffolds a new project with Prisma Next, including a family of skills which make your agent an instant expert.
+One command scaffolds a new project with Prisma Next, including a [family of skills](https://www.prisma.io/docs/ai/tools/skills) which make your agent an instant expert.
 
 ```bash
 npm create prisma@next
@@ -61,7 +61,7 @@ model Book {
 }
 ```
 
-This is the contract between your application and your database. The models are what your application depends on, and your database promises to store them in the shapes described in the contract.
+This is [the contract](https://www.prisma.io/docs/orm/next/contract-authoring/the-data-contract) between your application and your database. The models are what your application depends on, and your database promises to store them in the shapes described in the contract.
 
 It's easy to read, easy to update, and it's the single source of truth for everything in Prisma Next. Queries are type-checked against it, autocomplete reads from it, and when you change it, Prisma Next plans the migrations to match, so your database continues to satisfy the contract.
 
@@ -84,7 +84,7 @@ Considering the book table in the contract above, you can ask the agent for a fe
   after={contractAfterAuthor}
 />
 
-Then, when you ask the agent to write a query, it iterates inside its own tool calls until the query type-checks, or until it resolves any errors. Here's what that looks like in practice:
+Then, when you ask the agent to [write a query](https://www.prisma.io/docs/orm/next/fundamentals/reading-data), it iterates inside its own tool calls until the query type-checks, or until it resolves any errors. Here's what that looks like in practice:
 
 <AgentPrompt
   prompt="query all the books from the last week and also include the author"
@@ -99,7 +99,7 @@ You can be confident that if the agent's query typechecks, it matches the contra
 
 ## Never write a migration again
 
-If you've ever deployed an app, you've worked with migrations. Migrations are _one of the most painful parts_ of working with a database.
+If you've ever deployed an app, you've worked with [migrations](https://www.prisma.io/docs/orm/next/migrations/how-migrations-work). Migrations are _one of the most painful parts_ of working with a database.
 
 You spend time getting the syntax right. Then you spend more time debugging when things go sideways. And _when_ - not if - a migration breaks during deployment, you spend even more time fixing it while your production app is down.
 
@@ -194,7 +194,7 @@ If you find a bug, or something you feel is missing, ask your agent to tell us a
 
 Prisma Next brings **Prisma's world-class DX to your agent**, so you can focus on building your app. Stay hands-on, let your agent take over, or switch mid-flow. With Prisma Next, you can delegate with confidence.
 
-To try it today in a fresh project, run:
+To [try it today](https://www.prisma.io/docs/next/quickstart/postgresql) in a fresh project, run:
 
 ```bash
 npm create prisma@next

--- a/apps/blog/content/blog/prisma-next-performance-benchmark/index.mdx
+++ b/apps/blog/content/blog/prisma-next-performance-benchmark/index.mdx
@@ -18,7 +18,7 @@ seriesIndex: 9
 
 Every ORM does work on every query: it turns your query into SQL, sends it, and turns the rows that come back into objects. That work has a cost, and in Prisma 7 it sits deep in the architecture, so reducing it meant rebuilding the layers underneath.
 
-That rebuild is [Prisma Next](https://pris.ly/pn-series), the new foundation for Prisma ORM. It's written in TypeScript end to end and runs on a much lighter core, while keeping the same model-first, type-safe workflow you already use.
+That rebuild is [Prisma Next](https://pris.ly/pn-series), the new foundation for Prisma ORM. It's written in TypeScript end to end and runs on a much lighter core, while keeping the same [model-first, type-safe workflow](https://www.prisma.io/docs/orm/next) you already use.
 
 To see where it stands, we ran the same Postgres workload through three setups: Prisma 7, Prisma Next, and the raw `pg` driver. We pushed traffic up until each one reached its limit.
 
@@ -97,7 +97,7 @@ We've shared [our benchmark repo](https://pris.ly/pn-benchmarks), so you can run
 
 ## Try Prisma Next today
 
-There are two ways to get started. To spin up a complete template app, scaffold one with:
+There are two ways to [get started](https://www.prisma.io/docs/next/quickstart/postgresql). To spin up a complete template app, scaffold one with:
 
 ```shell
 bunx create-prisma@next

--- a/apps/blog/content/blog/prisma-next-roadmap-april-milestone/index.mdx
+++ b/apps/blog/content/blog/prisma-next-roadmap-april-milestone/index.mdx
@@ -21,7 +21,7 @@ In March we published the [Prisma Next roadmap](https://pris.ly/AgH6EUa). April 
 
 Four extensions now ship on it: [`pgvector`](https://github.com/prisma/prisma-next/pull/391), [`arktype-json`](https://github.com/prisma/prisma-next/pull/402), [ParadeDB](https://github.com/prisma/prisma-next/pull/374), and [CipherStash](https://github.com/prisma/prisma-next/pull/411). One planned piece did not land: streaming subscriptions in the runtime. May shifts to Early Access for users.
 
-If you want to build a Prisma Next extension, the [call for extension authors](https://pris.ly/pn-extension-authors) is the front door. The API will keep evolving, but it's stable enough to build something real against — and we want to hear what's missing.
+If you want to [build a Prisma Next extension](https://www.prisma.io/docs/orm/next/extensions/using-extensions), the [call for extension authors](https://pris.ly/pn-extension-authors) is the front door. The API will keep evolving, but it's stable enough to build something real against — and we want to hear what's missing.
 
 ## What you can build with the extension API
 
@@ -46,19 +46,19 @@ Data migrations are partly there. You can run a data transformation — say, spl
 
 ### Contract authoring
 
-You can define your data contract in `contract.prisma` or in TypeScript. Both surfaces produce the same compiled contract, regardless of which you choose. Next up: the everyday helpers, IDE autocomplete, and the patterns a first-time user expects to work without thinking.
+You can define your [data contract](https://www.prisma.io/docs/orm/next/contract-authoring/the-data-contract) in `contract.prisma` or in TypeScript. Both surfaces produce the same compiled contract, regardless of which you choose. Next up: the everyday helpers, IDE autocomplete, and the patterns a first-time user expects to work without thinking.
 
 ### Transactions and React Server Components
 
-Transactions work on Postgres. The ORM can open a transaction, and the SQL query builder can run inside it, sharing one database connection — so the SQL escape hatch actually works mid-transaction.
+[Transactions](https://www.prisma.io/docs/orm/next/fundamentals/transactions) work on Postgres. The ORM can open a transaction, and the [SQL query builder](https://www.prisma.io/docs/orm/next/reference/sql-query-builder) can run inside it, sharing one database connection — so the SQL escape hatch actually works mid-transaction.
 
 The runtime runs safely under React Server Components: parallel Server Components, shared runtime state, connection pooling, and query-result caching all behave correctly under concurrency.
 
-Middleware hooks are in place — a middleware function can see a query, return a cached result, or rewrite the response.
+[Middleware](https://www.prisma.io/docs/orm/next/middleware/how-middleware-works) hooks are in place — a middleware function can see a query, return a cached result, or rewrite the response.
 
 ### MongoDB
 
-MongoDB is a first-class database family in Prisma Next. You get type-safe queries, real database migrations (indexes, JSON Schema validators, collection options), polymorphic collections with discriminated unions, embedded documents, and a typed aggregation pipeline builder. [MongoDB Without Compromise](https://www.prisma.io/blog/mongodb-without-compromise) covers the full story.
+[MongoDB](https://www.prisma.io/docs/orm/next/data-modeling/mongodb) is a first-class database family in Prisma Next. You get type-safe queries, real database migrations (indexes, JSON Schema validators, collection options), polymorphic collections with discriminated unions, embedded documents, and a typed aggregation pipeline builder. [MongoDB Without Compromise](https://www.prisma.io/blog/mongodb-without-compromise) covers the full story.
 
 ### SQLite
 

--- a/apps/blog/content/blog/prisma-next-roadmap/index.mdx
+++ b/apps/blog/content/blog/prisma-next-roadmap/index.mdx
@@ -19,10 +19,10 @@ On March 4th we [introduced Prisma Next](https://www.prisma.io/blog/the-next-evo
 
 - a brand new query API with custom collection methods for your models
 - streaming query results
-- a low-level, type-safe SQL query builder (an escape hatch for complex or custom SQL queries)
-- extensions that let you install new behaviors and data types (including the first extension example: `pgvector`)
-- support for TypeScript Prisma schemas as an alternative to the traditional `schema.prisma`, so you can pick which you prefer
-- middleware, validations, query linting, and lots more
+- a low-level, type-safe [SQL query builder](https://www.prisma.io/docs/orm/next/reference/sql-query-builder) (an escape hatch for complex or custom SQL queries)
+- [extensions](https://www.prisma.io/docs/orm/next/extensions/using-extensions) that let you install new behaviors and data types (including the first extension example: `pgvector`)
+- support for [TypeScript Prisma schemas](https://www.prisma.io/docs/orm/next/contract-authoring/typescript-schema-builder) as an alternative to the traditional `schema.prisma`, so you can pick which you prefer
+- [middleware](https://www.prisma.io/docs/orm/next/middleware/how-middleware-works), validations, query linting, and lots more
 
 There's a lot still to do, so to make sure we can get Prisma Next into developers' hands as soon as possible, we're delivering the remaining work in phases.
 

--- a/apps/blog/content/blog/rethinking-database-migrations/index.mdx
+++ b/apps/blog/content/blog/rethinking-database-migrations/index.mdx
@@ -16,7 +16,7 @@ series: prisma-next
 seriesIndex: 3
 ---
 
-Database migrations are brittle and they break when you're most vulnerable; when you're deploying to production. Prisma Next migrations make them explicit, verifiable and safe to retry. Here's how.
+Database migrations are brittle and they break when you're most vulnerable; when you're deploying to production. [Prisma Next migrations](https://www.prisma.io/docs/orm/next) make them explicit, verifiable and safe to retry. Here's how.
 
 ## The problem with migrations today
 
@@ -54,7 +54,7 @@ With Prisma Next, we set out to build a migration system that handles all of the
 
 ## Prisma Next migrations
 
-In Prisma Next, a migration is explicit about what it needs to do and how it does it. Every migration knows:
+In Prisma Next, [a migration](https://www.prisma.io/docs/orm/next/migrations/how-migrations-work) is explicit about what it needs to do and how it does it. Every migration knows:
 
 - The expected DB schema **before** it's executed.
 - The DB schema **after** it's executed.
@@ -87,7 +87,7 @@ migrations/
 
 #### How `from` and `to` work
 
-In Prisma Next, your `schema.prisma` is converted into a JSON file which lists every table, column and relation that's expected to be present in your database, similar to a `package-lock.json`. Hashing that file gives us a simple identifier that describes a specific database state, like a git commit hash.
+In Prisma Next, your [`schema.prisma`](https://www.prisma.io/docs/orm/next/contract-authoring/the-data-contract) is converted into a [JSON file](https://www.prisma.io/docs/orm/next/contract-authoring/the-contract-artifact) which lists every table, column and relation that's expected to be present in your database, similar to a `package-lock.json`. Hashing that file gives us a simple identifier that describes a specific database state, like a git commit hash.
 
 Migrations promise to transition your database from one schema to another, which is recorded as a `from` hash and a `to` hash in the JSON example above. This works the same way as applying a git commit to your filesystem: it moves your filesystem from one state to the next.
 
@@ -123,7 +123,7 @@ Each operation has three parts:
 
 ## Migrations are a graph
 
-Because each migration records the schema it starts from and the schema it produces, migrations don't need to be ordered alphabetically. They form a graph of state transitions linked by their `from` and `to` hashes, and the system can figure out which path to follow.
+Because each migration records the schema it starts from and the schema it produces, migrations don't need to be ordered alphabetically. They form a [graph of state transitions](https://www.prisma.io/docs/orm/next/migrations/the-migration-graph) linked by their `from` and `to` hashes, and the system can figure out which path to follow.
 
 Here's what that looks like in practice. Two developers have branched from the same schema and each added a migration:
 
@@ -145,7 +145,7 @@ This idea isn't entirely new, tools like [Sqitch](https://sqitch.org/) and [Atla
 
 Remember the local-drift scenario? You iterate on a migration locally, your DB ends up in a slightly different state, and the migration fails in CI. With Prisma Next, the runner checks the database's current schema hash against the migration's `from` hash before doing anything. If they don't match, the migration stops immediately with a clear error. Not halfway through, leaving the database in an unknown state.
 
-What if a migration *does* fail partway through? Because every operation carries a precheck and a postcheck, the migration is safe to retry. Operations whose postchecks already pass are skipped; operations whose prechecks fail produce a clear error. The database never ends up in a state the system can't reason about.
+What if a migration *does* fail partway through? Because every operation carries a precheck and a postcheck, the migration is [safe to retry](https://www.prisma.io/docs/orm/next/migrations/rollbacks-and-recovery). Operations whose postchecks already pass are skipped; operations whose prechecks fail produce a clear error. The database never ends up in a state the system can't reason about.
 
 ## Resolving conflicts between branches
 

--- a/apps/blog/content/blog/the-next-evolution-of-prisma-orm/index.mdx
+++ b/apps/blog/content/blog/the-next-evolution-of-prisma-orm/index.mdx
@@ -32,7 +32,7 @@ If you’ve been using Prisma, you will have felt the pain. Fixes take longer th
 
 Prisma Next is a rewrite, which allows us to address what’s holding us back in the existing codebase, by rebuilding it end-to-end to be **extensible** and **composable** by default.
 
-And we’re keeping what developers love about Prisma: the **declarative schema** and the **model-first query experience**.
+And we’re keeping what developers love about Prisma: the **[declarative schema](https://www.prisma.io/docs/orm/next/data-modeling)** and the **model-first query experience**.
 
 And we’re doing it for the world we’re in now: AI agents are increasingly part of how teams ship software, so Prisma Next is designed to make **agent-assisted workflows** safer and more predictable.
 
@@ -110,13 +110,13 @@ const orders = await db.orders
   .all();
 ```
 
-In Prisma Next, queries remain easy to read, your editor continues to provide autocompletion, and even as queries grow more complex, they stay manageable.
+In Prisma Next, [queries](https://www.prisma.io/docs/orm/next/fundamentals/reading-data) remain easy to read, your editor continues to provide autocompletion, and even as queries grow more complex, they stay manageable.
 
 If you’d like a deeper side-by-side comparison of Prisma ORM and Prisma Next, take a look at [the API comparison doc](https://github.com/prisma/prisma-next/blob/27ae1d164ae7060626aabaefce1af8428031e5ef/specs/2026-02-16-repository-model-client/prisma-orm-comparison.md?plain=1).
 
 ## We’re adding a SQL query builder
 
-But an ORM can’t fit every use case. When you need something custom, or you need to tune performance, drop down to the **type-safe SQL query builder** and write it directly:
+But an ORM can’t fit every use case. When you need something custom, or you need to tune performance, drop down to the **[type-safe SQL query builder](https://www.prisma.io/docs/orm/next/fundamentals/advanced-queries)** and write it directly:
 
 ```ts title="sql-builder.ts"
 db.sql
@@ -140,7 +140,7 @@ Your query **builder stays in sync with your Prisma schema**, ensuring full type
 
 ## Write `schema.prisma` or TypeScript
 
-The other thing Prisma is known for is its clean, declarative schema language. In Prisma Next we add support for a TypeScript alternative, so you can keep your schema in the same language as your application.
+The other thing Prisma is known for is its clean, declarative schema language. In Prisma Next we add support for a [TypeScript alternative](https://www.prisma.io/docs/orm/next/contract-authoring/typescript-schema-builder), so you can keep your schema in the same language as your application.
 
 Both versions are read by your application the same way, determining the shape of queries you can write on your models, their fields and their relationships:
 
@@ -199,7 +199,7 @@ export default defineConfig({
 });
 ```
 
-When you install an extension like `pgvector` above, your schema and your queries gain new capabilities:
+When you install an [extension](https://www.prisma.io/docs/orm/next/extensions/using-extensions) like `pgvector` above, your schema and your queries gain new capabilities:
 
 ```prisma tab="Usage in Schema"
 // Use @pgvector columns in your Prisma schema
@@ -336,7 +336,7 @@ But fast feedback is only half the story - you also need enforcement.
 
 ## Middleware
 
-Middleware runs in your application and sees every query before it hits the database. It lets you inspect, block, or rewrite queries before execution.
+[Middleware](https://www.prisma.io/docs/orm/next/middleware/how-middleware-works) runs in your application and sees every query before it hits the database. It lets you inspect, block, or rewrite queries before execution.
 
 This is where you add real guardrails, for agents and humans alike.
 
@@ -381,7 +381,7 @@ The result is simple: the query you write, the schema you define, and the databa
 
 One of Prisma's core promises has always been simple: update your Prisma schema, and your database follows.
 
-Prisma Next makes migrations safer and more transparent. Instead of a linear list of files, migrations form a **graph** like Git branches, but for your database schema.
+Prisma Next makes migrations safer and more transparent. Instead of a linear list of files, migrations form a **[graph](https://www.prisma.io/docs/orm/next/migrations/the-migration-graph)** like Git branches, but for your database schema.
 
 With Prisma next you will be able to see exactly where your database is and where it's going:
 

--- a/apps/blog/content/blog/typescript-migrations-in-prisma-next/index.mdx
+++ b/apps/blog/content/blog/typescript-migrations-in-prisma-next/index.mdx
@@ -17,7 +17,7 @@ series: prisma-next
 seriesIndex: 4
 ---
 
-Migrations shouldn't be the scariest part of your deploy. In Prisma Next, migrations are TypeScript files you can read, edit, and re-run with confidence. Every step is verified before it runs and again after. Every failure points directly at the operation that caused it.
+Migrations shouldn't be the scariest part of your deploy. In Prisma Next, [migrations](https://www.prisma.io/docs/orm/next/migrations/how-migrations-work) are TypeScript files you can read, edit, and re-run with confidence. Every step is verified before it runs and again after. Every failure points directly at the operation that caused it.
 
 ## This is a SQL migration
 
@@ -175,7 +175,7 @@ You edit the TypeScript. The system runs the JSON. Both get committed, much like
 
 ## The workflow
 
-Most migrations don't get written from scratch. They get planned from changes to your Prisma contract (the `.prisma` file that describes your database schema). Say you add a `displayName String` field to your `User` model. Then:
+Most migrations don't get written from scratch. They get [planned](https://www.prisma.io/docs/orm/next/migrations/generating-a-migration) from changes to your [Prisma contract](https://www.prisma.io/docs/orm/next/contract-authoring/the-data-contract) (the `.prisma` file that describes your database schema). Say you add a `displayName String` field to your `User` model. Then:
 
 ```text
 $ npx prisma-next migration plan
@@ -194,7 +194,7 @@ $ npx prisma-next migrate --verbose
 
 The planner reads your contract, compares it to the current database, and writes both `migration.ts` and `ops.json`. For most changes (adding a model, adding a field, creating an index), that's all you need.
 
-When you do need to edit a migration, for example to backfill data before a constraint, reorder operations, or drop in a custom check, you open `migration.ts`, edit it like any other TypeScript file, and re-run it to regenerate `ops.json`. Your editor handles autocomplete, type checking, and inline docs for every operation. There's no SQL syntax to remember and no second-guessing whether you got the constraint definition right.
+When you do need to [edit a migration](https://www.prisma.io/docs/orm/next/migrations/editing-a-migration), for example to backfill data before a constraint, reorder operations, or drop in a custom check, you open `migration.ts`, edit it like any other TypeScript file, and re-run it to regenerate `ops.json`. Your editor handles autocomplete, type checking, and inline docs for every operation. There's no SQL syntax to remember and no second-guessing whether you got the constraint definition right.
 
 Where it gets interesting is when something goes wrong. The runner doesn't just bail with a database error. It names the operation that failed and the check inside it that the database refused to satisfy:
 
@@ -207,14 +207,14 @@ $ npx prisma-next migrate
 
 You know which operation failed (`alterNullability.setNotNull.user.displayName`) and which check failed inside it (`ensure no NULL values in "displayName"`). Both come straight from `ops.json`, and both tell you exactly where to look. From here, you fix it. You might backfill the nulls, drop and re-add the column with a default, or edit the migration to add a backfill step before the `setNotNull`. Then you re-run.
 
-**Re-running is safe.** Before running each operation, the migration runner first evaluates that operation's postcheck. If the postcheck is already true, the runner skips the operation (which makes each operation idempotent). The migration then continues at the first step that hasn't succeeded yet. There's no commenting out lines, no manually unwinding state, and no guessing what's been applied. The single most uncomfortable problem with SQL migrations is solved.
+**[Re-running is safe](https://www.prisma.io/docs/orm/next/migrations/rollbacks-and-recovery).** Before running each operation, the migration runner first evaluates that operation's postcheck. If the postcheck is already true, the runner skips the operation (which makes each operation idempotent). The migration then continues at the first step that hasn't succeeded yet. There's no commenting out lines, no manually unwinding state, and no guessing what's been applied. The single most uncomfortable problem with SQL migrations is solved.
 
 **Your development workflow becomes:**
 
 1. Edit your `contract.prisma`
 2. Plan a migration: `migration plan`
 3. Edit the TypeScript and run `./migration.ts`
-4. Apply the migration: `prisma-next migrate`
+4. [Apply the migration](https://www.prisma.io/docs/orm/next/migrations/applying-a-migration): `prisma-next migrate`
 5. Read the output, iterate
 
 The contract describes the database schema you want. `migration.ts` lets you edit the migration easily. The JSON is what runs. The feedback is granular enough to act on.
@@ -278,7 +278,7 @@ If you find yourself writing the same `rawSql` over and over, lift it into a fun
 
 You would probably never trust an agent to write a migration. Review one, maybe. But write and execute something this dangerous? With an ordinary migration system (a linear sequence of `.sql` files held together with discipline and hope), neither would we.
 
-Prisma Next migrations were designed to support agent-assisted workflows. Every step is checked against its expected result, and the final database state is verified against your contract. Agents don't write SQL directly either. Instead, they assemble simple factory functions in TypeScript, which minimizes the chances for mistakes (or overenthusiastic expressions of creativity).
+Prisma Next migrations were designed to support [agent-assisted workflows](https://www.prisma.io/docs/ai/tools/skills). Every step is checked against its expected result, and the final database state is verified against your contract. Agents don't write SQL directly either. Instead, they assemble simple factory functions in TypeScript, which minimizes the chances for mistakes (or overenthusiastic expressions of creativity).
 
 You can let an agent write a migration in Prisma Next with confidence that the system will catch a lot of mistakes. When something does go wrong, the agent gets the same feedback you do (which operation failed, which check returned what), and it can iterate in a dev environment until it works.
 


### PR DESCRIPTION
## What

Adds contextual documentation cross-links to all ten Prisma Next blog posts. Where a post mentions a concept that now has a docs page (contracts, fundamentals, data modeling, migrations, the migration graph, middleware, extensions, references), the first natural mention is linked to that page.

## Why

The `/orm/next` docs shipped after most of these posts were written, so the posts had almost no links into the docs. Readers who land on a launch, benchmark, or migrations post now have a direct path to the reference material.

## How links were chosen

- One link per concept, on its **first substantive mention**, using existing prose as the anchor. No sentences were rewritten or added.
- Specific sub-pages matched to specific topics (e.g. migration-graph passages → the-migration-graph, backfill passages → editing-a-migration, rollback passages → rollbacks-and-recovery).
- No stuffing: benchmark/roadmap posts get 2-6 links; concept-heavy posts get 5-7.
- Pre-existing links (blog, product, GitHub milestones, the old Prisma Migrate doc link) were left untouched.

## Posts updated (link count)

| Post | Links |
| --- | --- |
| the-next-evolution-of-prisma-orm | 7 |
| prisma-next-early-access-… | 5 |
| typescript-migrations-in-prisma-next | 7 |
| data-migrations-in-prisma-next | 6 |
| rethinking-database-migrations | 6 |
| prisma-next-call-for-extension-authors | 5 |
| mongodb-without-compromise | 6 |
| prisma-next-performance-benchmark | 2 |
| prisma-next-roadmap | 4 |
| prisma-next-roadmap-april-milestone | 6 |

## Validation

- All 23 unique target URLs verified against live docs `url:` frontmatter on `main`.
- Diff is 50/50 line replacements: only inline link syntax added, no code fences, frontmatter, imports, or JSX touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several blog articles with clearer wording and more inline links to related docs, quickstarts, and guides.
  * Improved navigation between topics like migrations, MongoDB, extensions, middleware, query building, and TypeScript schemas.
  * Refreshed article introductions and section lead-ins for better readability and easier discovery of related resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->