### PR TITLE
docs(site): add changelog entry 2026-08-02

### DIFF
--- a/apps/site/content/changelog/2026-08-02.mdx
+++ b/apps/site/content/changelog/2026-08-02.mdx
@@ -1,0 +1,107 @@
+---
+title: "Author expression and partial indexes in Prisma 8 and import GitHub repositories to Prisma Compute"
+date: "2026-08-02"
+version: "2026-08-02"
+slug: "2026-08-02"
+headline: "Author expression and partial indexes in Prisma 8 and import GitHub repositories to Prisma Compute"
+tags:
+  - "Prisma"
+  - "Prisma 8"
+  - "Prisma Compute"
+  - "Prisma Postgres"
+  - "Prisma ORM"
+canonical: "/changelog#log2026-08-02"
+metaDescription: "Prisma 8 makes expression, partial, and unique indexes authorable in schema and TypeScript, Prisma Compute opens GitHub repository import to every workspace, and Prisma ORM stops wrapping single-statement writes in transactions."
+share:
+  active: true
+  content: "Look at this page: "
+---
+Prisma 8 can now author expression, partial, and unique indexes in both Prisma Schema Language and TypeScript, and `contract infer` reads indexes and row-level security policies from an existing database at full fidelity. The legacy `@db.*` attributes are removed in favor of storage types in type position.
+
+Prisma Compute now imports GitHub repositories in every workspace: connect a repository, review the generated setup pull request, and deploy, including apps that live in a subdirectory of a pnpm or yarn workspace.
+
+Prisma ORM no longer wraps single-statement `updateMany` and `createMany` calls in a transaction, which fixes both operations on driver adapters without transaction support. New guides cover agent-and-database safety, searchable encryption, Object Store buckets, and moving a local database to Prisma Postgres.
+
+## Highlights
+
+### New · Author expression, partial, and unique indexes in Prisma 8
+
+Indexes over expressions had to live as raw SQL outside the schema, invisible to the toolchain. Prisma 8 now accepts expression, partial (`where`), and unique indexes in both Prisma Schema Language and TypeScript, plans byte-exact DDL for them, and verifies the result. Renaming an index plans exactly one `ALTER INDEX … RENAME`; editing its expression plans the rebuild.
+
+```prisma
+model User {
+  id    Int    @id
+  email String
+
+  @@index(expression: "lower(email)", name: "users_email_lower", type: "btree")
+}
+```
+
+The same index in TypeScript is `constraints.index({ expression: "lower(email)", name: "users_email_lower", type: "btree" })`.
+
+> **Note:** Prisma 8 (previously announced as Prisma Next) is in Early Access. Scope and behavior may still change. This release also removes the `@db.*` attributes, listed under breaking changes below.
+
+Shipped in [prisma/prisma-next#1048](https://github.com/prisma/prisma-next/pull/1048).
+
+### New · Import a GitHub repository to Prisma Compute from any workspace
+
+Deploying an existing GitHub repository to Prisma Compute (Public Beta) was gated to selected workspaces. The import flow is now on for everyone: connect a repository from the Prisma Console and a setup pull request adds the app configuration; merging it provisions the app and starts the first deploy. While the setup pull request is open, the Prisma Console now shows that phase and the preview deploys from the setup branch, instead of reporting the repository as not connected.
+
+```json
+{ "app": { "name": "orders-api", "root": "backend", "framework": "bun" } }
+```
+
+The committed configuration names the directory to build, so an app in a subdirectory of a monorepo builds from the right root.
+
+### Docs · Follow one getting-started path through the Prisma stack
+
+The docs entry pages presented Prisma ORM, Prisma Postgres, and Prisma Compute as three unrelated first commands. The rebuilt landing pages now recommend one journey: scaffold with Prisma 8, store data in Prisma Postgres, and deploy on Prisma Compute. Every flow gets a quick path, a guided path, and a copyable agent prompt. Prisma 7, the current GA release, stays one click away and is labeled as such.
+
+Start at the [Prisma docs](https://www.prisma.io/docs). Shipped in [prisma/web#8106](https://github.com/prisma/web/pull/8106).
+
+## Prisma 8
+
+Prisma 8 pairs the new index authoring with full-fidelity inference from existing databases.
+
+- **Improved** · Prisma 8 `contract infer` now reads expression, partial, and unique indexes and row-level security policies (permissive and restrictive, as `@@rls` blocks) from an existing database. Inferring a database the toolchain has never seen, emitting the contract, and verifying it reports zero issues and plans zero operations. ([prisma/prisma-next#1052](https://github.com/prisma/prisma-next/pull/1052))
+
+## Breaking changes
+
+> **Breaking:** Prisma 8 no longer supports the `@db.*` native-type attributes; storage types are written in type position instead. To migrate, replace each `@db.*` attribute with its type-position constructor: `String @db.Uuid` becomes `Uuid`, and `String @db.VarChar(191)` becomes `VarChar(191)`. Each removed attribute produces a diagnostic naming its replacement. ([prisma/prisma-next#1054](https://github.com/prisma/prisma-next/pull/1054))
+
+## Fixes and improvements
+
+**Prisma Compute**
+
+- **Fixed** · Prisma Compute builds now install dependencies in the configured app directory and detect the package manager from the repository root, so apps in a subdirectory of a pnpm or yarn workspace deploy instead of failing on a missing `package.json` or an `EUNSUPPORTEDPROTOCOL` install error.
+- **Improved** · Prisma Compute addresses with no deployed app now show a branded not-found page naming the address, so an address awaiting its first deploy is distinguishable from a dead link.
+
+**Prisma Console**
+
+- **Fixed** · Prisma Console account deletion no longer fails for workspaces that ever connected a GitHub repository.
+- **Fixed** · The Prisma Console sidebar now truncates long resource names, shows the full name on hover, and scrolls vertically instead of overflowing.
+
+**Prisma Postgres**
+
+- **Fixed** · Prisma Postgres databases transferred between workspaces through the Vercel Marketplace no longer stay suspended under the previous workspace's plan limit, and their usage now counts against the new workspace.
+- **Fixed** · Vercel Marketplace flexible-billing invoices no longer fail on proration line items.
+
+**Management API**
+
+- **Improved** · `GET /v1/databases/{databaseId}/usage` is now rate limited, and rate-limited responses include retry guidance instead of failing without direction under burst traffic.
+
+**Prisma ORM**
+
+- **Fixed** · Prisma ORM `updateMany` and `createMany` no longer wrap their single SQL statement in a transaction, so both operations work on driver adapters without transaction support, such as the Neon HTTP adapter, and skip the extra `BEGIN`/`COMMIT` round trips. ([prisma/prisma-engines#5840](https://github.com/prisma/prisma-engines/pull/5840))
+
+## Guides and articles
+
+- [Don't Let Your AI Agent Delete Your Production Database](https://www.prisma.io/blog/stop-your-ai-agent-dropping-your-database): how coding agents end up dropping production data and the safeguards to put between an agent and your database.
+- [Search encrypted data with Prisma 8 and CipherStash](https://www.prisma.io/blog/search-encrypted-data-with-prisma-next-and-cipherstash): CipherStash's searchable encryption now works with Prisma, querying encrypted columns through expression indexes.
+- [Give Your Agent File Storage: Object Store Buckets](https://www.prisma.io/blog/object-store-buckets): the launch post for Object Store buckets, walking the full lifecycle from `POST /v1/buckets` to serving objects with an S3 client, as one runnable script.
+- [From Local Development to Production with Prisma Postgres](https://www.prisma.io/blog/from-local-to-production-with-prisma-postgres): a five-step checklist for moving an app from local Postgres to hosted Prisma Postgres, covering the pooled and direct connection split and migration replay.
+- [Migrate a MongoDB project from Prisma ORM v6 to Prisma 8](https://www.prisma.io/docs/guides/next/upgrade-prisma-orm/mongodb): setup, schema conversion, client API changes, queries, transactions, and raw operations, with a production cutover checklist.
+
+---
+
+*Need help applying these changes in production? [Prisma Enterprise Support](https://prisma.io/enterprise) can help with schema design, performance, security, and compliance.*

--- a/apps/site/content/changelog/2026-08-02.mdx
+++ b/apps/site/content/changelog/2026-08-02.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Author expression and partial indexes in Prisma 8 and import GitHub repositories to Prisma Compute"
+title: "Author expression and partial indexes in Prisma 8 and import any GitHub repository to Prisma Compute"
 date: "2026-08-02"
 version: "2026-08-02"
 slug: "2026-08-02"
-headline: "Author expression and partial indexes in Prisma 8 and import GitHub repositories to Prisma Compute"
+headline: "Author expression and partial indexes in Prisma 8 and import any GitHub repository to Prisma Compute"
 tags:
   - "Prisma"
   - "Prisma 8"
@@ -16,17 +16,19 @@ share:
   active: true
   content: "Look at this page: "
 ---
-Prisma 8 can now author expression, partial, and unique indexes in both Prisma Schema Language and TypeScript, and `contract infer` reads indexes and row-level security policies from an existing database at full fidelity. The legacy `@db.*` attributes are removed in favor of storage types in type position.
+You can now author expression, partial, and unique indexes directly in Prisma 8, in Prisma Schema Language or TypeScript. Prisma 8 also reads an existing database's indexes and row-level security policies into a contract. The legacy `@db.*` attributes are removed; see breaking changes below.
 
-Prisma Compute now imports GitHub repositories in every workspace: connect a repository, review the generated setup pull request, and deploy, including apps that live in a subdirectory of a pnpm or yarn workspace.
+You can now import any GitHub repository to Prisma Compute from any workspace, including apps that live in a subdirectory of a monorepo.
 
-Prisma ORM no longer wraps single-statement `updateMany` and `createMany` calls in a transaction, which fixes both operations on driver adapters without transaction support. New guides cover agent-and-database safety, searchable encryption, Object Store buckets, and moving a local database to Prisma Postgres.
+Prisma ORM `updateMany` and `createMany` now work on driver adapters without transaction support. New guides cover agent safety, searchable encryption, Object Store buckets, and moving a local database to Prisma Postgres.
 
 ## Highlights
 
 ### New · Author expression, partial, and unique indexes in Prisma 8
 
-Indexes over expressions had to live as raw SQL outside the schema, invisible to the toolchain. Prisma 8 now accepts expression, partial (`where`), and unique indexes in both Prisma Schema Language and TypeScript, plans byte-exact DDL for them, and verifies the result. Renaming an index plans exactly one `ALTER INDEX … RENAME`; editing its expression plans the rebuild.
+You can now define expression, partial (`where`), and unique indexes in your Prisma 8 schema. Until now these indexes lived in raw SQL outside the schema, where migrations could not create, rename, or verify them.
+
+Declare the index in Prisma Schema Language or TypeScript. Prisma 8 generates the exact DDL, applies it, and verifies it. Renaming an index plans a single `ALTER INDEX` statement; editing its expression plans the rebuild.
 
 ```prisma
 model User {
@@ -43,19 +45,21 @@ The same index in TypeScript is `constraints.index({ expression: "lower(email)",
 
 Shipped in [prisma/prisma-next#1048](https://github.com/prisma/prisma-next/pull/1048).
 
-### New · Import a GitHub repository to Prisma Compute from any workspace
+### New · Import any GitHub repository to Prisma Compute
 
-Deploying an existing GitHub repository to Prisma Compute (Public Beta) was gated to selected workspaces. The import flow is now on for everyone: connect a repository from the Prisma Console and a setup pull request adds the app configuration; merging it provisions the app and starts the first deploy. While the setup pull request is open, the Prisma Console now shows that phase and the preview deploys from the setup branch, instead of reporting the repository as not connected.
+You can now import any GitHub repository to Prisma Compute (Public Beta) from any workspace. Until now the import flow was limited to selected workspaces.
+
+Connect a repository in the Prisma Console. Prisma opens a setup pull request that adds the app configuration. Merge it, and your app deploys.
+
+Apps in a subdirectory of a monorepo build correctly: the configuration names the directory to build.
 
 ```json
 { "app": { "name": "orders-api", "root": "backend", "framework": "bun" } }
 ```
 
-The committed configuration names the directory to build, so an app in a subdirectory of a monorepo builds from the right root.
-
 ### Docs · Follow one getting-started path through the Prisma stack
 
-The docs entry pages presented Prisma ORM, Prisma Postgres, and Prisma Compute as three unrelated first commands. The rebuilt landing pages now recommend one journey: scaffold with Prisma 8, store data in Prisma Postgres, and deploy on Prisma Compute. Every flow gets a quick path, a guided path, and a copyable agent prompt. Prisma 7, the current GA release, stays one click away and is labeled as such.
+The Prisma docs now recommend a single getting-started path: scaffold with Prisma 8, store data in Prisma Postgres, deploy on Prisma Compute. Each flow has a quick path, a guided path, and a copyable agent prompt. Prisma 7, the current GA release, stays one click away.
 
 Start at the [Prisma docs](https://www.prisma.io/docs). Shipped in [prisma/web#8106](https://github.com/prisma/web/pull/8106).
 
@@ -63,44 +67,50 @@ Start at the [Prisma docs](https://www.prisma.io/docs). Shipped in [prisma/web#8
 
 Prisma 8 pairs the new index authoring with full-fidelity inference from existing databases.
 
-- **Improved** · Prisma 8 `contract infer` now reads expression, partial, and unique indexes and row-level security policies (permissive and restrictive, as `@@rls` blocks) from an existing database. Inferring a database the toolchain has never seen, emitting the contract, and verifying it reports zero issues and plans zero operations. ([prisma/prisma-next#1052](https://github.com/prisma/prisma-next/pull/1052))
+- **Improved** · `contract infer` now captures expression, partial, and unique indexes and row-level security policies (permissive and restrictive, as `@@rls` blocks) from an existing database. The emitted contract verifies with zero issues and plans zero operations. ([prisma/prisma-next#1052](https://github.com/prisma/prisma-next/pull/1052))
+
+## Prisma Compute
+
+Prisma Compute makes the repository import flow visible while setup is in progress.
+
+- **Improved** · While a setup pull request is open, the Prisma Console shows its status and the preview deploys from the setup branch. It no longer reports the repository as not connected.
 
 ## Breaking changes
 
-> **Breaking:** Prisma 8 no longer supports the `@db.*` native-type attributes; storage types are written in type position instead. To migrate, replace each `@db.*` attribute with its type-position constructor: `String @db.Uuid` becomes `Uuid`, and `String @db.VarChar(191)` becomes `VarChar(191)`. Each removed attribute produces a diagnostic naming its replacement. ([prisma/prisma-next#1054](https://github.com/prisma/prisma-next/pull/1054))
+> **Breaking:** Prisma 8 removes the `@db.*` native-type attributes. Write storage types in type position instead: `String @db.Uuid` becomes `Uuid`, and `String @db.VarChar(191)` becomes `VarChar(191)`. Each removed attribute produces a diagnostic naming its replacement. ([prisma/prisma-next#1054](https://github.com/prisma/prisma-next/pull/1054))
 
 ## Fixes and improvements
 
 **Prisma Compute**
 
-- **Fixed** · Prisma Compute builds now install dependencies in the configured app directory and detect the package manager from the repository root, so apps in a subdirectory of a pnpm or yarn workspace deploy instead of failing on a missing `package.json` or an `EUNSUPPORTEDPROTOCOL` install error.
-- **Improved** · Prisma Compute addresses with no deployed app now show a branded not-found page naming the address, so an address awaiting its first deploy is distinguishable from a dead link.
+- **Fixed** · Apps in a subdirectory of a pnpm or yarn workspace now deploy. Builds install dependencies in the configured app directory and detect the package manager from the repository root, instead of failing on a missing `package.json` or an `EUNSUPPORTEDPROTOCOL` error.
+- **Improved** · Prisma Compute addresses with no deployed app now show a branded not-found page instead of a bare 404.
 
 **Prisma Console**
 
 - **Fixed** · Prisma Console account deletion no longer fails for workspaces that ever connected a GitHub repository.
-- **Fixed** · The Prisma Console sidebar now truncates long resource names, shows the full name on hover, and scrolls vertically instead of overflowing.
+- **Fixed** · Long resource names no longer break the Prisma Console sidebar. Names truncate, show in full on hover, and the list scrolls.
 
 **Prisma Postgres**
 
-- **Fixed** · Prisma Postgres databases transferred between workspaces through the Vercel Marketplace no longer stay suspended under the previous workspace's plan limit, and their usage now counts against the new workspace.
+- **Fixed** · Prisma Postgres databases transferred through the Vercel Marketplace no longer stay suspended under the previous workspace's plan limit. Their usage now counts against the new workspace.
 - **Fixed** · Vercel Marketplace flexible-billing invoices no longer fail on proration line items.
 
 **Management API**
 
-- **Improved** · `GET /v1/databases/{databaseId}/usage` is now rate limited, and rate-limited responses include retry guidance instead of failing without direction under burst traffic.
+- **Improved** · `GET /v1/databases/{databaseId}/usage` is now rate limited. Rate-limited responses include retry guidance.
 
 **Prisma ORM**
 
-- **Fixed** · Prisma ORM `updateMany` and `createMany` no longer wrap their single SQL statement in a transaction, so both operations work on driver adapters without transaction support, such as the Neon HTTP adapter, and skip the extra `BEGIN`/`COMMIT` round trips. ([prisma/prisma-engines#5840](https://github.com/prisma/prisma-engines/pull/5840))
+- **Fixed** · Prisma ORM `updateMany` and `createMany` now work on driver adapters without transaction support, such as the Neon HTTP adapter. Their single SQL statement is no longer wrapped in `BEGIN`/`COMMIT`, which also removes two round trips. ([prisma/prisma-engines#5840](https://github.com/prisma/prisma-engines/pull/5840))
 
 ## Guides and articles
 
-- [Don't Let Your AI Agent Delete Your Production Database](https://www.prisma.io/blog/stop-your-ai-agent-dropping-your-database): how coding agents end up dropping production data and the safeguards to put between an agent and your database.
-- [Search encrypted data with Prisma 8 and CipherStash](https://www.prisma.io/blog/search-encrypted-data-with-prisma-next-and-cipherstash): CipherStash's searchable encryption now works with Prisma, querying encrypted columns through expression indexes.
-- [Give Your Agent File Storage: Object Store Buckets](https://www.prisma.io/blog/object-store-buckets): the launch post for Object Store buckets, walking the full lifecycle from `POST /v1/buckets` to serving objects with an S3 client, as one runnable script.
-- [From Local Development to Production with Prisma Postgres](https://www.prisma.io/blog/from-local-to-production-with-prisma-postgres): a five-step checklist for moving an app from local Postgres to hosted Prisma Postgres, covering the pooled and direct connection split and migration replay.
-- [Migrate a MongoDB project from Prisma ORM v6 to Prisma 8](https://www.prisma.io/docs/guides/next/upgrade-prisma-orm/mongodb): setup, schema conversion, client API changes, queries, transactions, and raw operations, with a production cutover checklist.
+- [Don't Let Your AI Agent Delete Your Production Database](https://www.prisma.io/blog/stop-your-ai-agent-dropping-your-database): how coding agents end up dropping production data, and the safeguards to put between an agent and your database.
+- [Search encrypted data with Prisma 8 and CipherStash](https://www.prisma.io/blog/search-encrypted-data-with-prisma-next-and-cipherstash): query encrypted columns through expression indexes with CipherStash's Prisma support.
+- [Give Your Agent File Storage: Object Store Buckets](https://www.prisma.io/blog/object-store-buckets): the Object Store buckets launch post, walking the full lifecycle from `POST /v1/buckets` to serving objects with an S3 client.
+- [From Local Development to Production with Prisma Postgres](https://www.prisma.io/blog/from-local-to-production-with-prisma-postgres): a five-step checklist for moving an app from local Postgres to hosted Prisma Postgres.
+- [Migrate a MongoDB project from Prisma ORM v6 to Prisma 8](https://www.prisma.io/docs/guides/next/upgrade-prisma-orm/mongodb): schema conversion, client API changes, and a production cutover checklist.
 
 ---
 


### PR DESCRIPTION
## What

Adds the external changelog entry for 2026-07-27..2026-08-02 at `apps/site/content/changelog/2026-08-02.mdx`. The 2026-07-25..26 weekend gap after the previous entry had zero merges across the loggy-core repos.

Generated with `content-write-changelog` from a Loggy-style extraction (same repo discovery and PR window as Loggy's Extract step) for the same window.

Per operator instruction, this entry says **Prisma 8** instead of Prisma Next, with one "previously announced as Prisma Next" parenthetical for continuity. The public grounding is prisma/web#8106 ("becomes Prisma 8 at GA").

## Review focus

- Positioning and product naming (full names; maturity labels: Prisma 8 Early Access, Prisma Compute Public Beta). Confirm the Prisma 8 naming is cleared for public use now, not only at GA.
- Claims: every statement traceable to a public PR, docs page, or blog post, or listed below as "no public PR".
- Anything in the triage notes that should be added back or reworded.

## Triage notes

**Flagged for reviewer confirmation**

- **Prisma 8 naming**: entry-wide rename per operator instruction; the only public reference so far frames it as the GA name. Revert to "Prisma Next" if the rebrand is not yet public.
- **Click-to-deploy templates** (Console, 3 PRs): complete flow shipped but still behind the `venus` experimental gate, so it is not published. Add next window if the gate lifts.
- **Prisma Postgres backup verification, DR-to-end-of-WAL, restore hardening** (5 PRs across metal repos): single-region canary rollout and internal backup mechanics; excluded per the precedent of the cold-start coordinator item pulled from the 2026-07-24 entry (prisma/web#8109). Worth a proper item once fleet-wide.
- **Demo snippets**: the index example adapts the source PR's expression to `lower(email)` (established SQL, same parameter shape); the Compute app-config JSON is copied verbatim from a private PR. Confirm both shapes are public.
- **Screenshots**: the GitHub import highlight and the Compute not-found page would benefit from screenshots; none could be captured in the generating session. Please add Console captures if available.
- **CipherStash cross-post**: the PR noted its canonical URL 404'd at merge time; the local slug is live in the repo. Verify the published page before merge.

**No public PR (effect published, no link)**: Prisma Compute GitHub import gate lift, setup-PR phase in Console, build-runner app-root/package-manager fixes, branded not-found page, Console account-deletion and sidebar fixes, Vercel Marketplace transfer-hold and proration fixes, Management API usage rate limit.

**Excluded (internal, by category)**

- Prisma 8 internal engineering: codec descriptor protocols (#1051), structured-code framework tail (#1063), functional-test porting (#1042), project close-out chore (#1062).
- prisma-engines toolchain: Rust bump (#5849), CI branch tracking (#5850).
- Control-plane internal work (~35 PRs): the Prisma ORM to Prisma 8 internal migration series, usage/billing pipeline plumbing (shadow measurement, outbox, Vercel sync throughput), analytics instrumentation, runbooks, contributor tooling, contract-verification CI gates.
- Console cosmetic polish: dot-grid density fix (#4732), hairline border unification (#4702), legacy view migration (#4727).
- pdp-metal pre-launch and internal: connection pooler build-out (#193-#199), certificate issuance, test deflaking, CI gates, secrets refactor.
- Website mechanics: /stack redesign and OG image (#8104, #8110), changelog correction (#8109), spellcheck/checklist fixes (#8112, #8113), local-to-production post skeleton (#8101; the published post is linked in Guides instead).
- Internal docs (prisma/ignite): 4 architecture docs.

Note: the website repo's recent changelog commits (#8078, #8107) carry no Linear reference, so this PR follows that precedent; add one to the merge commit if required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prisma 8 guidance for index authoring, database inference, and streamlined schema attributes.
  * Added support for importing GitHub repositories into Prisma Compute.
  * Added new guides and articles covering Prisma workflows and product capabilities.
* **Improvements**
  * Updated documentation journeys across Prisma Compute, Console, PostgreSQL, API, and ORM experiences.
* **Bug Fixes**
  * Documented recent fixes across Prisma Compute, Console, PostgreSQL, API, and ORM.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->