### PR TITLE
docs(compute): sync Compute docs with current product behavior

### DIFF
--- a/apps/docs/content/docs/(index)/prisma-compute/deploy.mdx
+++ b/apps/docs/content/docs/(index)/prisma-compute/deploy.mdx
@@ -25,7 +25,7 @@ Before you start, make sure you have:
 
 :::info
 
-For Next.js apps, we recommend setting `output: "standalone"` in your Next.js config: it produces a much smaller deploy artifact. Without it, the build falls back to packaging the full project tree and serving it with `next start`. The `create-prisma` template already sets this for you.
+Next.js apps should set `output: "standalone"` in their Next.js config. The `create-prisma` template already sets this for you.
 
 ```ts title="next.config.ts"
 export default { output: "standalone" };

--- a/apps/docs/content/docs/(index)/prisma-compute/deploy.mdx
+++ b/apps/docs/content/docs/(index)/prisma-compute/deploy.mdx
@@ -21,11 +21,11 @@ Before you start, make sure you have:
 
 - **A JavaScript runtime.** Node.js 22.12 or newer for `npx`/`pnpm dlx`, or Bun for `bunx`.
 - **A [Prisma Data Platform account](https://pris.ly/pdp).** Free to create, and it holds your workspace.
-- **An app, if you are bringing your own.** Compute deploys **Next.js**, **Nuxt**, **Astro**, **Hono**, **TanStack Start**, and plain **Bun** servers today, including **Elysia** (which runs on Bun). Skip this if you are scaffolding a new app below.
+- **An app, if you are bringing your own.** Compute deploys **Next.js**, **Nuxt**, **Astro**, **Hono**, **NestJS**, **TanStack Start**, and plain **Bun** servers today, including **Elysia** (which runs on Bun). Skip this if you are scaffolding a new app below.
 
 :::info
 
-Next.js apps must set `output: "standalone"` in their Next.js config before deploying. The `create-prisma` template already does this for you.
+For Next.js apps, we recommend setting `output: "standalone"` in your Next.js config: it produces a much smaller deploy artifact. Without it, the build falls back to packaging the full project tree and serving it with `next start`. The `create-prisma` template already sets this for you.
 
 ```ts title="next.config.ts"
 export default { output: "standalone" };
@@ -87,7 +87,7 @@ npx @prisma/cli@latest app deploy
 
 In one pass, the CLI:
 
