### PR TITLE
fix(docs): add ANAME to cspell dictionary

### DIFF
--- a/apps/docs/cspell.json
+++ b/apps/docs/cspell.json
@@ -10,6 +10,7 @@
     "amcheck",
     "amet",
     "Amplication",
+    "ANAME",
     "Ania",
     "anotherproduct",
     "apbkobhfnmcqqzqeeqss",


### PR DESCRIPTION
Fixes the Spellcheck failure on main introduced by #8067: the apex-domain note in `compute/domains.mdx` uses the DNS record type **ANAME**, which wasn't in the dictionary. Verified locally: 766 files checked, 0 issues.