### PR TITLE
Fix broken link on Support page

### DIFF
--- a/apps/site/src/data/support.json
+++ b/apps/site/src/data/support.json
@@ -40,7 +40,7 @@
       "links": [
         {
           "label": "Submit a ticket",
-          "url": "https://console.prisma.io/support"
+          "url": "https://console.prisma.io"
         }
       ]
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Submit a ticket” link in the Prisma Support card to direct users to the Console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->