-1. **Detects your framework** from your project files, whether that is Next.js, Nuxt, Astro, Hono, TanStack Start, or a plain Bun server. To choose it yourself, pass `--framework` (use `--framework bun` for a Bun or Elysia server).
+1. **Detects your framework** from your project files, whether that is Next.js, Nuxt, Astro, Hono, NestJS, TanStack Start, or a plain Bun server. To choose it yourself, pass `--framework` (use `--framework bun` for a Bun or Elysia server).
 2. **Sets up a project** the first time you deploy from this directory, then writes [`.prisma/local.json`](/compute/getting-started#link-an-existing-project) to pin the directory to that project. That file is a gitignored local cache, not committed config. If your team already has a project, [link it first](/compute/getting-started#link-an-existing-project).
 3. **Resolves the target branch.** Inside a Git repository, the CLI uses your current Git branch name; otherwise it falls back to `main`. Pass `--branch <name>` to choose explicitly. Because each branch is its own isolated environment, this decides where the deploy lands.
 4. **Builds and uploads your app**, provisions it, and prints a live URL.
@@ -114,7 +114,7 @@ If it does not behave the way you expect, stream its logs:
 npx @prisma/cli@latest app logs
 ```
 
-Logs cover both the build and the running app, so a failed build and a runtime error both surface in the same place.
+`app logs` streams the running app's logs. Build failures surface in the deploy output itself, since the CLI builds on your machine; for builds triggered by a GitHub push or from the Console, stream them with `npx @prisma/cli@latest build logs <buildId>`.
 
 You can also inspect everything you have deployed in the [Console](https://pris.ly/pdp) instead of the terminal:
 
@@ -132,7 +132,9 @@ npx @prisma/cli@latest app deploy --prod
 Deploying from a Git feature branch behaves differently. Instead of touching production, the CLI:
 
 - resolves the branch name and creates a matching platform branch if one does not exist yet
-- gives you an isolated [preview deployment](/compute/branching) with its own app, database, and URL
+- gives you an isolated [preview deployment](/compute/branching) with its own app and URL (add `--db` to give it its own database too)
+
+One caveat: your project's very first deploy defines its production branch, whatever that Git branch is called. Run the first deploy from your default branch (e.g. `main`) so previews land where you expect.
 
 Preview deploys never ask for confirmation, so run them as often as you like. In scripts and CI, add `--yes` to accept the production confirmation up front:
 

--- a/apps/docs/content/docs/(index)/prisma-compute/deploy.mdx
+++ b/apps/docs/content/docs/(index)/prisma-compute/deploy.mdx
@@ -132,7 +132,7 @@ npx @prisma/cli@latest app deploy --prod
 Deploying from a Git feature branch behaves differently. Instead of touching production, the CLI:
 
 - resolves the branch name and creates a matching platform branch if one does not exist yet
-- gives you an isolated [preview deployment](/compute/branching) with its own app and URL (add `--db` to give it its own database too)
+- gives you an isolated [preview deployment](/compute/branching) with its own app and URL
 
 One caveat: your project's very first deploy defines its production branch, whatever that Git branch is called. Run the first deploy from your default branch (e.g. `main`) so previews land where you expect.
 

--- a/apps/docs/content/docs/compute/branching.mdx
+++ b/apps/docs/content/docs/compute/branching.mdx
@@ -50,7 +50,7 @@ You rarely create branches manually. They appear when work needs them:
 - **On deploy**: `app deploy --branch feature/search` creates the branch if it doesn't exist.
 - **From GitHub**: when a repo is connected, branch and push events create or update the matching platform branch automatically. To set this up, see the [GitHub integration docs](/compute/github).
 
-Connecting GitHub doesn't create branches retroactively; it wires up automation for future events.
+Connecting GitHub doesn't create branches retroactively; it aligns your default branch with the repo's default branch and wires up automation for future events.
 
 ## Cleaning up
 

--- a/apps/docs/content/docs/compute/cli-reference.mdx
+++ b/apps/docs/content/docs/compute/cli-reference.mdx
@@ -77,7 +77,6 @@ Promote and rollback switch the live endpoint between existing deployments; noth
 | `--http-port <port>`      | HTTP port your app listens on                                                |
 | `--region <region>`       | Region for a newly created app; existing apps keep their region              |
 | `--env <name=value\|file>`| Environment variable assignment or dotenv file for this deployment (repeatable); `--env` flags replace config env inputs entirely |
-| `--db` / `--no-db`        | Create and wire a Prisma Postgres database for this deploy target, or skip database setup |
 | `--prod`                  | Confirm intent to deploy to the production branch                            |
 | `--no-promote`            | Build the deployment without promoting it to live; promote later with `app promote <id>` |
 

--- a/apps/docs/content/docs/compute/cli-reference.mdx
+++ b/apps/docs/content/docs/compute/cli-reference.mdx
@@ -14,7 +14,7 @@ The package installs an executable called `prisma-cli`. Run it without installin
 npx @prisma/cli@latest <command>
 ```
 
-Requires Node.js 22.12 or newer for `npx` and `pnpm`; `bunx` also works. The command groups are `auth`, `project`, `project env`, `git`, `branch`, `database`, `app`, and `version`. There is no `init`, `schema`, or `migrate` command in the beta.
+Requires Node.js 22.12 or newer for `npx` and `pnpm`; `bunx` also works. The command groups are `auth`, `init`, `project`, `project env`, `git`, `branch`, `database`, `app`, `build`, `agent`, and `version`. There is no `schema` or `migrate` command in the beta.
 
 ## `auth`
 
@@ -27,6 +27,22 @@ Manage authentication.
 | `auth whoami` | Show the authenticated user and accessible workspace  |
 
 The browser step in `auth login` needs a human. Afterwards, anything running in that environment inherits the session, including coding agents. For CI, set [`PRISMA_SERVICE_TOKEN`](#environment-variables) instead.
+
+## `init`
+
+Scaffold Compute configuration for the current directory. `init` detects your framework and writes `prisma.compute.ts` (or, with `--format json`, a dependency-free `prisma.compute.json`). The `app` commands read this file for app targets, framework, entry point, HTTP port, region, and env inputs.
+
+| Flag                         | Description                                                          |
+| ---------------------------- | --------------------------------------------------------------------- |
+| `--framework <framework>`    | Framework override; detected when omitted                              |
+| `--entry <path>`             | Source entrypoint for entrypoint frameworks (Bun, Hono)                |
+| `--http-port <port>`         | HTTP port the app listens on                                           |
+| `--region <region>`          | Region used when deploy creates the app                                |
+| `--name <app-name>`          | App name                                                               |
+| `--link` / `--no-link`       | Link this directory to a project, or skip that step                    |
+| `--project <id-or-name>`     | Project to link this directory to                                      |
+| `--install` / `--no-install` | Install `@prisma/compute-sdk` for config types, or skip that step      |
+| `--format <ts\|json>`        | `ts` (default) writes `prisma.compute.ts`; `json` writes `prisma.compute.json`; `--format ts` converts an existing `prisma.compute.json` |
 
 ## `app`
 
@@ -42,46 +58,51 @@ Manage apps and deployments for a project.
 | `app logs`                    | Stream logs for the app's current deployment                              |
 | `app list-deploys`            | List deployments for the app                                              |
 | `app show-deploy <deployment>`| Show a deployment in detail                                               |
-| `app promote <deployment>`    | Promote a deployment to production, rebuilding with production env vars   |
+| `app promote <deployment>`    | Make a deployment live behind the app endpoint, starting it first if stopped |
 | `app rollback`                | Roll back production to the previous deployment, without rebuilding       |
 | `app remove`                  | Remove the app from the current branch                                    |
+
+Promote and rollback switch the live endpoint between existing deployments; nothing is rebuilt, and env vars stay as resolved when each deployment was created. Most `app` commands also accept an optional `[app]` positional argument to pick a target from `prisma.compute.ts` when the config defines multiple apps.
 
 ### `app deploy` options
 
 | Flag                      | Description                                                                |
 | ------------------------- | --------------------------------------------------------------------------- |
-| `--app <name>`            | Target a specific app; otherwise inferred from `package.json` name or directory |
+| `--app <name>`            | Target a specific app; otherwise resolved from `PRISMA_APP_ID`, the app name in `prisma.compute.ts`, the `package.json` name, then the directory name |
 | `--project <id-or-name>`  | Target a specific project                                                    |
 | `--create-project <name>` | Create and link a new project before deploying                               |
 | `--branch <name>`         | Deploy to a specific branch; otherwise your active Git branch, then `main`   |
-| `--framework <name>`      | One of `nextjs`, `nuxt`, `astro`, `hono`, `tanstack-start`, `bun`            |
+| `--framework <name>`      | One of `nextjs`, `nuxt`, `astro`, `hono`, `nestjs`, `tanstack-start`, `custom`, `bun` |
 | `--entry <path>`          | Entry point, required for `bun` and useful when detection needs a hand       |
 | `--http-port <port>`      | HTTP port your app listens on                                                |
-| `--env <KEY=value>`       | Set a one-off variable for this deployment (repeatable)                      |
+| `--region <region>`       | Region for a newly created app; existing apps keep their region              |
+| `--env <name=value\|file>`| Environment variable assignment or dotenv file for this deployment (repeatable); `--env` flags replace config env inputs entirely |
+| `--db` / `--no-db`        | Create and wire a Prisma Postgres database for this deploy target, or skip database setup |
 | `--prod`                  | Confirm intent to deploy to the production branch                            |
+| `--no-promote`            | Build the deployment without promoting it to live; promote later with `app promote <id>` |
 
-After the first production deploy, every later production deploy needs `--prod`; without it the deploy fails with `PROD_DEPLOY_REQUIRES_FLAG`. With `--prod`, the CLI asks for confirmation; pass `-y` / `--yes` to accept it up front. In non-interactive mode, a `--prod` deploy without `--yes` fails with `CONFIRMATION_REQUIRED`. The first production deploy is auto-promoted and needs neither flag.
+After the first production deploy, every later production deploy needs `--prod`; without it the deploy fails with `PROD_DEPLOY_REQUIRES_FLAG`. With `--prod`, the CLI asks for confirmation; pass `-y` / `--yes` to accept it up front. In non-interactive mode, a `--prod` deploy without `--yes` fails with `CONFIRMATION_REQUIRED`. The first production deploy is auto-promoted and needs neither flag. A `--no-promote` deploy never replaces the live deployment, so the production gate does not apply.
 
 ### `app build` and `app run` options
 
 | Flag                  | Description                                                                  |
 | --------------------- | ----------------------------------------------------------------------------- |
 | `--entry <path>`      | Entry point for Bun apps                                                       |
-| `--build-type <type>` | `app build`: `auto`, `bun`, `nextjs`, `nuxt`, `astro`, `tanstack-start`. `app run`: `auto`, `bun`, `nextjs` |
+| `--build-type <type>` | `app build`: `auto`, `nextjs`, `nuxt`, `astro`, `nestjs`, `tanstack-start`, `custom`, `bun`. `app run`: `auto`, `nextjs`, `bun` |
 | `--port <port>`       | Port for `app run`                                                             |
 
 ### Other `app` options
 
 | Flag                  | Applies to                       | Description                          |
 | --------------------- | -------------------------------- | ------------------------------------ |
-| `--app`, `--project`  | all inspection and deploy commands | Select the app or project explicitly |
+| `--app`, `--project`  | most inspection and deploy commands (`app show-deploy` takes only the deployment id; `app build` and `app run` are local) | Select the app or project explicitly |
 | `--deployment <id>`   | `app logs`                       | Stream logs for a specific deployment |
 | `--to <deployment>`   | `app rollback`                   | Roll back to a specific deployment    |
 | `--yes`               | `app remove`, `--prod` deploys   | Accept the confirmation prompt        |
 
 ## `app domain`
 
-Manage custom domains for an app. All commands take a `<hostname>` argument plus `--app` / `--project`. Domains target the production branch; to learn more, see the [Domains docs](/compute/domains).
+Manage custom domains for an app. All commands take a `<hostname>` argument plus `--app` / `--project` / `--branch`, and the optional `[app]` config target. Domains target the production branch; to learn more, see the [Domains docs](/compute/domains).
 
 | Command                       | Description                                                    |
 | ----------------------------- | --------------------------------------------------------------- |
@@ -104,7 +125,7 @@ Manage projects and directory bindings.
 | `project create <name>`      | Create a project and link the directory to it                  |
 | `project link [id-or-name]`  | Link the directory to an existing project                      |
 
-Linking writes `.prisma/local.json`, a gitignored local pin of the workspace and project. It is a cache, not committed config; the CLI never reads or writes committed config files.
+Linking writes `.prisma/local.json`, a gitignored local pin of the workspace and project. It is a cache, not committed config. Committed configuration lives in `prisma.compute.ts` (or `prisma.compute.json`), which [`init`](#init) writes and the `app` commands read.
 
 ## `project env`
 
@@ -113,9 +134,11 @@ Manage environment variables for the active project. Writes require an explicit 
 | Command                          | Description                                                |
 | -------------------------------- | ----------------------------------------------------------- |
 | `project env add <KEY=value\|KEY>` | Create a variable; pass just `KEY` to read the value from your environment |
-| `project env update <KEY=value>` | Replace an existing variable's value                         |
+| `project env update <KEY=value\|KEY>` | Replace an existing variable's value; a bare `KEY` also reads from your environment |
 | `project env list`               | List variable names and metadata for a scope, never values   |
 | `project env remove <key>`       | Remove a variable from a scope (`rm` also works)             |
+
+`add` and `update` also accept `--file <path>` to read `KEY=VALUE` assignments from a dotenv file, and every `project env` command takes `--project <id-or-name>`.
 
 Values are write-only: encrypted at rest and never returned by any surface. They resolve at deploy time; redeploy to apply changes.
 
@@ -127,6 +150,24 @@ Inspect platform branches for the resolved project without creating remote state
 | ------------- | ------------------------------------------------- |
 | `branch list` | List platform branches for the resolved project    |
 
+## `database`
+
+Manage Prisma Postgres databases for the resolved project. Most commands take `--project <id-or-name>` and `--branch <git-name>`.
+
+| Command                                    | Description                                                    |
+| ------------------------------------------ | --------------------------------------------------------------- |
+| `database list`                            | List databases                                                   |
+| `database show <database>`                 | Show a database in detail                                        |
+| `database create <name>`                   | Create a database; `--region` sets the Prisma Postgres region    |
+| `database usage <database>`                | Show usage; `--from` / `--to` bound the period                   |
+| `database restore <database>`              | Restore from a backup (`--backup`, `--source-database`, `--confirm`) |
+| `database remove <database>`               | Remove a database (`--confirm <database-id>`)                    |
+| `database backup list <database>`          | List backups (`--limit <n>`)                                     |
+| `database connection list <database>`      | List connections                                                 |
+| `database connection create <database>`    | Create a connection (`--name <name>`)                            |
+| `database connection rotate <connection>`  | Rotate a connection's credentials (`--confirm`)                  |
+| `database connection remove <connection>`  | Remove a connection (`--confirm`)                                |
+
 ## `git`
 
 Manage the GitHub repository connection. To learn more, see the [GitHub integration docs](/compute/github).
@@ -136,7 +177,27 @@ Manage the GitHub repository connection. To learn more, see the [GitHub integrat
 | `git connect [git-url]`  | Link the project to a GitHub repository; starts the GitHub App install flow if needed |
 | `git disconnect`         | Stop push-triggered automation; keeps the project and existing branches |
 
-In `--json` / `--no-interactive` mode, `git connect` returns an install URL instead of blocking.
+In `--json` / `--no-interactive` mode, `git connect` doesn't block: if the GitHub App isn't installed yet, it exits with a `REPO_INSTALLATION_REQUIRED` error whose payload carries the install URL and next steps.
+
+## `build`
+
+Inspect builds that run on the platform (git-push and Console deploys).
+
+| Command                | Description                                                                  |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| `build logs <buildId>` | Stream logs for a platform build; `--follow` keeps streaming as the build runs, `--cursor <cursor>` resumes from a prior terminal cursor |
+
+## `agent`
+
+Install and inspect Prisma agent skills; see [Agent skills](#agent-skills) below.
+
+| Command         | Description                                                          |
+| --------------- | ---------------------------------------------------------------------- |
+| `agent install` | Install Prisma skills for coding agents                                |
+| `agent update`  | Update installed Prisma skills                                          |
+| `agent status`  | Show installed Prisma skills; `--global` checks the user directory      |
+
+`agent install` and `agent update` take `--agent <agent>` (repeatable), `--all-agents`, `--skill <skill>` (repeatable), `--global`, `--copy`, and `--dry-run`.
 
 ## `version`
 
@@ -175,7 +236,7 @@ An agent skill teaches a coding agent the Compute deploy workflow. Install it in
 npx skills add prisma/skills --skill prisma-compute
 ```
 
-This adds the `prisma-compute` skill to `.agents/skills/`, where supported agents pick it up. To install every Prisma skill at once, run `npx skills add prisma/skills`. To learn more, see [Agent skills](/compute/getting-started#agent-skills) in the getting started guide.
+This adds the `prisma-compute` skill to `.agents/skills/`, where supported agents pick it up. To install every Prisma skill at once, run `npx skills add prisma/skills`, or use the CLI's [`agent install`](#agent) command, which wraps the same flow. To learn more, see [Agent skills](/compute/getting-started#agent-skills) in the getting started guide.
 
 ## Environment variables
 
@@ -233,6 +294,7 @@ The common codes, grouped by area:
 | `DOMAIN_ALREADY_REGISTERED`   | The hostname is already registered.                    |
 | `DOMAIN_DNS_NOT_CONFIGURED`   | The CNAME record isn't visible yet.                    |
 | `DOMAIN_VERIFICATION_FAILED`  | DNS verification or TLS provisioning failed.           |
+| `DOMAIN_VERIFICATION_TIMEOUT` | `app domain wait` hit its timeout before the domain became active. |
 | `DOMAIN_QUOTA_EXCEEDED`       | The app already has 3 custom domains.                  |
 | `DOMAIN_RETRY_NOT_ELIGIBLE`   | The domain isn't in a retryable state.                 |
 

--- a/apps/docs/content/docs/compute/cli-reference.mdx
+++ b/apps/docs/content/docs/compute/cli-reference.mdx
@@ -94,7 +94,7 @@ After the first production deploy, every later production deploy needs `--prod`;
 
 | Flag                  | Applies to                       | Description                          |
 | --------------------- | -------------------------------- | ------------------------------------ |
-| `--app`, `--project`  | most inspection and deploy commands (`app show-deploy` takes only the deployment id; `app build` and `app run` are local) | Select the app or project explicitly |
+| `--app`, `--project`  | most inspection and deploy commands (`app show-deploy` takes only the deployment id) | Select the app or project explicitly |
 | `--deployment <id>`   | `app logs`                       | Stream logs for a specific deployment |
 | `--to <deployment>`   | `app rollback`                   | Roll back to a specific deployment    |
 | `--yes`               | `app remove`, `--prod` deploys   | Accept the confirmation prompt        |

--- a/apps/docs/content/docs/compute/cli-reference.mdx
+++ b/apps/docs/content/docs/compute/cli-reference.mdx
@@ -174,7 +174,7 @@ Manage the GitHub repository connection. To learn more, see the [GitHub integrat
 | `git connect [git-url]`  | Link the project to a GitHub repository; starts the GitHub App install flow if needed |
 | `git disconnect`         | Stop push-triggered automation; keeps the project and existing branches |
 
-In `--json` / `--no-interactive` mode, `git connect` doesn't block: if the GitHub App isn't installed yet, it exits with a `REPO_INSTALLATION_REQUIRED` error whose payload carries the install URL and next steps.
+In `--json` / `--no-interactive` mode, `git connect` doesn't block: if the GitHub App isn't installed yet, it fails with `REPO_INSTALLATION_REQUIRED` and gives you the install URL.
 
 ## `build`
 

--- a/apps/docs/content/docs/compute/cli-reference.mdx
+++ b/apps/docs/content/docs/compute/cli-reference.mdx
@@ -51,7 +51,6 @@ Manage apps and deployments for a project.
 | Command                       | Description                                                              |
 | ----------------------------- | ------------------------------------------------------------------------ |
 | `app build`                   | Build the app locally into a deployable artifact                          |
-| `app run`                     | Run your app locally                                                      |
 | `app deploy`                  | Create a new deployment for the app                                       |
 | `app show`                    | Show the app and its current deployment                                   |
 | `app open`                    | Open the app's live URL                                                   |
@@ -82,19 +81,18 @@ Promote and rollback switch the live endpoint between existing deployments; noth
 
 After the first production deploy, every later production deploy needs `--prod`; without it the deploy fails with `PROD_DEPLOY_REQUIRES_FLAG`. With `--prod`, the CLI asks for confirmation; pass `-y` / `--yes` to accept it up front. In non-interactive mode, a `--prod` deploy without `--yes` fails with `CONFIRMATION_REQUIRED`. The first production deploy is auto-promoted and needs neither flag. A `--no-promote` deploy never replaces the live deployment, so the production gate does not apply.
 
-### `app build` and `app run` options
+### `app build` options
 
 | Flag                  | Description                                                                  |
 | --------------------- | ----------------------------------------------------------------------------- |
 | `--entry <path>`      | Entry point for Bun apps                                                       |
-| `--build-type <type>` | `app build`: `auto`, `nextjs`, `nuxt`, `astro`, `nestjs`, `tanstack-start`, `custom`, `bun`. `app run`: `auto`, `nextjs`, `bun` |
-| `--port <port>`       | Port for `app run`                                                             |
+| `--build-type <type>` | One of `auto`, `nextjs`, `nuxt`, `astro`, `nestjs`, `tanstack-start`, `custom`, `bun` |
 
 ### Other `app` options
 
 | Flag                  | Applies to                       | Description                          |
 | --------------------- | -------------------------------- | ------------------------------------ |
-| `--app`, `--project`  | most inspection and deploy commands (`app show-deploy` takes only the deployment id) | Select the app or project explicitly |
+| `--app`, `--project`  | most inspection and deploy commands (`app show-deploy` takes only the deployment id; `app build` is local) | Select the app or project explicitly |
 | `--deployment <id>`   | `app logs`                       | Stream logs for a specific deployment |
 | `--to <deployment>`   | `app rollback`                   | Roll back to a specific deployment    |
 | `--yes`               | `app remove`, `--prod` deploys   | Accept the confirmation prompt        |

--- a/apps/docs/content/docs/compute/configuration.mdx
+++ b/apps/docs/content/docs/compute/configuration.mdx
@@ -40,7 +40,7 @@ Every field is optional. An empty `app: {}` is valid and defers entirely to dete
 npm install -D @prisma/compute-sdk
 ```
 
-JavaScript configs work too: a plain `export default { app: { ... } }` from `prisma.compute.js`/`.mjs`/`.cjs` is valid, just without the type checking.
+JavaScript configs work too: a plain `export default { app: { ... } }` from `prisma.compute.js`/`.mjs`/`.cjs` is valid, just without the type checking. So is a static `prisma.compute.json` with the same shape; it may include a `$schema` field for editor tooling, which is ignored at load time.
 
 :::
 
@@ -51,12 +51,13 @@ Each app accepts these fields. All are optional.
 | Field       | Type                          | Description                                                                                 |
 | ----------- | ----------------------------- | ------------------------------------------------------------------------------------------- |
 | `name`      | `string`                      | The deployed app name. Defaults to the `apps` key, then to inference from `package.json`.   |
+| `region`    | region name                   | Region for a newly created app; existing apps keep their region. See [Regions](#regions).    |
 | `root`      | `string`                      | The app directory, relative to the config file. Defaults to the config file's directory.    |
-| `framework` | framework name                | One of `nextjs`, `nuxt`, `astro`, `hono`, `tanstack-start`, `bun`. Defaults to detection.   |
-| `entry`     | `string`                      | Entrypoint path for `bun` and `hono` apps, relative to the app root.                         |
+| `framework` | framework name                | One of `nextjs`, `nuxt`, `astro`, `hono`, `nestjs`, `tanstack-start`, `custom`, `bun`. Defaults to detection. |
+| `entry`     | `string`                      | Entrypoint path for `bun` and `hono` apps, relative to the app root. Setting it with any other framework is a configuration error. |
 | `httpPort`  | `number`                      | The port your app listens on. Defaults to the framework's default.                          |
 | `env`       | `string` or `{ file, vars }`  | Environment inputs for the deploy. See [Environment](#environment).                          |
-| `build`     | `{ command, outputDirectory }`| Build settings. See [Build settings](#build-settings).                                       |
+| `build`     | `{ command, outputDirectory, entrypoint }` | Build settings. See [Build settings](#build-settings).                         |
 
 ```ts title="prisma.compute.ts"
 import { defineComputeConfig } from "@prisma/compute-sdk/config";
@@ -70,6 +71,12 @@ export default defineComputeConfig({
   },
 });
 ```
+
+### Regions
+
+`region` is one of `us-east-1`, `us-west-1`, `eu-west-3`, `eu-central-1`, `ap-northeast-1`, or `ap-southeast-1`. It applies only when a deploy creates the app; an app that already exists keeps its current region.
+
+A top-level `region` (next to `app` or `apps`) sets the default for every app in the config; a per-app `region` overrides it.
 
 ### Environment
 
@@ -119,17 +126,18 @@ export default defineComputeConfig({
 });
 ```
 
-- Both fields are optional. A field you set overrides the framework default; a field you omit is inferred.
+- Every field is optional. A field you set overrides the framework default; a field you omit is inferred.
 - `command: null` skips the build step entirely.
-- A `build` block applies to `nextjs`, `hono`, `tanstack-start`, and `bun`. `nuxt` and `astro` run their own framework CLI, so a `build` block with those frameworks is a configuration error.
+- `entrypoint` names the built artifact's entry file, relative to `outputDirectory` when one is set (otherwise to the app root). For `hono` and `bun` apps it's required whenever you set `outputDirectory`, and setting both `entry` and a differing `build.entrypoint` is a configuration error.
+- A `build` block works with every framework. With the `custom` framework it's required, and must set both `outputDirectory` and `entrypoint`.
 
 Without a `build` block, the CLI infers everything (running your `package.json` build script when there is one, otherwise the framework default) and shows you what it chose during the deploy.
 
 ## Where the file lives
 
-`app deploy` reads the **nearest** config file, searching from your current directory up to the repository or workspace root (the closest ancestor with a `.git`, `pnpm-workspace.yaml`, `bun.lock`, or a `workspaces` field). Discovery never escapes the repository.
+`app deploy` reads the **nearest** config file, searching from your current directory up to the repository or workspace root (the closest ancestor with a `.git`, `pnpm-workspace.yaml`, `bun.lock`, `bun.lockb`, or a `workspaces` field). Discovery never escapes the repository.
 
-Per directory, exactly one of `prisma.compute.ts`, `prisma.compute.mts`, `prisma.compute.js`, `prisma.compute.mjs`, or `prisma.compute.cjs` may exist.
+Per directory, exactly one of `prisma.compute.ts`, `prisma.compute.mts`, `prisma.compute.js`, `prisma.compute.mjs`, `prisma.compute.cjs`, or `prisma.compute.json` may exist.
 
 The config file's directory is treated as the project directory: the [`.prisma/local.json`](/compute/getting-started#link-an-existing-project) project pin lives there, and paths in the config (`root`, `env.file`) resolve from there. That means the config means the same thing no matter which subdirectory you run the command from.
 

--- a/apps/docs/content/docs/compute/configuration.mdx
+++ b/apps/docs/content/docs/compute/configuration.mdx
@@ -12,7 +12,7 @@ metaDescription: "Reference for the prisma.compute.ts file: declare your app's f
 - **A monorepo.** Declare several apps in one repository and deploy them together, or one at a time.
 - **Type safety.** Catch a typo'd field or an invalid framework in your editor, before you deploy.
 
-The file is read by `app deploy`, `app build`, and `app run`. It never selects your project, branch, or production; those stay explicit. It also does not configure a database; that stays on the [`--db` flag](/compute/cli-reference#app-deploy-options).
+The file is read by `app deploy` and `app build`. It never selects your project, branch, or production; those stay explicit. It also does not configure a database; that stays on the [`--db` flag](/compute/cli-reference#app-deploy-options).
 
 ## A minimal config
 
@@ -183,7 +183,7 @@ All the apps live in one project, deploying to the same branch. From here:
 
 When you deploy everything at once, per-app flags like `--framework` or `--entry` are rejected as ambiguous. Pass a target to apply them to one app. Project- and branch-level flags (`--branch`, `--db`, `--prod`, `--yes`) apply to the whole run.
 
-`app build` and `app run` always target a single app in a multi-app config. Unlike `deploy`, they have no all-apps form, so pass a target or run from inside the app's `root`.
+`app build` always targets a single app in a multi-app config. Unlike `deploy`, it has no all-apps form, so pass a target or run from inside the app's `root`.
 
 ## How config and flags interact
 

--- a/apps/docs/content/docs/compute/deployments.mdx
+++ b/apps/docs/content/docs/compute/deployments.mdx
@@ -40,7 +40,7 @@ npx @prisma/cli@latest app build
 npx @prisma/cli@latest app run --port 3000
 ```
 
-`app build` supports the build types `auto`, `bun`, `nextjs`, `nuxt`, `astro`, and `tanstack-start`. `app run` currently supports `auto`, `bun`, and `nextjs`.
+`app build` supports the build types `auto`, `nextjs`, `nuxt`, `astro`, `nestjs`, `tanstack-start`, `custom`, and `bun`. `app run` currently supports `auto`, `bun`, and `nextjs`.
 
 ## Deploy to production
 
@@ -80,19 +80,19 @@ npx @prisma/cli@latest app logs --app web
 npx @prisma/cli@latest app logs --app web --deployment dep_123
 ```
 
-Your app's log lines go to stdout; the CLI's own status and errors go to stderr, so you can pipe them apart. If the platform can't serve logs for the resolved deployment, the command fails with `FEATURE_UNAVAILABLE`.
+Your app's log lines go to stdout; the CLI's own status and errors go to stderr, so you can pipe them apart. If the log stream can't be served for the resolved deployment, the command fails with `DEPLOY_FAILED`.
 
 ## Promote and roll back
 
-Promote an earlier deployment to production:
+Promote an earlier deployment to be the live one:
 
 ```npm
 npx @prisma/cli@latest app promote dep_123 --app web
 ```
 
-Promotion rebuilds the deployment with your production environment variables. The rebuild is necessary because values are baked in at deploy time: a preview build still carries preview config, so it can't serve production as-is.
+Promotion makes an existing deployment live behind the app's endpoint. If the deployment is stopped, it's started first and promoted once it's running. Nothing is rebuilt: environment variables are baked in when a deployment is created, so a promoted deployment keeps the config it was built with. To build a deployment without making it live, deploy with `--no-promote` and promote it later.
 
-Roll back to the previous deployment, or a specific one. Unlike `promote`, rollback reuses an existing build, so there is no rebuild step between you and a known-good state:
+Roll back to the previous deployment, or a specific one. Rollback works the same way — it reuses an existing build and just targets the previous deployment, so there is no rebuild step between you and a known-good state:
 
 ```npm
 npx @prisma/cli@latest app rollback --app web

--- a/apps/docs/content/docs/compute/deployments.mdx
+++ b/apps/docs/content/docs/compute/deployments.mdx
@@ -31,16 +31,15 @@ npx @prisma/cli@latest app deploy --env DATABASE_URL=postgresql://example
 
 `--env` is for one-off values at deploy time. For variables that should persist across deploys, set them on the project. To learn more, see the [Environment variables docs](/compute/environment-variables).
 
-## Build and run locally
+## Build locally
 
 Check your app builds before you ship it:
 
 ```npm
 npx @prisma/cli@latest app build
-npx @prisma/cli@latest app run --port 3000
 ```
 
-`app build` supports the build types `auto`, `nextjs`, `nuxt`, `astro`, `nestjs`, `tanstack-start`, `custom`, and `bun`. `app run` currently supports `auto`, `bun`, and `nextjs`.
+`app build` supports the build types `auto`, `nextjs`, `nuxt`, `astro`, `nestjs`, `tanstack-start`, `custom`, and `bun`.
 
 ## Deploy to production
 

--- a/apps/docs/content/docs/compute/domains.mdx
+++ b/apps/docs/content/docs/compute/domains.mdx
@@ -16,7 +16,7 @@ You'll need:
 - A production app with a [promoted, running deployment](/compute/deployments).
 - Access to edit DNS records within your DNS provider.
 
-Domain commands target the [production branch](/compute/branching). Pointing them at any other branch fails with [`BRANCH_NOT_DEPLOYABLE`](/compute/cli-reference#error-codes).
+Domain commands target the [production branch](/compute/branching). Pointing them at any other branch fails with [`BRANCH_NOT_DEPLOYABLE`](/compute/cli-reference#error-codes). Every domain subcommand also accepts `--project` and `--branch` flags.
 
 ## Add a custom domain
 
@@ -26,16 +26,18 @@ Domain commands target the [production branch](/compute/branching). Pointing the
 npx @prisma/cli@latest app domain add shop.acme.com --app web
 ```
 
-The command registers the custom domain for your production app. If the **CNAME** record isn't visible yet, it prints the record name and value for you to create.
+Registration verifies DNS up front. If the **CNAME** record isn't visible yet, the command fails with [`DOMAIN_DNS_NOT_CONFIGURED`](/compute/cli-reference#error-codes) and prints the record name and value for you to create. Re-running `add` for a hostname that's already attached is safe: it shows the existing domain instead of failing.
 
 ### 2. Create CNAME Record
 
-Add the printed DNS record which looks like `switchboard.{region}.prisma.build`.
+Add the printed DNS record, which points at `switchboard.{region}.prisma.build`.
 
 Example:
-| Type  | Name   | Value                          | TTL |
-| ----- | ------ | ------------------------------ | --- |
-| CNAME | `shop` | `switchboard.fra.prisma.build` | 300 |
+| Type  | Name            | Value                          | TTL |
+| ----- | --------------- | ------------------------------ | --- |
+| CNAME | `shop.acme.com` | `switchboard.cdg.prisma.build` | 300 |
+
+The CLI prints the record name as the full hostname. If your DNS provider expects a relative name, enter just the label (`shop`).
 
 :::note[What is switchboard?]
 
@@ -43,9 +45,9 @@ Switchboard is the routing layer that sits in front of your Compute app. Switchb
 
 :::
 
-### 3. Wait for DNS propagation
+### 3. Re-run `add`, then wait for provisioning
 
-Verify using:
+Once the CNAME record has propagated, re-run `app domain add`. This time registration succeeds and TLS provisioning starts. Track it with:
 
 ```npm
 npx @prisma/cli@latest app domain wait shop.acme.com --app web
@@ -57,7 +59,7 @@ npx @prisma/cli@latest app domain wait shop.acme.com --app web
 npx @prisma/cli@latest app domain wait shop.acme.com --app web --timeout 0 --json
 ```
 
-In `--json` mode, `wait` streams newline-delimited status events, so an agent can track provisioning as it progresses.
+A single check exits non-zero with `DOMAIN_VERIFICATION_TIMEOUT` while the domain is still provisioning, so automation should read the status event rather than the exit code. In `--json` mode, `wait` streams newline-delimited status events, so an agent can track provisioning as it progresses.
 
 ## Remove a domain
 
@@ -71,18 +73,18 @@ Removing detaches the domain from the app; pass `--yes` to skip the confirmation
 
 A domain moves through these states:
 
-| Status             | Meaning                                                       |
-| ------------------ | ------------------------------------------------------------- |
-| `pending_dns`      | Waiting for your CNAME record to be visible                    |
-| `verifying`        | DNS found; ownership and routing are being verified            |
-| `provisioning_tls` | The TLS certificate is being issued                            |
+| Status             | Meaning                                                         |
+| ------------------ | --------------------------------------------------------------- |
+| `pending_dns`      | The domain is registered; TLS provisioning hasn't started yet   |
+| `provisioning_tls` | The TLS certificate is being issued                             |
 | `active`           | The domain is fully provisioned and routing traffic to your app |
 | `failed`           | Registration or provisioning failed; see the failure reason     |
 
 ## Limits
 
 - Custom domains are only available on production apps.
-- DNS uses CNAME records.
+- DNS uses CNAME records only. Apex domains need a DNS provider that supports CNAME-like records (ALIAS, ANAME, or CNAME flattening) at the apex.
+- Wildcard hostnames such as `*.acme.com` are rejected.
 - Up to 3 custom domains per app; more returns `DOMAIN_QUOTA_EXCEEDED`.
 - There's no workspace-wide domain list in the CLI.
 

--- a/apps/docs/content/docs/compute/environment-variables.mdx
+++ b/apps/docs/content/docs/compute/environment-variables.mdx
@@ -38,6 +38,12 @@ To keep a secret out of your shell history, pass just the key and let the CLI re
 DATABASE_URL=postgresql://example npx @prisma/cli@latest project env add DATABASE_URL --role production
 ```
 
+To import many variables at once, pass a dotenv file with `--file` instead of a `KEY=value` argument (one or the other, not both). It works for `add` and `update`:
+
+```npm
+npx @prisma/cli@latest project env add --file .env.production --role production
+```
+
 ## Connect a database
 
 To give your app a database, set its connection string per scope, then redeploy. Use a different database per scope if you want preview deployments isolated from production data.
@@ -59,6 +65,8 @@ npx @prisma/cli@latest project env remove DATABASE_URL --role preview
 
 `list --role` shows names and metadata, never values. `list --branch` shows the resolved view for one branch. `rm` works as an alias for `remove`.
 
+`add` never overwrites: it fails if the key already exists in that scope, so use `update` to change a value. Every `project env` subcommand also accepts `--project <id-or-name>` to target a project other than the linked one.
+
 ## Values are write-only
 
 Once you save a variable, the platform never gives it back. Values are encrypted at rest and never returned: not by the CLI, the API, or the Console. In practice:
@@ -72,7 +80,7 @@ Keep your own copy of every value in a secret manager. Treat Prisma as the place
 
 ## Rules
 
-- Keys must match `[A-Z_][A-Z0-9_]*`.
+- Keys must match `[A-Z_][A-Z0-9_]*`, up to 256 characters.
 - Values must be non-empty, up to 8 KB.
 - Production variables can't be branch-scoped: use `--role production` for production, and `--branch <name>` only for preview overrides.
 

--- a/apps/docs/content/docs/compute/getting-started.mdx
+++ b/apps/docs/content/docs/compute/getting-started.mdx
@@ -115,11 +115,10 @@ export default { output: "standalone" };
 
 ## Check it builds locally
 
-Before you deploy, you can build and run the app on your machine:
+Before you deploy, you can build the app on your machine:
 
 ```npm
 npx @prisma/cli@latest app build
-npx @prisma/cli@latest app run --port 3000
 ```
 
 ## Deploy to production

--- a/apps/docs/content/docs/compute/getting-started.mdx
+++ b/apps/docs/content/docs/compute/getting-started.mdx
@@ -105,7 +105,7 @@ npx @prisma/cli@latest app deploy --framework bun --entry src/server.ts
 
 :::note
 
-For Next.js apps, set `output: "standalone"` in your Next.js config. Without it, the build still works: the CLI packages the full project tree and serves it with `next start`. Standalone output produces a much smaller artifact, so it's the recommended setup.
+Next.js apps should set `output: "standalone"` in their Next.js config.
 
 ```ts title="next.config.ts"
 export default { output: "standalone" };

--- a/apps/docs/content/docs/compute/getting-started.mdx
+++ b/apps/docs/content/docs/compute/getting-started.mdx
@@ -89,7 +89,7 @@ npx @prisma/cli@latest project list
 
 ## Pick a framework
 
-The CLI detects your framework automatically. Today there is first-class support for **Next.js**, **Nuxt**, **Astro**, **Hono**, and **TanStack Start**:
+The CLI detects your framework automatically. Today there is first-class support for **Next.js**, **Nuxt**, **Astro**, **Hono**, **NestJS**, and **TanStack Start**:
 
 ```npm
 npx @prisma/cli@latest app deploy --framework nextjs
@@ -105,7 +105,7 @@ npx @prisma/cli@latest app deploy --framework bun --entry src/server.ts
 
 :::note
 
-Next.js apps must set `output: "standalone"` in their Next.js config before deploying. The CLI builds the standalone output and fails the build if it's missing.
+For Next.js apps, set `output: "standalone"` in your Next.js config. Without it, the build still works: the CLI packages the full project tree and serves it with `next start`. Standalone output produces a much smaller artifact, so it's the recommended setup.
 
 ```ts title="next.config.ts"
 export default { output: "standalone" };
@@ -121,6 +121,8 @@ Before you deploy, you can build and run the app on your machine:
 npx @prisma/cli@latest app build
 npx @prisma/cli@latest app run --port 3000
 ```
+
+`app build` works for every framework. `app run` currently runs a local server for Next.js, Hono, and plain Bun apps.
 
 ## Deploy to production
 
@@ -140,7 +142,7 @@ npx @prisma/cli@latest app deploy --prod --yes
 
 In non-interactive mode, a `--prod` deploy without `--yes` can't prompt, so it fails with `CONFIRMATION_REQUIRED`; re-run with `--prod --yes`.
 
-Preview deploys never need `--prod` and never ask for confirmation. To learn about promotion and rollback, see the [Deployments docs](/compute/deployments).
+Preview deploys never need `--prod` and never ask for confirmation. To build a new deployment without making it live, pass `--no-promote` and promote it later with `app promote <id>`. To learn about promotion and rollback, see the [Deployments docs](/compute/deployments).
 
 ## Automation and CI
 
@@ -191,7 +193,7 @@ In `--json` mode, every result is an envelope with an `ok` flag. On failure, `er
 | `APP_AMBIGUOUS`          | More than one app matched. Pass `--app <name>`.                        |
 | `PROD_DEPLOY_REQUIRES_FLAG` | A production deploy is missing explicit intent. Re-run with `--prod`.  |
 | `CONFIRMATION_REQUIRED`  | A `--prod` deploy can't prompt for confirmation here. Pass `--prod --yes`. |
-| `FEATURE_UNAVAILABLE`    | The platform can't serve this yet (e.g. logs for some deployments).    |
+| `FEATURE_UNAVAILABLE`    | The platform can't serve this yet (e.g. the app has no live URL yet for `app open`). |
 
 For the full list, see the [error codes reference](/compute/cli-reference#error-codes).
 

--- a/apps/docs/content/docs/compute/getting-started.mdx
+++ b/apps/docs/content/docs/compute/getting-started.mdx
@@ -122,8 +122,6 @@ npx @prisma/cli@latest app build
 npx @prisma/cli@latest app run --port 3000
 ```
 
-`app build` works for every framework. `app run` currently runs a local server for Next.js, Hono, and plain Bun apps.
-
 ## Deploy to production
 
 Your first deployment is promoted to production automatically. After that, every production deploy needs an explicit `--prod` flag, so you don't ship to production by accident:

--- a/apps/docs/content/docs/compute/github.mdx
+++ b/apps/docs/content/docs/compute/github.mdx
@@ -32,7 +32,7 @@ To name the repository explicitly:
 npx @prisma/cli@latest git connect https://github.com/acme/shop
 ```
 
-If the GitHub App isn't installed yet, the CLI starts the install flow. In `--json` / `--no-interactive` mode it returns an install URL instead of blocking, so automation can hand it off:
+If the GitHub App isn't installed yet, the CLI starts the install flow. In `--json` / `--no-interactive` mode it doesn't block: the command exits with a `REPO_INSTALLATION_REQUIRED` error whose payload carries the install URL and next steps, so automation can hand the install off:
 
 ```npm
 npx @prisma/cli@latest git connect https://github.com/acme/shop --json --no-interactive
@@ -58,7 +58,7 @@ Connecting doesn't deploy anything on its own; it wires up automation for *futur
 
 ## CI and monorepos
 
-GitHub auto-deploy is single-app in beta. For monorepos, custom pipelines, or anywhere you want full control, run the CLI directly with a service token and explicit targets:
+Auto-deploy handles monorepos that declare their apps in `prisma.compute.ts`: one pushed commit fans out into a targeted build per app. For custom pipelines, or anywhere you want full control, run the CLI directly with a service token and explicit targets:
 
 ```bash
 PRISMA_SERVICE_TOKEN=... npx @prisma/cli@latest app deploy \
@@ -73,7 +73,7 @@ This keeps deploys deterministic and gives agents a structured result to read.
 
 ## What's not in beta
 
-GitHub is the only supported provider; others return `REPO_PROVIDER_UNSUPPORTED`. The webhook path is branch- and push-driven only: don't rely on pull-request comments, PR status checks, or preview comments. They aren't part of the beta surface.
+GitHub is the only supported provider; others return `REPO_PROVIDER_UNSUPPORTED`. The webhook path is branch- and push-driven. Each webhook deployment posts a "Prisma Compute Deploy" check run on the commit — success or failure, with the deploy URL — on a best-effort basis. Pull-request comments and preview comments aren't part of the beta surface.
 
 ## Next steps
 

--- a/apps/docs/content/docs/compute/github.mdx
+++ b/apps/docs/content/docs/compute/github.mdx
@@ -32,7 +32,7 @@ To name the repository explicitly:
 npx @prisma/cli@latest git connect https://github.com/acme/shop
 ```
 
-If the GitHub App isn't installed yet, the CLI starts the install flow. In `--json` / `--no-interactive` mode it doesn't block: the command exits with a `REPO_INSTALLATION_REQUIRED` error whose payload carries the install URL and next steps, so automation can hand the install off:
+If the GitHub App isn't installed yet, the CLI starts the install flow. In `--json` / `--no-interactive` mode it doesn't block: it gives you the install URL to finish in the browser, so automation can hand the install off:
 
 ```npm
 npx @prisma/cli@latest git connect https://github.com/acme/shop --json --no-interactive

--- a/apps/docs/content/docs/compute/index.mdx
+++ b/apps/docs/content/docs/compute/index.mdx
@@ -35,7 +35,7 @@ Compute organizes everything into a few resources:
 - A **branch** maps to a Git branch in the linked repository, and gets its own isolated app, environment variables, and deployments.
 - An **app** is an HTTP service, such as a frontend or backend, and can have multiple **deployments**.
 
-The branch is the concept that ties Compute together. Each branch owns its own app, database, URL, and environment variables. When you create a branch, Compute provisions isolated resources for that branch, so you can test changes in preview without affecting production.
+The branch is the concept that ties Compute together. Each branch owns its own app, URL, and environment variables, and can have its own database: pass `--db` on deploy, or accept the prompt when the deploy detects a Prisma schema. When you deploy to a new branch, Compute provisions isolated resources for that branch, so you can test changes in preview without affecting production.
 
 - **Production**: the default Git branch (e.g., `main`) is your production branch, with its own resources and environment variables.
 - **Preview**: every other branch is a preview branch, with its own isolated resources and environment variables scoped to **preview**.

--- a/apps/docs/content/docs/compute/index.mdx
+++ b/apps/docs/content/docs/compute/index.mdx
@@ -35,7 +35,7 @@ Compute organizes everything into a few resources:
 - A **branch** maps to a Git branch in the linked repository, and gets its own isolated app, environment variables, and deployments.
 - An **app** is an HTTP service, such as a frontend or backend, and can have multiple **deployments**.
 
-The branch is the concept that ties Compute together. Each branch owns its own app, URL, and environment variables, and can have its own database: pass `--db` on deploy, or accept the prompt when the deploy detects a Prisma schema. When you deploy to a new branch, Compute provisions isolated resources for that branch, so you can test changes in preview without affecting production.
+The branch is the concept that ties Compute together. Each branch owns its own app, URL, and environment variables, and can have its own database. When you deploy to a new branch, Compute provisions isolated resources for that branch, so you can test changes in preview without affecting production.
 
 - **Production**: the default Git branch (e.g., `main`) is your production branch, with its own resources and environment variables.
 - **Preview**: every other branch is a preview branch, with its own isolated resources and environment variables scoped to **preview**.

--- a/apps/docs/content/docs/compute/keeping-instances-awake.mdx
+++ b/apps/docs/content/docs/compute/keeping-instances-awake.mdx
@@ -130,7 +130,7 @@ The `signal` follows the standard `AbortSignal` pattern, so you can pass any sig
 ### `waitUntil`
 
 ```ts title="@prisma/compute"
-waitUntil(promise: Promise<unknown>, options?: { signal?: AbortSignal }): void;
+waitUntil(promise: PromiseLike<unknown>, options?: { signal?: AbortSignal }): void;
 ```
 
 Keeps the instance awake until `promise` settles. Pass `options.signal` as a caller-owned fallback to stop keeping the instance awake if the promise hangs or never settles. The signal does not cancel the promise.

--- a/apps/docs/content/docs/compute/limitations.mdx
+++ b/apps/docs/content/docs/compute/limitations.mdx
@@ -25,7 +25,6 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). 
 
 - `app deploy --framework` accepts `nextjs`, `nuxt`, `astro`, `hono`, `nestjs`, `tanstack-start`, `custom`, and `bun`.
 - `app build --build-type` accepts `auto`, `nextjs`, `nuxt`, `astro`, `nestjs`, `tanstack-start`, `custom`, and `bun`.
-- `app run --build-type` accepts `auto`, `bun`, and `nextjs`.
 - Use `--entry` for Bun, or whenever detection needs a hand.
 
 ## Environment variables

--- a/apps/docs/content/docs/compute/limitations.mdx
+++ b/apps/docs/content/docs/compute/limitations.mdx
@@ -11,8 +11,8 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). 
 ## CLI
 
 - The package is `@prisma/cli`; the executable is `prisma-cli`. The quickest way to run it is `npx @prisma/cli@latest <command>` (or `bunx`/`pnpm dlx`), with Node.js 22.12 or newer for `npx` and `pnpm`.
-- The command groups are `auth`, `project`, `project env`, `git`, `branch`, `database`, `app`, and `version`. There is no `init`, `schema`, or `migrate` command, and no product-branded `compute` namespace.
-- Project and app resolution never reads or writes committed config files. `.prisma/local.json` is a gitignored local pin, and `PRISMA_PROJECT_ID` / `PRISMA_APP_ID` override it for CI.
+- The command groups are `version`, `init`, `agent`, `auth`, `project` (including `project env`), `git`, `branch`, `build`, `database`, and `app`. There is no `schema` or `migrate` command, and no product-branded `compute` namespace.
+- Committed configuration lives in [`prisma.compute.ts`](/compute/configuration) (or `prisma.compute.json`). `.prisma/local.json` is a gitignored local pin of the workspace and project, and `PRISMA_PROJECT_ID` / `PRISMA_APP_ID` override it for CI.
 
 ## Projects and branches
 
@@ -23,8 +23,8 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). 
 
 ## Frameworks and runtimes
 
-- `app deploy --framework` accepts `nextjs`, `nuxt`, `astro`, `hono`, `tanstack-start`, and `bun`.
-- `app build --build-type` accepts `auto`, `bun`, `nextjs`, `nuxt`, `astro`, and `tanstack-start`.
+- `app deploy --framework` accepts `nextjs`, `nuxt`, `astro`, `hono`, `nestjs`, `tanstack-start`, `custom`, and `bun`.
+- `app build --build-type` accepts `auto`, `nextjs`, `nuxt`, `astro`, `nestjs`, `tanstack-start`, `custom`, and `bun`.
 - `app run --build-type` accepts `auto`, `bun`, and `nextjs`.
 - Use `--entry` for Bun, or whenever detection needs a hand.
 
@@ -39,12 +39,12 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). 
 ## GitHub
 
 - GitHub is the only supported provider, and a project connects to one repository.
-- Auto-deploy is single-app; use CI with a service token for monorepos.
+- Auto-deploy supports multiple apps declared in `prisma.compute.ts`: one push build fans out into a targeted build per app. CI with a service token remains available when you need full control.
 - The webhook path is branch- and push-driven. There are no PR comments or PR status automation.
 
 ## Domains
 
-- Custom domains are production-only and CNAME-based.
+- Custom domains are production-only and CNAME-based: they attach to the default (production) branch, and the app needs a promoted deployment first.
 - Up to 3 custom domains per app.
 - There is no workspace-wide domain list in the CLI.
 
@@ -56,8 +56,8 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). 
 
 ## Runtime
 
-- This release focuses on HTTP apps. WebSockets, cron or background jobs, a persistent filesystem, and edge runtimes are not part of it.
-- No multi-region deployments.
+- This release focuses on HTTP apps. Background work between requests is supported through the `@prisma/compute` keep-awake primitives; see [Keeping instances awake](/compute/keeping-instances-awake). Cron scheduling, a persistent filesystem, and edge runtimes are not part of it.
+- No multi-region deployments. Each app lives in one region, chosen at creation with `app deploy --region`: `us-east-1` (the default), `us-west-1`, `eu-west-3`, `eu-central-1`, `ap-northeast-1`, or `ap-southeast-1`.
 - Not yet recommended for mission-critical or heavy production workloads.
 - Exact limits, pricing, retention policies, and runtime guardrails can still change before general availability.
 

--- a/apps/docs/content/docs/compute/pricing.mdx
+++ b/apps/docs/content/docs/compute/pricing.mdx
@@ -107,7 +107,7 @@ A preview branch only costs money when it does work, such as serving traffic or 
 
 ## Usage data for humans and agents
 
-The usage data shown in the [Console](https://pris.ly/pdp) is also available from the [CLI](/compute/cli-reference) and API, including as JSON. An agent can read it to estimate a cost, explain a change, or suggest a fix.
+Database usage is available from the [CLI](/compute/cli-reference) (`database usage`) and API, including as JSON, and an agent can read it to estimate a cost, explain a change, or suggest a fix. Equivalent Compute usage surfaces are still taking shape during the beta.
 
 ## Beta and bandwidth
 


### PR DESCRIPTION
## Summary

Audited every Compute doc page against current product behavior (CLI, config schema, and platform) and fixed the drift. Each change reflects verified, user-observable behavior; claims that couldn't be verified (e.g. pricing rates) were left untouched.

## Wrong claims fixed

- **Promote doesn't rebuild** (`deployments.mdx`, `cli-reference.mdx`): promote and rollback both switch the live endpoint between existing deployments (starting a stopped one first). Env vars are baked in at deployment creation — there is no rebuild with production env vars.
- **`init` exists** (`cli-reference.mdx`, `limitations.mdx`): removed the stale "no `init` command" claim; documented the `init`, `agent`, `build`, and `database` command groups (the last was named but never documented).
- **Custom domain flow was backwards** (`domains.mdx`): `domain add` verifies DNS up front and fails with `DOMAIN_DNS_NOT_CONFIGURED` until the CNAME is visible — reordered the steps (CNAME first, re-run `add`), listed only the statuses users actually see, fixed the region example and the record-name example (full hostname), documented the `--timeout 0` exit-code gotcha.
- **Monorepo auto-deploy is no longer single-app** (`github.mdx`, `limitations.mdx`): one push build fans out into a targeted build per app declared in `prisma.compute.ts`. A "Prisma Compute Deploy" check run is posted best-effort per webhook deployment. Non-interactive `git connect` exits with `REPO_INSTALLATION_REQUIRED` (install URL in the payload) rather than returning a URL.
- **Next.js `output: "standalone"` note simplified** (`getting-started.mdx`, `deploy.mdx`): dropped the inaccurate "fails the build if it's missing" claim.
- **Logs**: `app logs` streams runtime logs only; stream failures surface as `DEPLOY_FAILED` (not `FEATURE_UNAVAILABLE`); platform build logs come from `build logs <buildId>`.
- **Branch databases are opt-in** (`index.mdx`, `deploy.mdx`): a branch *can have* its own database; databases aren't provisioned automatically per branch.
- **Config**: removed the stale "a `build` block with nuxt/astro is a configuration error" rule — `build` now applies to every framework.

## Missing surface documented

- Frameworks `nestjs` and `custom` in every list (5 files)
- `prisma.compute.json` as a valid config file; `region` (per-app + top-level, six regions); `build.entrypoint`; `bun.lockb` workspace marker
- `app deploy` flags: `--region`, `--no-promote`, `[app]` positional; `--env` accepts dotenv files
- `project env`: `--file` dotenv import, `--project` flag, bare-`KEY` form on `update`, 256-char key cap
- Domains: wildcard hostnames rejected, apex CNAME caveat, idempotent re-add, `DOMAIN_VERIFICATION_TIMEOUT` error code
- Keep-awake: `waitUntil` signature corrected to `PromiseLike<unknown>`; `limitations.mdx` no longer contradicts the keep-awake doc on background work

## Needs a human eye

- `pricing.mdx`: scoped the "usage data via CLI/API" claim to database usage, since equivalent Compute usage surfaces aren't available yet. Pricing rates were left as-is.

## Verification

- `pnpm lint:links`: 0 errors (631 files)
