### PR TITLE
docs: fix spellcheck failures from the MongoDB migration guide

### DIFF
--- a/apps/docs/content/docs/guides/next/upgrade-prisma-orm/mongodb.mdx
+++ b/apps/docs/content/docs/guides/next/upgrade-prisma-orm/mongodb.mdx
@@ -42,7 +42,7 @@ Scaffold the project:
 npx prisma-next init --yes --target mongodb --authoring psl
 ```
 
-`init` writes a `prisma-next.config.ts` at the repo root. MongoDB is selected by importing the `@prisma-next/mongo` façade, not by a `provider` string in the schema. Point the connection at the **same database** your v6 app uses.
+`init` writes a `prisma-next.config.ts` at the repo root. MongoDB is selected by importing the `@prisma-next/mongo` facade, not by a `provider` string in the schema. Point the connection at the **same database** your v6 app uses.
 
 ```typescript tab="After"
 // prisma-next.config.ts

--- a/apps/docs/content/docs/guides/next/upgrade-prisma-orm/mongodb.mdx
+++ b/apps/docs/content/docs/guides/next/upgrade-prisma-orm/mongodb.mdx
@@ -73,7 +73,7 @@ Run `npx prisma-next contract emit` to generate `contract.json` from your `.pris
 
 ### Import the client
 
-The way to instantiate the Prisma client now is from the emitted contract:
+The way to instantiate the Prisma client now is from the emitted contract. Replace `my-app-db` with the database name your v6 connection string uses; if the connection URL already carries the database name in its path, omit `dbName` and the client reads it from the URL:
 
 ```typescript tab="After"
 // src/prisma/db.ts

--- a/apps/docs/cspell.json
+++ b/apps/docs/cspell.json
@@ -70,6 +70,7 @@
     "Ctype",
     "cursorrules",
     "cursorstream",
+    "cutover",
     "datadog",
     "datamodel",
     "DATAPROXY",


### PR DESCRIPTION
The Spellcheck workflow failed on main after #8111 merged: `cutover` (three occurrences, including two headings) and `façade` were unknown words.

- Add `cutover` to the cspell project dictionary in `apps/docs/cspell.json`. It is the standard term for this guide's production-switch step and the lowercase entry also covers the capitalized heading use.
- Replace `façade` with `facade` in the guide, which the default dictionary accepts.

`pnpm run lint:spellcheck` now passes locally across all 778 docs files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified MongoDB setup after `npx prisma-next init`, including that it creates `prisma-next.config.ts` at the repo root.
  * Updated guidance to enable MongoDB via importing `@prisma-next/mongo` and to match the same database used in the Prisma v6 connection.
  * Refined “Import the client” steps to use the v6 database name (and omit `dbName` when it’s already included in `DATABASE_URL`).
* **Chores**
  * Added “cutover” to the spell-check word list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->