### PR TITLE
Persist signup attribution across prisma.io

### DIFF
--- a/apps/blog/src/components/utm-persistence.tsx
+++ b/apps/blog/src/components/utm-persistence.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { UtmPersistence as SharedUtmPersistence } from "@prisma-docs/ui/components/utm-persistence";
+import { UTM_ATTRIBUTION_STORAGE_KEY } from "@prisma-docs/ui/lib/utm";
 
 export function UtmPersistence() {
-  return <SharedUtmPersistence storageKey="blog_utm_params" basePath="/blog" />;
+  return <SharedUtmPersistence storageKey={UTM_ATTRIBUTION_STORAGE_KEY} basePath="/blog" />;
 }

--- a/apps/docs/src/components/utm-persistence.tsx
+++ b/apps/docs/src/components/utm-persistence.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { UtmPersistence as SharedUtmPersistence } from "@prisma-docs/ui/components/utm-persistence";
+import { UTM_ATTRIBUTION_STORAGE_KEY } from "@prisma-docs/ui/lib/utm";
 
 export function UtmPersistence() {
-  return <SharedUtmPersistence storageKey="docs_utm_params" basePath="/docs" />;
+  return <SharedUtmPersistence storageKey={UTM_ATTRIBUTION_STORAGE_KEY} basePath="/docs" />;
 }

--- a/apps/site/src/components/utm-persistence.tsx
+++ b/apps/site/src/components/utm-persistence.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { UtmPersistence as SharedUtmPersistence } from "@prisma-docs/ui/components/utm-persistence";
+import { UTM_ATTRIBUTION_STORAGE_KEY } from "@prisma-docs/ui/lib/utm";
 
 const PROXIED_PATHS = ["/docs", "/blog"];
 
 export function UtmPersistence() {
-  return <SharedUtmPersistence storageKey="site_utm_params" proxiedPaths={PROXIED_PATHS} />;
+  return (
+    <SharedUtmPersistence storageKey={UTM_ATTRIBUTION_STORAGE_KEY} proxiedPaths={PROXIED_PATHS} />
+  );
 }

