### PR TITLE
feat(blog): move "About the author" card to the bottom of each post

### DIFF
--- a/apps/blog/src/app/(blog)/[slug]/page.tsx
+++ b/apps/blog/src/app/(blog)/[slug]/page.tsx
@@ -237,10 +237,6 @@ export default async function Page(props: { params: Promise<{ slug: string }> })
           {seriesContext ? <SeriesMarker series={seriesContext} /> : null}
         </header>
 
-        {/* About the author(s) — surfaced high in the document for E-E-A-T and
-            so LLMs/agents encounter author credentials early. */}
-        <AuthorBio authors={page.data.authors} />
-
         {/* Body */}
         <article className="w-full flex flex-col pb-8 mt-12">
           <div className="prose min-w-0 [&_figure]:w-full [&_figure]:md:max-w-140 [&_figure]:lg:max-w-200">
@@ -281,6 +277,11 @@ export default async function Page(props: { params: Promise<{ slug: string }> })
             />
           </div>
         </article>
+
+        {/* About the author(s) — placed at the end of the post so readers reach
+            the author credentials right after finishing the article. */}
+        <AuthorBio authors={page.data.authors} />
+
         {seriesContext ? (
           <>
             <SeriesBanner series={seriesContext} />

--- a/apps/blog/src/components/AuthorBio.tsx
+++ b/apps/blog/src/components/AuthorBio.tsx
@@ -59,8 +59,8 @@ export function AuthorSocialLinks({
 }
 
 /**
- * E-E-A-T "About the author" card surfaced near the top of a blog post, so
- * both readers and LLM/agent crawlers encounter author credentials early.
+ * E-E-A-T "About the author" card rendered at the end of a blog post, so
+ * readers reach the author credentials right after finishing the article.
  * Renders one entry per author that has a published bio; authors without a
  * bio are silently skipped.
  */


### PR DESCRIPTION
## What

Moves the per-post **"About the author"** card (`AuthorBio`) from just below the post header to the **end of the article**, after the body and before the series / related-posts section. This affects every blog post page (`apps/blog/src/app/(blog)/[slug]/page.tsx`).

The compact **byline** at the top (author avatars + publish date, `AuthorAvatarGroup`) is unchanged — only the full author-bio card moves.

## Why

Places author credentials where readers naturally reach them: right after finishing the post, the conventional spot for an "About the author" block.

## Changes

- `apps/blog/src/app/(blog)/[slug]/page.tsx` — render `<AuthorBio>` after `</article>` instead of before the body.
- `apps/blog/src/components/AuthorBio.tsx` — update the component docstring to describe the end-of-post placement.
- Placement comments updated to match.

## Note / tradeoff

The bio was originally surfaced high in the document deliberately, for E-E-A-T and so LLM/agent crawlers encounter author credentials early (#8037). Moving it to the bottom reverses that choice. The author name/link still appears at the top via the byline, and full `BlogPosting` + `Person` structured data (author name, URL, bio, social profiles) is emitted in JSON-LD regardless of visual placement, so machine-readable authorship is preserved. Flag if you'd prefer the bio to remain near the top.

## Scope

Layout-only; no data, schema, or API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Moved the “About the author” biography to the end of blog posts, placing it immediately after the article content.
  * Kept related posts, calls to action, and sharing options following the author biography.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->