### PR TITLE
Update privacy policy for DPF renewal and privacy-law coverage

### DIFF
--- a/apps/site/src/data/privacy.tsx
+++ b/apps/site/src/data/privacy.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-export const privacyLastUpdated = "July 10, 2025";
+export const privacyLastUpdated = "7th of August, 2026";
 
 type PrivacySection = {
   title: string;
@@ -13,7 +13,9 @@ export const privacySections: PrivacySection[] = [
     content: (
       <p>
         This privacy policy applies to the following Prisma websites: prisma.io, console.prisma.io,
-        cloud.prisma.io, cloudprojects.prisma.io, optimize.prisma.io, and graph.cool.
+        cloud.prisma.io, cloudprojects.prisma.io, and graph.cool. It is issued
+        by Prisma Data, Inc., which acts as the data controller for personal data described in this
+        policy. Questions may be directed to <a href="mailto:dpo@prisma.io">dpo@prisma.io</a>.
       </p>
     ),
   },
@@ -41,6 +43,10 @@ export const privacySections: PrivacySection[] = [
           Free Tier telemetry captures API call frequency, schema size, project activities, and
           integration types — helping prevent abuse while maintaining service reliability.
         </p>
+        <p>
+          Prisma does not intentionally collect sensitive personal data (such as health data,
+          biometric data, or data revealing racial or ethnic origin).
+        </p>
       </>
     ),
   },
