### PR TITLE
docs(skills): add missing skills, including Mongo migration and Prisma Compute

### DIFF
--- a/apps/docs/content/docs/ai/tools/skills.mdx
+++ b/apps/docs/content/docs/ai/tools/skills.mdx
@@ -101,6 +101,7 @@ npx skills add prisma/prisma-next/skills
 | `prisma-next-quickstart` | First-touch setup and orientation after scaffolding |
 | `prisma-next-contract` | Edit the schema: models, relations, enums, namespaces, extensions, then emit the contract |
 | `prisma-next-queries` | Write queries in the right lane: the ORM API, the SQL query builder, or the MongoDB pipeline builder |
+| `prisma-next-supabase` | Use Prisma Next with Supabase: the extension pack, RLS policies, and per-request role binding (`asUser` / `asAnon` / `asServiceRole`) |
 | `prisma-next-runtime` | Wire `db.ts`, middleware, and environment configuration |
 | `prisma-next-migrations` | Author migrations: `db update` vs `migration plan`, and filling in data transforms |
 | `prisma-next-migration-review` | Review migrations on deploy and reconcile concurrent migration work |

--- a/apps/docs/content/docs/ai/tools/skills.mdx
+++ b/apps/docs/content/docs/ai/tools/skills.mdx
@@ -55,7 +55,7 @@ Covers ESM module configuration, required driver adapters, the new `prisma.confi
 
 Helps you move a MongoDB project from Prisma v6 to [Prisma Next](/orm/next).
 
-Covers the migration mechanics: schema-to-contract mapping, client API changes, the migration lifecycle, and cutiver verification. Use this when your agent needs to make that move: it maps your schema and queries across and guides the cutover, following the [MongoDB upgrade guide](/guides/next/upgrade-prisma-orm/mongodb).
+Covers the migration mechanics: schema-to-contract mapping, client API changes, the migration lifecycle, and cutover verification. Use this when your agent needs to make that move: it maps your schema and queries across and guides the cutover, following the [MongoDB upgrade guide](/guides/next/upgrade-prisma-orm/mongodb).
 
 ### `prisma-database-setup`
 

--- a/apps/docs/content/docs/ai/tools/skills.mdx
+++ b/apps/docs/content/docs/ai/tools/skills.mdx
@@ -51,6 +51,12 @@ Step-by-step migration guide from Prisma v6 to v7.
 
 Covers ESM module configuration, required driver adapters, the new `prisma.config.ts` file, manual environment variable loading, and removed features (middleware, metrics, deprecated CLI flags). Essential for upgrading existing projects.
 
+### `prisma-mongodb-upgrade`
+
+Helps you move a MongoDB project from Prisma v6 to [Prisma Next](/orm/next).
+
+Covers the migration mechanics: schema-to-contract mapping, client API changes, the migration lifecycle, and cutiver verification. Use this when your agent needs to make that move: it maps your schema and queries across and guides the cutover, following the [MongoDB upgrade guide](/guides/next/upgrade-prisma-orm/mongodb).
+
 ### `prisma-database-setup`
 
 Guides for configuring Prisma with different database providers.
@@ -62,6 +68,24 @@ Covers PostgreSQL, Prisma Postgres, MySQL/MariaDB, SQLite, MongoDB, SQL Server, 
 Prisma Postgres workflows across Console, CLI, Management API, and SDK.
 
 Covers `npx create-db`, Console operations, programmatic provisioning via the Management API, and the `@prisma/management-api-sdk`. Use this when creating or managing Prisma Postgres databases.
+
+### `prisma-postgres-setup`
+
+Gets a new Prisma Postgres database up and connected to your project.
+
+Covers authenticating with a service token, listing regions, creating a project and database via the Management API, obtaining a connection string, and configuring `prisma.config.ts`, the schema, and the driver adapter. Use this when setting up a database or connecting an app to Prisma Postgres.
+
+### `prisma-compute`
+
+Deploys and hosts your app on [Prisma Compute](/compute).
+
+Covers `prisma.compute.ts` and `defineComputeConfig`, deploying with `@prisma/cli app deploy` and `create-prisma`, auth and workspace selection, runtime host/port binding, and framework readiness for Next.js, Nuxt, Astro, Hono, Nest, TanStack Start, and more. Use this when deploying or hosting a Prisma app.
+
+### `prisma-driver-adapter-implementation`
+
+Helps you build a SQL driver adapter for Prisma v7.
+
+Covers `SqlDriverAdapter`, `Transaction`, savepoint hooks, argument and result mapping, `DriverAdapterError` behavior, and shadow-database handling. Use this when building a new database driver adapter or debugging adapter-level transaction and error behavior.
 
 ## Available skills for Prisma Next
 

--- a/apps/docs/cspell.json
+++ b/apps/docs/cspell.json
@@ -310,6 +310,7 @@
     "s3cret",
     "Sabelle",
     "safeql",
+    "savepoint",
     "Saqui",
     "schemaname",
     "secondtolastproduct",


### PR DESCRIPTION
Added missing skils to the list of available agent skills:

- Prisma skills:
  - `prisma-mongodb-upgrade`
  - `prisma-postgres-setup`
  - `prisma-compute`
  - `prisma-driver-adapter-implementation`
- Prisma Next skills:
  - `prisma-next-supabase`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Prisma MongoDB upgrade, PostgreSQL setup, compute, and driver adapter implementation skills.
  * Added the Prisma Next Supabase skill to the skills reference table.
  * Updated spelling support for the term “savepoint.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->