### PR TITLE
docs(site): remove the Prisma Postgres section from the 2026-07-24 changelog

### DIFF
--- a/apps/site/content/changelog/2026-07-24.mdx
+++ b/apps/site/content/changelog/2026-07-24.mdx
@@ -6,7 +6,6 @@ slug: "2026-07-24"
 headline: "Store files with Object Store buckets and see your workspace at a glance"
 tags:
   - "Prisma"
-  - "Prisma Postgres"
   - "Prisma Compute"
   - "Prisma Next"
 canonical: "/changelog#log2026-07-24"
@@ -72,12 +71,6 @@ App detection moved into the public SDK, and app URLs are now correct before you
 - **New** · The Prisma Compute SDK can inspect a repository without cloning it: `detectComputeApp` reads a repository snapshot and reports the app's framework, build type, HTTP port, and entrypoint. Elysia, Express, and Fastify apps are recognized and run on Bun. Available since `@prisma/compute-sdk` 0.37.0.
 - **Improved** · The GitHub repository picker in the Prisma Console loads repositories page by page, so installations with more than 100 repositories can reach all of them, and switching accounts mid-load no longer briefly shows the wrong account's list.
 - **Fixed** · The app URL returned before your first deployment now names the domain your app will actually serve on. Previously it could point at the wrong region and never resolve.
-
-## Prisma Postgres
-
-One reliability improvement for databases waking from idle.
-
-- **Improved** · Cold starts no longer run through a single per-region coordinator, so one degraded coordinator cannot block databases from waking across its region.
 
 ## Prisma docs
 


### PR DESCRIPTION
## What

Follow-up to #8107: removes the **Prisma Postgres** section from the published [2026-07-24 changelog entry](https://www.prisma.io/changelog/2026-07-24#prisma-postgres) and drops the matching `Prisma Postgres` frontmatter tag.

Removed item:

> **Improved** · Cold starts no longer run through a single per-region coordinator, so one degraded coordinator cannot block databases from waking across its region.

## Why

The item describes internal infrastructure topology (the per-region coordinator) rather than a user-actionable change, and it was sourced from a private repo with no public citation.

The passing mention of Prisma Postgres in the Object Store highlight is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the July 24, 2026 changelog by removing the Prisma Postgres tag and its related “Cold starts” reliability entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->