### PR TITLE
docs(orm/next): use code-block tabs for code-only tab groups in contract authoring

### DIFF
--- a/apps/docs/content/docs/orm/next/contract-authoring/psl-syntax.mdx
+++ b/apps/docs/content/docs/orm/next/contract-authoring/psl-syntax.mdx
@@ -12,11 +12,7 @@ If you know the Prisma schema language, most of a contract file reads exactly as
 
 ## A complete contract
 
-<Tabs items={["PostgreSQL", "MongoDB"]}>
-
-<Tab value="PostgreSQL">
-
-```prisma title="prisma/contract.prisma"
+```prisma title="prisma/contract.prisma" tab="PostgreSQL"
 // use prisma-next
 
 types {
@@ -60,11 +56,7 @@ model Post {
 }
 ```
 
-</Tab>
-
-<Tab value="MongoDB">
-
-```prisma title="prisma/contract.prisma"
+```prisma title="prisma/contract.prisma" tab="MongoDB"
 // use prisma-next
 
 type Address {
@@ -107,21 +99,13 @@ model Post {
 }
 ```
 
-</Tab>
-
-</Tabs>
-
 Run `npx prisma-next contract emit` after any change to refresh the artifacts.
 
 ## Point the config at the schema
 
 The config's `contract` path names the source of truth. A `.prisma` extension selects PSL authoring:
 
-<Tabs items={["PostgreSQL", "MongoDB"]}>
-
-<Tab value="PostgreSQL">
-
-```typescript title="prisma-next.config.ts"
+```typescript title="prisma-next.config.ts" tab="PostgreSQL"
 import { defineConfig } from "@prisma-next/postgres/config";
 
 export default defineConfig({
@@ -129,21 +113,13 @@ export default defineConfig({
 });
 ```
 
-</Tab>
-
-<Tab value="MongoDB">
-
-```typescript title="prisma-next.config.ts"
+```typescript title="prisma-next.config.ts" tab="MongoDB"
 import { defineConfig } from "@prisma-next/mongo/config";
 
 export default defineConfig({
   contract: "./prisma/contract.prisma",
 });
 ```
-
-</Tab>
-
-</Tabs>
 
 Scaffolded projects (`npx create-prisma@next`) already contain this wiring and a starter schema.
 

--- a/apps/docs/content/docs/orm/next/contract-authoring/typescript-schema-builder.mdx
+++ b/apps/docs/content/docs/orm/next/contract-authoring/typescript-schema-builder.mdx
@@ -21,11 +21,7 @@ If neither applies, write PSL: it is more compact, and it is what `create-prisma
 
 The config's `contract` path names the source of truth. A `.ts` extension selects TypeScript authoring:
 
-<Tabs items={["PostgreSQL", "MongoDB"]}>
-
-<Tab value="PostgreSQL">
-
-```typescript title="prisma-next.config.ts"
+```typescript title="prisma-next.config.ts" tab="PostgreSQL"
 import { defineConfig } from "@prisma-next/postgres/config";
 
 export default defineConfig({
@@ -33,11 +29,7 @@ export default defineConfig({
 });
 ```
 
-</Tab>
-
-<Tab value="MongoDB">
-
-```typescript title="prisma-next.config.ts"
+```typescript title="prisma-next.config.ts" tab="MongoDB"
 import { defineConfig } from "@prisma-next/mongo/config";
 
 export default defineConfig({
@@ -45,19 +37,11 @@ export default defineConfig({
 });
 ```
 
-</Tab>
-
-</Tabs>
-
 ## A complete contract
 
 The builder comes from your database's target package: `@prisma-next/postgres/contract-builder` for PostgreSQL, `@prisma-next/mongo/contract-builder` for MongoDB.
 
-<Tabs items={["PostgreSQL", "MongoDB"]}>
-
-<Tab value="PostgreSQL">
-
-```typescript title="prisma/contract.ts"
+```typescript title="prisma/contract.ts" tab="PostgreSQL"
 import pgvector from "@prisma-next/extension-pgvector/pack";
 import { defineContract, enumType, member, rel } from "@prisma-next/postgres/contract-builder";
 
@@ -127,11 +111,7 @@ export const contract = defineContract(
 );
 ```
 
-</Tab>
-
-<Tab value="MongoDB">
-
-```typescript title="prisma/contract.ts"
+```typescript title="prisma/contract.ts" tab="MongoDB"
 import { defineContract, field, model, rel } from "@prisma-next/mongo/contract-builder";
 
 const User = model("User", {
@@ -167,10 +147,6 @@ export const contract = defineContract({
   },
 });
 ```
-
-</Tab>
-
-</Tabs>
 
 Run `npx prisma-next contract emit` after any change to refresh the artifacts.
 


### PR DESCRIPTION
## Problem

The two contract-authoring pages (`/orm/next/contract-authoring/typescript-schema-builder` and `/orm/next/contract-authoring/psl-syntax`) hand-wrote `<Tabs items>`/`<Tab>` (the general-purpose **content tabs** from `@prisma/eclipse`) around tab groups that contain **only code blocks**.

The site convention everywhere else (81 content files, including all of `/orm/next/fundamentals/*`) is the fence meta syntax:

~~~
```typescript title="..." tab="PostgreSQL"
```
~~~

which the `remarkCodeTab` plugin (configured in `apps/docs/source.config.ts`) converts into `CodeBlockTabs` — tabs integrated into the code block chrome. The hand-written version rendered as a floating tab strip with a separate panel border, visually inconsistent with the rest of the section.

## Change

- **typescript-schema-builder.mdx**: converted both `<Tabs>` blocks (config + complete contract) to consecutive fences with `tab=` meta.
- **psl-syntax.mdx**: converted the two code-only `<Tabs>` blocks (complete contract + config). The third block ("How IDs map differs by database") **stays** as content tabs — each tab contains prose after the code, which is exactly what content tabs are for.
- **seeding.mdx (v6)** was also audited: its tabs hold numbered steps with multiple code blocks and prose, so content tabs are correct there — no change.

## Verification

Rendered both pages on the local dev server:
- typescript-schema-builder: 2 tab groups now render with `CodeBlockTabs` markup, titles (`prisma-next.config.ts`, `prisma/contract.ts`) preserved in the code block header.
- psl-syntax: exactly 2 code-block tab groups + 1 content tab group.