### PR TITLE
Clarify Compute keep-awake and WebSocket limitations

### DIFF
--- a/apps/docs/content/docs/compute/keeping-instances-awake.mdx
+++ b/apps/docs/content/docs/compute/keeping-instances-awake.mdx
@@ -1,25 +1,32 @@
 ---
 title: Keeping instances awake
-description: "Keep a Prisma Compute instance awake so it does not scale to zero while you run background work, long-running jobs, or WebSocket connections."
+description: "Keep a Prisma Compute instance awake so it does not scale to zero while bounded background work completes."
 url: /compute/keeping-instances-awake
 metaTitle: "Keeping instances awake | Prisma Compute"
-metaDescription: Keep a Prisma Compute instance awake and prevent scale-to-zero while you run background work, long-running jobs, or WebSocket connections with waitUntil and KeepAwakeGuard from @prisma/compute.
+metaDescription: Keep a Prisma Compute instance awake while bounded background work completes using waitUntil and KeepAwakeGuard from @prisma/compute.
 ---
 
-By default, Prisma Compute [scales idle instances to zero](/compute/pricing) to save cost: idle instances sleep with a memory snapshot, then resume with memory intact in milliseconds. Some workloads need the instance to keep running instead. Long-running jobs, background processing, and open WebSocket connections all need the instance awake after a request ends or while no request is in flight.
+By default, Prisma Compute [scales idle instances to zero](/compute/pricing) to save cost: idle instances sleep with a memory snapshot, then resume with memory intact in milliseconds. Some bounded background work needs the instance to keep running after a request ends or while no request is in flight.
 
 `@prisma/compute` provides two primitives for these cases:
 
 - `waitUntil`: keeps the current instance awake until a background promise settles.
 - `KeepAwakeGuard`: keeps the current instance awake until you release the guard.
 
+:::warning
+
+These primitives are for best-effort background work. They only prevent the current instance from scaling to zero; they do not make work durable, retry failures, guarantee that work continues through restarts or deployments, or change connection-lifetime limits. Persist progress and design work so it can safely restart.
+
+WebSocket servers are not currently a supported Public Beta capability.
+
+:::
+
 ## When to keep instances awake
 
-Reach for `waitUntil` or `KeepAwakeGuard` when your app must keep running between requests, for example:
+Reach for `waitUntil` or `KeepAwakeGuard` for bounded, best-effort work between requests, for example:
 
-- A long-running job that outlives the request that started it.
+- A bounded job that outlives the request that started it.
 - Background processing you kick off after returning a response.
-- A WebSocket connection that must stay open.
 
 If your work always finishes inside a single request, you do not need either primitive. Let the instance sleep as usual.
 

--- a/apps/docs/content/docs/compute/limitations.mdx
+++ b/apps/docs/content/docs/compute/limitations.mdx
@@ -56,6 +56,7 @@ Prisma Compute is in [Public Beta](/console/more/feature-maturity#public-beta). 
 ## Runtime
 
 - This release focuses on HTTP apps. Background work between requests is supported through the `@prisma/compute` keep-awake primitives; see [Keeping instances awake](/compute/keeping-instances-awake). Cron scheduling, a persistent filesystem, and edge runtimes are not part of it.
+- WebSocket servers are not currently a supported Public Beta capability. `waitUntil` and `KeepAwakeGuard` only prevent an instance from scaling to zero; they do not change connection-lifetime limits or guarantee continuity through restarts or deployments.
 - No multi-region deployments. Each app lives in one region, chosen at creation with `app deploy --region`: `us-east-1` (the default), `us-west-1`, `eu-west-3`, `eu-central-1`, `ap-northeast-1`, or `ap-southeast-1`.
 - Not yet recommended for mission-critical or heavy production workloads.
 - Exact limits, pricing, retention policies, and runtime guardrails can still change before general availability.


### PR DESCRIPTION
## Overview

Clarifies that Compute keep-awake primitives prevent scale-to-zero but do not provide durable execution or supported WebSocket lifecycle guarantees. This aligns the keep-awake and limitations pages with the current Public Beta scope.

Tracked in [DR-8760](https://linear.app/prisma-company/issue/DR-8760/clarify-compute-keep-awake-and-websocket-limitations-in-docs). Related to [PRS-185](https://linear.app/prisma-company/issue/PRS-185/support-websocket-connections-for-compute-apps).

## Changes

- Reframes keep-awake use cases as bounded, best-effort background work and removes WebSocket claims from metadata and examples.
- Adds a prominent warning covering durability, retries, restarts, deployments, and connection-lifetime boundaries.
- Documents WebSocket servers as unsupported in Public Beta on both relevant pages without publishing an unverified duration limit.

## Why

`waitUntil` and `KeepAwakeGuard` control scale-to-zero only. Stating that boundary next to the APIs avoids implying durable job execution or connection continuity while preserving the existing API signatures and examples.

## Verification

- `pnpm --filter docs exec cspell content/docs/compute/keeping-instances-awake.mdx content/docs/compute/limitations.mdx --show-context`
- `pnpm --filter docs types:check`
- `pnpm --filter docs lint:links`
- `pnpm --filter docs test:llm-markdown`
- `git diff --check`

Visual verification was attempted with the docs-only dev server and the documented webpack fallback. Both were blocked by an unrelated existing docs app compile failure (`Sidebar*` exports missing, followed by `ERR_STRING_TOO_LONG`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that keeping instances awake applies to bounded background work completed after requests or between requests.
  * Added a warning that WebSocket servers are not currently supported.
  * Documented that `waitUntil` and `KeepAwakeGuard` do not extend connection limits or preserve connections across restarts and deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->