--- a/packages/ui/src/components/utm-persistence.tsx
+++ b/packages/ui/src/components/utm-persistence.tsx
@@ -3,12 +3,12 @@
 import { useEffect } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import {
-  clearStoredUtmParams,
   CONSOLE_HOST,
   getUtmParams,
-  hasUtmParams,
-  syncUtmParams,
-  writeStoredUtmParams,
+  mergeUtmAttribution,
+  readStoredUtmAttribution,
+  syncUtmAttribution,
+  writeStoredUtmAttribution,
 } from "../lib/utm";
 
 interface UtmPersistenceProps {
@@ -24,8 +24,19 @@ interface UtmPersistenceProps {
    * Only relevant for the root app (no basePath).
    */
   proxiedPaths?: string[];
-  /** Session storage key for persisting UTM params. */
+  /** Local storage key for persisting first- and last-touch UTM params. */
   storageKey: string;
+}
+
+function getActiveAttribution(storageKey: string) {
+  const currentUtmParams = getUtmParams(new URLSearchParams(window.location.search));
+  const attribution = mergeUtmAttribution(readStoredUtmAttribution(storageKey), currentUtmParams);
+
+  if (attribution && Object.keys(currentUtmParams).length > 0) {
+    writeStoredUtmAttribution(storageKey, attribution);
+  }
+
+  return attribution;
 }
 
 export function UtmPersistence({ basePath, proxiedPaths = [], storageKey }: UtmPersistenceProps) {
@@ -33,14 +44,7 @@ export function UtmPersistence({ basePath, proxiedPaths = [], storageKey }: UtmP
   const router = useRouter();
 
   useEffect(() => {
-    const currentUtmParams = getUtmParams(new URLSearchParams(window.location.search));
-
-    if (hasUtmParams(currentUtmParams)) {
-      writeStoredUtmParams(storageKey, currentUtmParams);
-      return;
-    }
-
-    clearStoredUtmParams(storageKey);
+    getActiveAttribution(storageKey);
   }, [pathname, storageKey]);
 
   useEffect(() => {
@@ -67,21 +71,26 @@ export function UtmPersistence({ basePath, proxiedPaths = [], storageKey }: UtmP
         return;
       }
 
-      const activeUtmParams = getUtmParams(new URLSearchParams(window.location.search));
-
-      if (!hasUtmParams(activeUtmParams)) {
+      const attribution = getActiveAttribution(storageKey);
+      if (!attribution) {
         return;
       }
 
       const targetUrl = new URL(anchor.href, window.location.href);
       const isInternalLink = targetUrl.origin === window.location.origin;
       const isConsoleLink = targetUrl.hostname === CONSOLE_HOST;
+      const isConsoleRedirect =
+        isInternalLink && (targetUrl.pathname === "/login" || targetUrl.pathname === "/sign-up");
 
       if (!isInternalLink && !isConsoleLink) {
         return;
       }
 
-      if (!syncUtmParams(targetUrl, activeUtmParams)) {
+      if (
+        !syncUtmAttribution(targetUrl, attribution, {
+          includeFirstTouch: isConsoleLink || isConsoleRedirect,
+        })
+      ) {
         return;
       }
 
@@ -115,7 +124,7 @@ export function UtmPersistence({ basePath, proxiedPaths = [], storageKey }: UtmP
 
     document.addEventListener("click", handleClick, true);
     return () => document.removeEventListener("click", handleClick, true);
-  }, [router, basePath, proxiedPaths]);
+  }, [router, basePath, proxiedPaths, storageKey]);
 
   return null;
 }

--- a/packages/ui/src/lib/utm.test.ts
+++ b/packages/ui/src/lib/utm.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+// @ts-expect-error Node's TypeScript test runner requires the explicit extension.
+import { mergeUtmAttribution, syncUtmAttribution, syncUtmParams } from "./utm.ts";
+
+test("preserves first touch and replaces last touch", () => {
+  const firstVisit = mergeUtmAttribution(undefined, {
+    utm_source: "x",
+    utm_campaign: "rebrand-launch",
+  });
+  const laterVisit = mergeUtmAttribution(firstVisit, {
+    utm_source: "chatgpt",
+    utm_medium: "referral",
+  });
+
+  assert.deepEqual(laterVisit, {
+    first: {
+      utm_source: "x",
+      utm_campaign: "rebrand-launch",
+    },
+    last: {
+      utm_source: "chatgpt",
+      utm_medium: "referral",
+    },
+  });
+});
+
+test("keeps attribution through an untagged page transition", () => {
+  const attribution = {
+    first: { utm_source: "x" },
+    last: { utm_source: "chatgpt" },
+  };
+
+  assert.deepEqual(mergeUtmAttribution(attribution, {}), attribution);
+});
+
+test("adds immutable first touch and rolling last touch to Console links", () => {
+  const url = new URL("https://console.prisma.io/sign-up?utm_source=website&utm_medium=pricing");
+
+  syncUtmAttribution(
+    url,
+    {
+      first: {
+        utm_source: "x",
+        utm_campaign: "rebrand-launch",
+        ref: "launch-link",
+      },
+      last: {
+        utm_source: "chatgpt",
+        utm_medium: "referral",
+      },
+    },
+    { includeFirstTouch: true },
+  );
+
+  assert.equal(url.searchParams.get("first_utm_source"), "x");
+  assert.equal(url.searchParams.get("first_utm_campaign"), "rebrand-launch");
+  assert.equal(url.searchParams.get("first_ref"), "launch-link");
+  assert.equal(url.searchParams.get("utm_source"), "chatgpt");
+  assert.equal(url.searchParams.get("utm_medium"), "referral");
+  assert.equal(url.searchParams.has("utm_campaign"), false);
+});
+
+test("does not add first-touch parameters to ordinary internal links", () => {
+  const url = new URL("https://www.prisma.io/pricing");
+
+  syncUtmAttribution(url, {
+    first: { utm_source: "x" },
+    last: { utm_source: "chatgpt" },
+  });
+
+  assert.equal(url.searchParams.get("utm_source"), "chatgpt");
+  assert.equal(url.searchParams.has("first_utm_source"), false);
+});
+
+test("removes stale UTM parameters when forwarding a newer touch", () => {
+  const url = new URL("https://console.prisma.io/login?utm_source=website&utm_campaign=login");
+
+  syncUtmParams(url, { utm_source: "rebrand-test" });
+
+  assert.equal(url.searchParams.get("utm_source"), "rebrand-test");
+  assert.equal(url.searchParams.has("utm_campaign"), false);
+});

--- a/packages/ui/src/lib/utm.ts
+++ b/packages/ui/src/lib/utm.ts
@@ -1,6 +1,15 @@
 export const CONSOLE_HOST = "console.prisma.io";
+export const UTM_ATTRIBUTION_STORAGE_KEY = "prisma_utm_attribution";
 
 export type UtmParams = Record<string, string>;
+export interface UtmAttribution {
+  first: UtmParams;
+  last: UtmParams;
+}
+
+function isAttributionKey(key: string) {
+  return key.startsWith("utm_") || key === "ref";
+}
 
 function sanitizeUtmParams(input: unknown): UtmParams {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
@@ -9,7 +18,7 @@ function sanitizeUtmParams(input: unknown): UtmParams {
 
   return Object.fromEntries(
     Object.entries(input).filter(
-      ([key, value]) => key.startsWith("utm_") && typeof value === "string" && value.length > 0,
+      ([key, value]) => isAttributionKey(key) && typeof value === "string" && value.length > 0,
     ),
   );
 }
@@ -18,7 +27,7 @@ export function getUtmParams(searchParams: URLSearchParams): UtmParams {
   const utmParams: UtmParams = {};
 
   for (const [key, value] of searchParams.entries()) {
-    if (key.startsWith("utm_") && value) {
+    if (isAttributionKey(key) && value) {
       utmParams[key] = value;
     }
   }
@@ -30,11 +39,40 @@ export function hasUtmParams(utmParams: UtmParams) {
   return Object.keys(utmParams).length > 0;
 }
 
+function sanitizeUtmAttribution(input: unknown): UtmAttribution | undefined {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return undefined;
+  }
+
+  const candidate = input as Partial<UtmAttribution>;
+  const first = sanitizeUtmParams(candidate.first);
+  const last = sanitizeUtmParams(candidate.last);
+
+  return hasUtmParams(first) && hasUtmParams(last) ? { first, last } : undefined;
+}
+
+export function mergeUtmAttribution(
+  existing: UtmAttribution | undefined,
+  latest: UtmParams,
+): UtmAttribution | undefined {
+  const validExisting = sanitizeUtmAttribution(existing);
+  const validLatest = sanitizeUtmParams(latest);
+
+  if (!hasUtmParams(validLatest)) {
+    return validExisting;
+  }
+
+  return {
+    first: validExisting?.first ?? validLatest,
+    last: validLatest,
+  };
+}
+
 export function syncUtmParams(url: URL, utmParams: UtmParams) {
   let updated = false;
 
   for (const key of Array.from(url.searchParams.keys())) {
-    if (key.startsWith("utm_") && !(key in utmParams)) {
+    if (isAttributionKey(key) && !(key in utmParams)) {
       url.searchParams.delete(key);
       updated = true;
     }
@@ -50,49 +88,69 @@ export function syncUtmParams(url: URL, utmParams: UtmParams) {
   return updated;
 }
 
-export function readStoredUtmParams(storageKey: string) {
+export function syncUtmAttribution(
+  url: URL,
+  attribution: UtmAttribution,
+  options: { includeFirstTouch?: boolean } = {},
+) {
+  let updated = syncUtmParams(url, attribution.last);
+
+  if (!options.includeFirstTouch) {
+    return updated;
+  }
+
+  const firstTouchParams = Object.fromEntries(
+    Object.entries(attribution.first).map(([key, value]) => [`first_${key}`, value]),
+  );
+
+  for (const key of Array.from(url.searchParams.keys())) {
+    if ((key.startsWith("first_utm_") || key === "first_ref") && !(key in firstTouchParams)) {
+      url.searchParams.delete(key);
+      updated = true;
+    }
+  }
+
+  for (const [key, value] of Object.entries(firstTouchParams)) {
+    if (url.searchParams.get(key) !== value) {
+      url.searchParams.set(key, value);
+      updated = true;
+    }
+  }
+
+  return updated;
+}
+
+export function readStoredUtmAttribution(storageKey: string) {
   if (typeof window === "undefined") {
-    return {};
+    return undefined;
   }
 
   try {
-    const storedUtmParams = window.sessionStorage.getItem(storageKey);
+    const storedAttribution = window.localStorage.getItem(storageKey);
 
-    if (!storedUtmParams) {
-      return {};
+    if (!storedAttribution) {
+      return undefined;
     }
 
-    return sanitizeUtmParams(JSON.parse(storedUtmParams));
+    return sanitizeUtmAttribution(JSON.parse(storedAttribution));
   } catch {
-    return {};
+    return undefined;
   }
 }
 
-export function writeStoredUtmParams(storageKey: string, utmParams: UtmParams) {
+export function writeStoredUtmAttribution(storageKey: string, attribution: UtmAttribution) {
   if (typeof window === "undefined") {
     return;
   }
 
-  const validUtmParams = sanitizeUtmParams(utmParams);
+  const validAttribution = sanitizeUtmAttribution(attribution);
 
-  if (!hasUtmParams(validUtmParams)) {
+  if (!validAttribution) {
     return;
   }
 
   try {
-    window.sessionStorage.setItem(storageKey, JSON.stringify(validUtmParams));
-  } catch {
-    // Ignore storage failures in restricted environments.
-  }
-}
-
-export function clearStoredUtmParams(storageKey: string) {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  try {
-    window.sessionStorage.removeItem(storageKey);
+    window.localStorage.setItem(storageKey, JSON.stringify(validAttribution));
   } catch {
     // Ignore storage failures in restricted environments.
   }


### PR DESCRIPTION
## What

- persist immutable first-touch and rolling last-touch UTM/ref attribution across prisma.io, blog, and docs
- keep attribution through untagged page transitions
- forward last-touch as standard `utm_*` and first-touch as `first_utm_*` when entering Console
- cover later campaign visits, untagged navigation, and Console handoff with unit tests

## Why

This is the marketing-side companion to prisma/pdp-control-plane#4689. Together they preserve campaign attribution from the first prisma.io landing through email or OAuth signup and the server-side PostHog event.

## Validation

- `node --test packages/ui/src/lib/utm.test.ts`
- site, blog, and docs type checks
- formatter and linter on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved campaign attribution persistence across the site, documentation, and blog.
  - Preserves both first-touch and most recent campaign information for more reliable attribution.
  - Carries relevant attribution details across internal navigation and selected login or sign-up links.
  - Supports referral parameters alongside standard UTM campaign parameters.

- **Bug Fixes**
  - Prevents attribution from being lost when visitors move between tagged and untagged pages.
  - Avoids carrying first-touch campaign details to ordinary internal links unnecessarily.

- **Tests**
  - Added coverage for attribution merging, persistence, URL forwarding, and stale campaign cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->