### PR TITLE
Remove gtag url_passthrough to stop _gl link decoration

### DIFF
--- a/packages/ui/src/components/google-tag-manager.tsx
+++ b/packages/ui/src/components/google-tag-manager.tsx
@@ -22,7 +22,6 @@ gtag('consent', 'default', {
   wait_for_update: 2000
 });
 gtag('set', 'ads_data_redaction', true);
-gtag('set', 'url_passthrough', true);
 window.dataLayer.push({ site_section: ${JSON.stringify(section)} });
 
 // Bridge CookieYes consent


### PR DESCRIPTION
## Problem

Internal links on prisma.io get decorated with an enormous `_gl` query parameter for any visitor who hasn't accepted analytics cookies:

```
https://www.prisma.io/blog/image-transformations-with-bun-on-prisma-compute?_gl=1*kytdm6*_up*MQ..*_ga*NjM5NjE2NTEuMTc4NDE4MTYzMA..*_ga_4B72WBX9ET*czE3ODQxODE2MjkkbzEkZzEkdDE3ODQxODE2ODIkajckbDAkaDA.
```

That parameter is base64-encoded GA cookie state (client ID + session state). It comes from `gtag('set', 'url_passthrough', true)` in our Consent Mode v2 bootstrap (#7965): with `analytics_storage` denied by default, gtag carries GA state through URLs instead of cookies — on every internal link, for every unconsented visitor. These URLs end up in shared links and bookmarks, fragment `$current_url` in PostHog and page reports in Search Console, and vary CDN cache keys.

## Fix

Remove the `url_passthrough` line from the shared `GoogleTagManager` component (used by site, blog, and docs). The feature's main purpose is preserving Google Ads click IDs (`gclid`) without cookies, and we run no Google Ads. The only measurement cost: unconsented visitors' pageviews are no longer stitched into sessions in GA4 (consent-mode cookieless pings still fire; consented visitors are unaffected).

Consent defaults, the CookieYes bridge, and `ads_data_redaction` are untouched.

## Verification

On a local dev server with the real GTM container (`GTM-KRTRXXQ6`) and GA4 tag (`G-4B72WBX9ET`) loading:

- Rendered pages no longer contain `url_passthrough`; the bootstrap executes without console errors
- The GA4 tag still fires its cookieless consent-mode ping under denied consent
- Clicking internal links lands on clean URLs with no `_gl` parameter
- Fetched the public container JS and confirmed no Conversion Linker enables URL passthrough on the GTM side — this inline line was the sole source

Note: cross-domain `_gl` decoration toward domains configured in GA4 Admin (e.g. console.prisma.io) is separate and intentionally unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Google Tag Manager initialization to stop enabling URL passthrough while preserving existing consent settings and consent integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->