@@ -59,15 +65,27 @@ export const privacySections: PrivacySection[] = [
           personalization.
         </p>
         <p>
+          Where the GDPR or UK GDPR applies, Prisma processes personal data on the following legal
+          bases: performance of a contract (providing the services), legitimate interests (service
+          improvement, security, and abuse prevention), consent (marketing communications and
+          non-essential cookies), and compliance with legal obligations.
+        </p>
+        <p>
           Embeddable Studio telemetry enhances functionality and stability. Free Tier users receive
-          transactional communications about plan limitations and feature announcements without
-          opt-out options.
+          transactional communications — such as plan limit, security, and service change notices —
+          that are part of core service functionality and cannot be opted out of. Marketing
+          communications, including feature announcements, always include an opt-out.
+        </p>
+        <p>
+          Prisma uses automated systems to monitor usage trends for abuse detection. Prisma does not
+          make decisions producing legal or similarly significant effects about individuals based
+          solely on automated processing.
         </p>
       </>
     ),
   },
   {
-    title: "4. Website Navigational Information",
+    title: "4. Cookies and Website Navigational Information",
     content: (
       <>
         <p>
@@ -83,6 +101,12 @@ export const privacySections: PrivacySection[] = [
         <p>
           IP addresses track geographic data from visitors. Third-party ad networks collect
           navigational information to deliver targeted advertisements based on browsing history.
+        </p>
+        <p>
+          Where required by law, non-essential cookies are set only with your consent, and you can
+          change your cookie preferences at any time through our cookie settings. You can opt out of
+          targeted advertising as described in Section 10, and Prisma honors opt-out preference
+          signals such as Global Privacy Control (GPC) as required by applicable law.
         </p>
       </>
     ),
@@ -111,49 +135,83 @@ export const privacySections: PrivacySection[] = [
         </p>
         <p>
           Credit card processing involves third-party providers prohibited from storing or using
-          billing information beyond payment processing. Prisma reserves disclosure rights when
-          legally required.
+          billing information beyond payment processing.
+        </p>
+        <p>
+          Prisma may be required to disclose personal data in response to lawful requests by public
+          authorities, including to meet national security or law enforcement requirements.
         </p>
         <p>
           All third parties undergo vetting and must maintain privacy standards consistent with the
-          Data Privacy Framework. Prisma complies with DPF notice and choice principles; individuals
-          may limit data use by contacting <a href="mailto:dpo@prisma.io">dpo@prisma.io</a>. Free
-          Tier abuse detection employs automated systems monitoring usage trends.
+          Data Privacy Framework. Prisma complies with DPF notice and choice principles: you may opt
+          out of the disclosure of your personal data to third parties, or its use for a purpose
+          materially different from the purpose for which it was collected, by contacting{" "}
+          <a href="mailto:dpo@prisma.io">dpo@prisma.io</a>. Free Tier abuse detection employs
+          automated systems monitoring usage trends.
         </p>
       </>
     ),
   },
   {
-    title: "7. International Transfer of Information Collected",
+    title: "7. International Transfers and the Data Privacy Framework",
     content: (
       <>
         <p>
-          Prisma transfers customer data globally while maintaining Privacy Statement compliance.
-          The company certifies adherence to EU-U.S. DPF, the UK Extension, and Swiss-U.S. DPF
-          principles regarding personal data from those regions.
+          Prisma transfers customer data globally while maintaining compliance with this privacy
+          policy. Prisma Data, Inc. complies with the EU-U.S. Data Privacy Framework (EU-U.S. DPF),
+          the UK Extension to the EU-U.S. DPF, and the Swiss-U.S. Data Privacy Framework (Swiss-U.S.
+          DPF) as set forth by the U.S. Department of Commerce. Prisma Data, Inc. has certified to
+          the U.S. Department of Commerce that it adheres to the EU-U.S. DPF Principles with regard
+          to the processing of personal data received from the European Union and, under the UK
+          Extension, from the United Kingdom (and Gibraltar), and to the Swiss-U.S. DPF Principles
+          with regard to personal data received from Switzerland. If there is any conflict between
+          the terms in this privacy policy and the DPF Principles, the Principles shall govern. To
+          learn more about the Data Privacy Framework program, and to view our certification, please
+          visit{" "}
+          <a href="https://www.dataprivacyframework.gov/" target="_blank" rel="noreferrer">
+            https://www.dataprivacyframework.gov/
+          </a>
+          .
         </p>
         <p>
-          Disputes resolve through relevant authorities and data protection authorities. The company
-          commits to cooperating with EU DPAs, UK ICO, and Swiss FDPIC regarding unresolved
-          complaints at no cost.
+          Prisma Data, Inc. is subject to the investigatory and enforcement powers of the U.S.
+          Federal Trade Commission (FTC).
+        </p>
+        <p>
+          In compliance with the DPF Principles, Prisma commits to resolve complaints about our
+          collection or use of your personal data. Individuals in the EU, UK, or Switzerland with
+          inquiries or complaints should first contact{" "}
+          <a href="mailto:dpo@prisma.io">dpo@prisma.io</a>. For complaints that cannot be resolved
+          directly, Prisma has committed to cooperate and comply with the advice of the panel
+          established by the EU data protection authorities (DPAs), the UK Information
+          Commissioner&apos;s Office (ICO), and the Swiss Federal Data Protection and Information
+          Commissioner (FDPIC). This independent dispute resolution mechanism is available to you at
+          no cost. Under certain conditions described in the DPF Principles, you may also invoke
+          binding arbitration when other dispute resolution procedures have been exhausted.
+        </p>
+        <p>
+          Prisma remains responsible and liable under the DPF Principles if third-party agents
+          processing personal data on its behalf do so in a manner inconsistent with the Principles,
+          unless Prisma proves that it is not responsible for the event giving rise to the damage.
         </p>
       </>
     ),
   },
   {
-    title: "8. Human Resource Data and Personal Data",
+    title: "8. Human Resource Data",
     content: (
       <>
         <p>
-          Prisma cooperates with EU data protection authorities, UK ICO, and Swiss FDPIC regarding
-          unresolved HR data complaints. The FTC investigates DPF compliance.
+          For human resources data transferred from the EU, UK, or Switzerland in the context of an
+          employment relationship, Prisma commits to cooperate and comply with the advice of the EU
+          data protection authorities, the UK ICO, and the Swiss FDPIC, and to grant the rights
+          provided under the DPF Principles.
         </p>
         <p>
           Partner organizations handling HR and personal data follow equivalent legal requirements.
-          Third-party liability limitations apply unless legally mandated. Users may contact{" "}
-          <a href="mailto:dpo@prisma.io">dpo@prisma.io</a> with questions or to limit data use.
+          Team members may contact <a href="mailto:dpo@prisma.io">dpo@prisma.io</a> with questions
+          or to limit data use.
         </p>
-        <p>Binding arbitration is available under DPF Principles conditions.</p>
       </>
     ),
   },
@@ -174,17 +232,62 @@ export const privacySections: PrivacySection[] = [
     ),
   },
   {
-    title: "10. Correcting and Updating Your Information",
+    title: "10. Your Privacy Rights",
+    content: (
+      <>
+        <p>
+          Account registration changes can be made by logging in at{" "}
+          <a href="https://www.prisma.io/">prisma.io</a>. You may also request access to,
+          correction, or deletion of your personal data by contacting{" "}
+          <a href="mailto:dpo@prisma.io">dpo@prisma.io</a>. Requests receive responses within 30
+          days, or any shorter period required by applicable law. Individuals covered by the DPF may
+          access, correct, amend, or delete personal data we hold about them.
+        </p>
+        <p>
+          Where the GDPR or UK GDPR applies, you additionally have the right to data portability,
+          the right to restrict or object to processing, the right to withdraw consent at any time
+          without affecting prior processing, and the right to lodge a complaint with your data
+          protection supervisory authority.
+        </p>
+        <p>
+          Residents of California and other U.S. states with comprehensive privacy laws have the
+          right to know and access the personal information we collect, correct or delete it,
+          receive it in a portable format, and opt out of targeted advertising and the sale or
+          sharing of personal information. Prisma does not sell personal information for money;
+          third-party advertising cookies described in Section 4 may constitute "sharing" under
+          California law, and you may opt out via our cookie settings, the Global Privacy Control
+          signal, or <a href="mailto:dpo@prisma.io">dpo@prisma.io</a>. We will not discriminate
+          against you for exercising your rights, and you may appeal a refused request by replying
+          to our decision.
+        </p>
+      </>
+    ),
+  },
+  {
+    title: "11. Data Retention",
     content: (
       <p>
-        Account registration changes can be made by logging in at{" "}
-        <a href="https://www.prisma.io/">prisma.io</a>. Information access, modification, or
-        deletion requests receive responses within 30 days.
+        Prisma retains personal data only for as long as needed to fulfill the purposes described in
+        this policy, including providing the services, complying with legal, tax, and accounting
+        obligations, resolving disputes, and enforcing agreements. When personal data is no longer
+        required, it is deleted or anonymized. Retention periods vary by data category and are
+        available on request via <a href="mailto:dpo@prisma.io">dpo@prisma.io</a>.
       </p>
     ),
   },
   {
-    title: "11. Security",
+    title: "12. Children's Privacy",
+    content: (
+      <p>
+        Prisma&apos;s websites and services are not directed at children, and Prisma does not
+        knowingly collect personal data from children under 16. If you believe a child has provided
+        us personal data, contact <a href="mailto:dpo@prisma.io">dpo@prisma.io</a> and we will
+        delete it.
+      </p>
+    ),
+  },
+  {
+    title: "13. Security",
     content: (
       <p>
         Prisma employs administrative, technical, and physical security safeguards for customer data
@@ -193,7 +296,7 @@ export const privacySections: PrivacySection[] = [
     ),
   },
   {
-    title: "12. Changes to this Privacy Statement",
+    title: "14. Changes to this Privacy Statement",
     content: (
       <p>
         Prisma reserves the right to modify this privacy policy at any time. Free Tier
@@ -203,7 +306,7 @@ export const privacySections: PrivacySection[] = [
     ),
   },
   {
-    title: "13. Regulatory and Compliance Notice",
+    title: "15. Regulatory and Compliance Notice",
     content: (
       <p>
         Embeddable Prisma Studio operates as client-side software without visibility into end-user


### PR DESCRIPTION
Updates the privacy policy for the Data Privacy Framework renewal (onward-transfer liability, DPF program link, named recourse mechanism, FTC statement, lawful-request disclosure) and broader coverage: new Your Privacy Rights, Data Retention, and Children's Privacy sections, GPC/cookie-consent language, and GDPR legal bases. Bumps the last-updated date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the privacy policy date and website coverage.
  * Added details about data collection, legal bases, cookies, disclosures, international transfers, retention, children’s privacy, and privacy rights.
  * Expanded information about controller and contact details, automated decision-making, HR data, and DPF compliance.
  * Renamed and renumbered sections to reflect the updated policy content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->