### PR TITLE
Dedupe blog search results so a post appears only once

### DIFF
--- a/apps/blog/src/app/api/search/route.ts
+++ b/apps/blog/src/app/api/search/route.ts
@@ -27,7 +27,12 @@ export const { GET } = createMixedbreadSearchAPI({
   storeIdentifier: "blog-search",
   topK: 20,
   transform: (results, _query) => {
+    // Mixedbread returns chunk-level matches; keep only the highest-scoring
+    // chunk per file so a post never appears more than once.
+    const seenFiles = new Set<string>();
     return results.flatMap((item) => {
+      if (seenFiles.has(item.file_id)) return [];
+      seenFiles.add(item.file_id);
       const metadata = item.generated_metadata as unknown as GeneratedMetadata;
       const slug = (metadata?.slug ?? "").replace(/^\/+/, "");
       const title = metadata?.metaTitle ?? metadata?.title ?? "Untitled";


### PR DESCRIPTION
## Problem

Searching the blog shows the same post multiple times. For example, searching "Neon" returns **Prisma Postgres vs Neon Pricing 2026** four times:

The blog search is backed by a Mixedbread vector store, which searches at the **chunk level**. The route's `transform` mapped every matching chunk to its own `page` result (keyed by `file_id`-`chunk_index`), so any post matching the query in several chunks rendered as several identical cards. Live evidence: `/blog/api/search?query=Neon` returned the same `file_id` with chunk indices 0, 1, 2, and 3 as four separate results.

The more relevant a post is to a query, the more chunks match, and the more it duplicates. The duplicates also crowd out other posts inside the `topK: 20` window.

## Fix

Track seen `file_id`s in the transform and skip chunks from files already emitted. Results arrive in score order, so each post keeps its best-ranked position and appears exactly once. Query-time only, no reindexing of the store needed.

## Verification

No `MIXEDBREAD_API_KEY` is available locally, so I replayed the exact live chunk sequence for "Neon" (4 chunks of the pricing post interleaved with 2 other posts) through the real route `GET` handler with only the SDK network call stubbed:

- **Before**: 7 results, pricing post duplicated 4 times (reproduces production behavior)
- **After**: 3 results, one per post, pricing post still ranked first

`types:check` (tsc) passes; oxlint reports 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now show only one result per file or blog post.
  * Removed duplicate entries caused by multiple matches within the same file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->