### PR TITLE
docs: fix broken checklist rendering in the MongoDB migration guide

### DIFF
--- a/apps/docs/content/docs/guides/next/upgrade-prisma-orm/mongodb.mdx
+++ b/apps/docs/content/docs/guides/next/upgrade-prisma-orm/mongodb.mdx
@@ -428,16 +428,16 @@ npx prisma-next db verify --db "$DATABASE_URL"   # check the DB matches the cont
 
 Work through this list before you switch production traffic over:
 
-- [ ] **Same database.** Your Prisma Next config points at the **same** database and connection string as v6.
-- [ ] **Server version.** Your MongoDB server is on 8.0 or newer.
-- [ ] **Dry run first.** Rehearse the whole flow on a throwaway copy of your database (`contract emit`, `db update --dry-run`, `db update`, `db verify`) and make sure `db verify` passes before you touch production.
-- [ ] **Index parity.** The indexes on each collection (`db.collection.getIndexes()`) match your contract.
-- [ ] **Validators.** Your existing documents pass the strict validators Prisma Next adds to each collection (see *Good to know* in step 4).
-- [ ] **Addressing.** Every call site uses storage names like `db.orm.users`, not model names.
-- [ ] **Transactions.** Every v6 `$transaction` now has a driver-session equivalent.
-- [ ] **Raw calls.** Every `$runCommandRaw`, `findRaw`, and `aggregateRaw` has a pipeline-builder or `mongodb`-driver replacement.
-- [ ] **Read-only trial run.** Run Prisma Next read-only alongside your v6 app for a while and compare the results. This surfaces any differences while v6 is still handling all the writes.
-- [ ] **Cutover and rollback.** Switch writes over only once the trial run looks good, and keep the v6 branch deployable. Rolling back is just a code rollback since your data never moved.
+- **Same database.** Your Prisma Next config points at the **same** database and connection string as v6.
+- **Server version.** Your MongoDB server is on 8.0 or newer.
+- **Dry run first.** Rehearse the whole flow on a throwaway copy of your database (`contract emit`, `db update --dry-run`, `db update`, `db verify`) and make sure `db verify` passes before you touch production.
+- **Index parity.** The indexes on each collection (`db.collection.getIndexes()`) match your contract.
+- **Validators.** Your existing documents pass the strict validators Prisma Next adds to each collection (see *Good to know* in step 4).
+- **Addressing.** Every call site uses storage names like `db.orm.users`, not model names.
+- **Transactions.** Every v6 `$transaction` now has a driver-session equivalent.
+- **Raw calls.** Every `$runCommandRaw`, `findRaw`, and `aggregateRaw` has a pipeline-builder or `mongodb`-driver replacement.
+- **Read-only trial run.** Run Prisma Next read-only alongside your v6 app for a while and compare the results. This surfaces any differences while v6 is still handling all the writes.
+- **Cutover and rollback.** Switch writes over only once the trial run looks good, and keep the v6 branch deployable. Rolling back is just a code rollback since your data never moved.
 
 Don't delete the v6 client, schema, or dependencies until this checklist passes.
 


### PR DESCRIPTION
The pre-flight checklist in the MongoDB v6-to-Next migration guide used GitHub task-list syntax (`- [ ]`), which the docs renderer doesn't style: each checkbox rendered as an orphaned box floating above its bullet text (screenshot in the merged guide's step 5). The items already carry bold labels, so this converts them to plain bullets, matching the list style used elsewhere in the guide.

Follow-up to #8111/#8112. Note `ai/tutorials/linktree-clone.mdx` and `guides/upgrade-prisma-orm/v4.mdx` also use `- [ ]` and presumably render the same way; left untouched here to keep this scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the MongoDB production cutover checklist formatting for improved readability.
  * Checklist guidance and recommendations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->